### PR TITLE
feat(fs): remove filesystem ID management from individual filesystems

### DIFF
--- a/kernel/src/fs/drivers/cpio/mod.rs
+++ b/kernel/src/fs/drivers/cpio/mod.rs
@@ -52,7 +52,6 @@ pub struct CpiofsEntry {
 
 /// Structure representing the entire Initramfs
 pub struct Cpiofs {
-    id: usize,
     name: &'static str,
     entries: Mutex<Vec<CpiofsEntry>>, // List of entries
     mounted: bool,
@@ -74,7 +73,6 @@ impl Cpiofs {
     pub fn new(name: &'static str, cpio_data: &[u8]) -> Result<Self> {
         let entries = Self::parse_cpio(cpio_data)?;
         Ok(Self {
-            id: 0, // ID is set by the VfsManager
             name,
             entries: Mutex::new(entries),
             mounted: false,
@@ -224,14 +222,6 @@ impl FileSystem for Cpiofs {
 
     fn name(&self) -> &str {
         self.name
-    }
-
-    fn set_id(&mut self, id: usize) {
-        self.id = id;
-    }
-
-    fn get_id(&self) -> usize {
-        self.id
     }
 }
 

--- a/kernel/src/fs/mount_tree.rs
+++ b/kernel/src/fs/mount_tree.rs
@@ -29,6 +29,7 @@ struct MountNode {
 pub struct MountPoint {
     pub path: String,
     pub fs: super::FileSystemRef,
+    pub fs_id: usize,  // VfsManager managed filesystem ID
     pub mount_type: MountType,
     pub mount_options: MountOptions,
     pub parent: Option<String>,

--- a/kernel/src/fs/params.rs
+++ b/kernel/src/fs/params.rs
@@ -28,15 +28,12 @@ pub trait FileSystemParams {
 pub struct TmpFSParams {
     /// Maximum memory usage in bytes (0 = unlimited)
     pub memory_limit: usize,
-    /// Filesystem identifier
-    pub fs_id: usize,
 }
 
 impl Default for TmpFSParams {
     fn default() -> Self {
         Self {
             memory_limit: 0, // Unlimited by default
-            fs_id: 0,
         }
     }
 }
@@ -46,23 +43,6 @@ impl TmpFSParams {
     pub fn with_memory_limit(memory_limit: usize) -> Self {
         Self {
             memory_limit,
-            fs_id: 0,
-        }
-    }
-    
-    /// Create TmpFS parameters with specified filesystem ID
-    pub fn with_fs_id(fs_id: usize) -> Self {
-        Self {
-            memory_limit: 0,
-            fs_id,
-        }
-    }
-    
-    /// Create TmpFS parameters with both memory limit and filesystem ID
-    pub fn new(memory_limit: usize, fs_id: usize) -> Self {
-        Self {
-            memory_limit,
-            fs_id,
         }
     }
 }
@@ -71,7 +51,6 @@ impl FileSystemParams for TmpFSParams {
     fn to_string_map(&self) -> BTreeMap<String, String> {
         let mut map = BTreeMap::new();
         map.insert("memory_limit".to_string(), self.memory_limit.to_string());
-        map.insert("fs_id".to_string(), self.fs_id.to_string());
         map
     }
     
@@ -83,14 +62,7 @@ impl FileSystemParams for TmpFSParams {
             0 // Default to unlimited memory
         };
 
-        let fs_id = if let Some(id_str) = map.get("fs_id") {
-            id_str.parse::<usize>()
-                .map_err(|_| format!("Invalid fs_id value: {}", id_str))?
-        } else {
-            0 // Default filesystem ID
-        };
-
-        Ok(Self { memory_limit, fs_id })
+        Ok(Self { memory_limit })
     }
     
     fn as_any(&self) -> &dyn Any {
@@ -101,41 +73,29 @@ impl FileSystemParams for TmpFSParams {
 /// Parameters for CPIO filesystem creation
 #[derive(Debug, Clone, PartialEq)]
 pub struct CpioFSParams {
-    /// Filesystem identifier
-    pub fs_id: usize,
 }
 
 impl Default for CpioFSParams {
     fn default() -> Self {
         Self {
-            fs_id: 0,
         }
     }
 }
 
 impl CpioFSParams {
-    /// Create CPIO parameters with specified filesystem ID
-    pub fn new(fs_id: usize) -> Self {
-        Self { fs_id }
+    /// Create CPIO parameters
+    pub fn new() -> Self {
+        Self { }
     }
 }
 
 impl FileSystemParams for CpioFSParams {
     fn to_string_map(&self) -> BTreeMap<String, String> {
-        let mut map = BTreeMap::new();
-        map.insert("fs_id".to_string(), self.fs_id.to_string());
-        map
+        BTreeMap::new()
     }
     
-    fn from_string_map(map: &BTreeMap<String, String>) -> Result<Self, String> {
-        let fs_id = if let Some(id_str) = map.get("fs_id") {
-            id_str.parse::<usize>()
-                .map_err(|_| format!("Invalid fs_id value: {}", id_str))?
-        } else {
-            0 // Default filesystem ID
-        };
-
-        Ok(Self { fs_id })
+    fn from_string_map(_map: &BTreeMap<String, String>) -> Result<Self, String> {
+        Ok(Self { })
     }
     
     fn as_any(&self) -> &dyn Any {
@@ -146,8 +106,6 @@ impl FileSystemParams for CpioFSParams {
 /// Generic parameters for basic filesystem creation
 #[derive(Debug, Clone, PartialEq)]
 pub struct BasicFSParams {
-    /// Filesystem identifier
-    pub fs_id: usize,
     /// Block size (for block-based filesystems)
     pub block_size: Option<usize>,
     /// Read-only flag
@@ -157,7 +115,6 @@ pub struct BasicFSParams {
 impl Default for BasicFSParams {
     fn default() -> Self {
         Self {
-            fs_id: 0,
             block_size: None,
             read_only: false,
         }
@@ -165,10 +122,9 @@ impl Default for BasicFSParams {
 }
 
 impl BasicFSParams {
-    /// Create basic parameters with specified filesystem ID
-    pub fn new(fs_id: usize) -> Self {
+    /// Create basic parameters with default values
+    pub fn new() -> Self {
         Self {
-            fs_id,
             block_size: None,
             read_only: false,
         }
@@ -190,7 +146,6 @@ impl BasicFSParams {
 impl FileSystemParams for BasicFSParams {
     fn to_string_map(&self) -> BTreeMap<String, String> {
         let mut map = BTreeMap::new();
-        map.insert("fs_id".to_string(), self.fs_id.to_string());
         
         if let Some(block_size) = self.block_size {
             map.insert("block_size".to_string(), block_size.to_string());
@@ -201,13 +156,6 @@ impl FileSystemParams for BasicFSParams {
     }
     
     fn from_string_map(map: &BTreeMap<String, String>) -> Result<Self, String> {
-        let fs_id = if let Some(id_str) = map.get("fs_id") {
-            id_str.parse::<usize>()
-                .map_err(|_| format!("Invalid fs_id value: {}", id_str))?
-        } else {
-            0 // Default filesystem ID
-        };
-
         let block_size = if let Some(size_str) = map.get("block_size") {
             Some(size_str.parse::<usize>()
                 .map_err(|_| format!("Invalid block_size value: {}", size_str))?)
@@ -222,7 +170,7 @@ impl FileSystemParams for BasicFSParams {
             false // Default to read-write
         };
 
-        Ok(Self { fs_id, block_size, read_only })
+        Ok(Self { block_size, read_only })
     }
     
     fn as_any(&self) -> &dyn Any {

--- a/kernel/src/fs/testfs.rs
+++ b/kernel/src/fs/testfs.rs
@@ -11,7 +11,6 @@ use crate::device::{Device, DeviceType, char::CharDevice, block::BlockDevice};
 
 // Simple file system implementation for testing
 pub struct TestFileSystem {
-    id: usize,
     name: &'static str,
     block_device: Mutex<Box<dyn BlockDevice>>,
     block_size: usize,
@@ -22,7 +21,7 @@ pub struct TestFileSystem {
 }
 
 impl TestFileSystem {
-    pub fn new(id: usize, name: &'static str, block_device: Box<dyn BlockDevice>, block_size: usize) -> Self {
+    pub fn new(name: &'static str, block_device: Box<dyn BlockDevice>, block_size: usize) -> Self {
         // Initialize the root directory
         let mut dirs = Vec::new();
         dirs.push((
@@ -44,7 +43,6 @@ impl TestFileSystem {
         ));
         
         Self {
-            id,
             name,
             block_device: Mutex::new(block_device),
             block_size,
@@ -111,14 +109,6 @@ impl FileSystem for TestFileSystem {
     
     fn name(&self) -> &str {
         self.name
-    }
-
-    fn set_id(&mut self, id: usize) {
-        self.id = id;
-    }
-    
-    fn get_id(&self) -> usize {
-        self.id
     }
 }
 
@@ -686,7 +676,7 @@ impl FileSystemDriver for TestFileSystemDriver {
     }
     
     fn create_from_block(&self, block_device: Box<dyn BlockDevice>, block_size: usize) -> Result<Box<dyn VirtualFileSystem>> {
-        Ok(Box::new(TestFileSystem::new(0, "testfs", block_device, block_size)))
+        Ok(Box::new(TestFileSystem::new("testfs", block_device, block_size)))
     }
     
     fn create_with_params(&self, params: &dyn crate::fs::params::FileSystemParams) -> Result<Box<dyn VirtualFileSystem>> {
@@ -698,7 +688,7 @@ impl FileSystemDriver for TestFileSystemDriver {
             // Create a mock block device for testing
             let block_device = Box::new(MockBlockDevice::new(1, "test_block", 512, 100));
             let block_size = basic_params.block_size.unwrap_or(512);
-            return Ok(Box::new(TestFileSystem::new(basic_params.fs_id, "testfs", block_device, block_size)));
+            return Ok(Box::new(TestFileSystem::new("testfs", block_device, block_size)));
         }
         
         // If downcast fails, return error
@@ -786,7 +776,7 @@ mod device_tests {
     fn test_device_file_through_filesystem() {
         // Create a test file system
         let block_device = Box::new(MockBlockDevice::new(3, "fs_block", 512, 100));
-        let fs = TestFileSystem::new(0, "testfs", block_device, 512);
+        let fs = TestFileSystem::new("testfs", block_device, 512);
         
         // Verify the filesystem was created properly
         assert_eq!(fs.name(), "testfs");
@@ -873,7 +863,7 @@ mod device_tests {
     fn test_device_file_comprehensive_operations() {
         // Create a test file system
         let block_device = Box::new(MockBlockDevice::new(6, "test_block", 512, 100));
-        let fs = TestFileSystem::new(0, "testfs", block_device, 512);
+        let fs = TestFileSystem::new("testfs", block_device, 512);
         
         // Create test character device for comprehensive testing
         let mut test_char_device = Box::new(MockCharDevice::new(7, "comprehensive_char"));
@@ -930,7 +920,7 @@ mod device_tests {
     fn test_device_file_block_device_operations() {
         // Create a test file system
         let fs_block_device = Box::new(MockBlockDevice::new(8, "fs_block", 512, 100));
-        let fs = TestFileSystem::new(0, "testfs", fs_block_device, 512);
+        let fs = TestFileSystem::new("testfs", fs_block_device, 512);
         
         // Create test block device for device file
         let test_block_device = Box::new(MockBlockDevice::new(9, "test_block_dev", 512, 100));
@@ -970,7 +960,7 @@ mod device_tests {
     fn test_device_file_error_handling() {
         // Create a test file system
         let block_device = Box::new(MockBlockDevice::new(10, "error_test_block", 512, 100));
-        let fs = TestFileSystem::new(0, "testfs", block_device, 512);
+        let fs = TestFileSystem::new("testfs", block_device, 512);
         
         // Test opening non-existent device file
         let result = fs.open("/dev/nonexistent", 0);
@@ -1000,7 +990,7 @@ mod device_tests {
     fn test_mixed_file_types_in_filesystem() {
         // Create a test file system
         let block_device = Box::new(MockBlockDevice::new(11, "mixed_test_block", 512, 100));
-        let fs = TestFileSystem::new(0, "testfs", block_device, 512);
+        let fs = TestFileSystem::new("testfs", block_device, 512);
         
         // Create test devices
         let mut char_device = Box::new(MockCharDevice::new(12, "mixed_char"));

--- a/kernel/src/fs/tests.rs
+++ b/kernel/src/fs/tests.rs
@@ -16,7 +16,7 @@ fn test_vfs_manager_creation() {
 fn test_fs_registration_and_mount() {
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     assert_eq!(manager.filesystems.read().len(), 1);
@@ -31,7 +31,7 @@ fn test_fs_registration_and_mount() {
 fn test_path_resolution() {
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -65,7 +65,7 @@ fn test_path_resolution() {
 fn test_file_operations() {
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -96,7 +96,7 @@ fn test_file_operations() {
 fn test_directory_operations() {
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -139,7 +139,7 @@ fn test_directory_operations() {
 #[test_case]
 fn test_block_device_operations() {
     let device = MockBlockDevice::new(1, "test_disk", 512, 100);
-    let fs = GenericFileSystem::new(0, "generic", Box::new(device), 512);
+    let fs = GenericFileSystem::new("generic", Box::new(device), 512);
     
     // Prepare test data
     let test_data = [0xAA; 512];
@@ -161,7 +161,7 @@ fn test_block_device_operations() {
 fn test_unmount() {
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
      let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
     assert_eq!(manager.mount_count(), 1);
@@ -190,7 +190,7 @@ fn test_file_creation() {
     // Setup
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -205,7 +205,7 @@ fn test_file_open_close() {
     // Setup
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -222,7 +222,7 @@ fn test_file_read_write() {
     // Setup
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -253,7 +253,7 @@ fn test_file_seek() {
     // Setup
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -282,7 +282,7 @@ fn test_file_metadata_and_size() {
     // Setup
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -306,7 +306,7 @@ fn test_file_read_all() {
     // Setup
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -335,7 +335,7 @@ fn test_file_auto_close() {
     // Setup
     let mut manager = VfsManager::new();
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     
     let fs_id = manager.register_fs(fs); // Get fs_id
     let _ = manager.mount(fs_id, "/mnt"); // Use fs_id
@@ -373,7 +373,7 @@ fn test_filesystem_driver_and_create_register_fs() {
     assert_eq!(manager.filesystems.read().len(), 1);
 
     // Check the name of the registered file system
-    let registered_fs = manager.filesystems.read()[0].clone();
+    let registered_fs = manager.filesystems.read().get(&fs_id).unwrap().clone();
     assert_eq!(registered_fs.read().name(), "testfs");
 
     // Mount and verify functionality
@@ -390,18 +390,18 @@ fn test_nested_mount_points() {
     
     // Root file system
     let root_device = Box::new(MockBlockDevice::new(1, "root_disk", 512, 100));
-    let root_fs = Box::new(TestFileSystem::new(0, "rootfs", root_device, 512));
+    let root_fs = Box::new(TestFileSystem::new("rootfs", root_device, 512));
     let root_fs_id = manager.register_fs(root_fs);
     
     // File system for /mnt
     let mnt_device = Box::new(MockBlockDevice::new(2, "mnt_disk", 512, 100));
-    let mnt_fs = Box::new(TestFileSystem::new(0, "mntfs", mnt_device, 512));
+    let mnt_fs = Box::new(TestFileSystem::new("mntfs", mnt_device, 512));
     let mnt_fs_id = manager.register_fs(mnt_fs);
     
     // File system for /mnt/usb
     let usb_device = Box::new(MockBlockDevice::new(3, "usb_disk", 512, 100));
 
-    let usb_fs = Box::new(TestFileSystem::new(0, "usbfs", usb_device, 512));
+    let usb_fs = Box::new(TestFileSystem::new("usbfs", usb_device, 512));
     let usb_fs_id = manager.register_fs(usb_fs);
 
     
@@ -509,13 +509,13 @@ fn test_directory_boundary_handling() {
     let mut manager = VfsManager::new();
     
     // Create 4 different file systems
-    let root_fs = Box::new(TestFileSystem::new(0, "rootfs", 
+    let root_fs = Box::new(TestFileSystem::new("rootfs", 
         Box::new(MockBlockDevice::new(1, "root_disk", 512, 100)), 512));
-    let mnt_fs = Box::new(TestFileSystem::new(0, "mntfs", 
+    let mnt_fs = Box::new(TestFileSystem::new("mntfs", 
         Box::new(MockBlockDevice::new(2, "mnt_disk", 512, 100)), 512));
-    let mnt_data_fs = Box::new(TestFileSystem::new(0, "mnt_datafs", 
+    let mnt_data_fs = Box::new(TestFileSystem::new("mnt_datafs", 
         Box::new(MockBlockDevice::new(3, "mnt_data_disk", 512, 100)), 512));
-    let mnt_sub_fs = Box::new(TestFileSystem::new(0, "mnt_subfs", 
+    let mnt_sub_fs = Box::new(TestFileSystem::new("mnt_subfs", 
         Box::new(MockBlockDevice::new(4, "mnt_sub_disk", 512, 100)), 512));
     
     // Register file systems
@@ -735,7 +735,7 @@ fn test_container_rootfs_switching_demo() {
     
     // Filesystem for main system (using TestFileSystem)
     let main_device = Box::new(MockBlockDevice::new(1, "main_disk", 512, 100));
-    let main_fs = Box::new(TestFileSystem::new(0, "main_testfs", main_device, 512));
+    let main_fs = Box::new(TestFileSystem::new("main_testfs", main_device, 512));
     let main_fs_id = main_vfs.register_fs(main_fs);
     main_vfs.mount(main_fs_id, "/")
         .expect("Failed to mount main filesystem");
@@ -749,7 +749,7 @@ fn test_container_rootfs_switching_demo() {
     
     // Filesystem for container 1
     let container1_device = Box::new(MockBlockDevice::new(2, "container1_disk", 512, 100));
-    let container1_fs = Box::new(TestFileSystem::new(1, "container1_testfs", container1_device, 512));
+    let container1_fs = Box::new(TestFileSystem::new("container1_testfs", container1_device, 512));
     let container1_fs_id = container1_vfs.register_fs(container1_fs);
     container1_vfs.mount(container1_fs_id, "/")
         .expect("Failed to mount container1 filesystem");
@@ -764,7 +764,7 @@ fn test_container_rootfs_switching_demo() {
     
     // Filesystem for container 2
     let container2_device = Box::new(MockBlockDevice::new(3, "container2_disk", 512, 100));
-    let container2_fs = Box::new(TestFileSystem::new(2, "container2_testfs", container2_device, 512));
+    let container2_fs = Box::new(TestFileSystem::new("container2_testfs", container2_device, 512));
     let container2_fs_id = container2_vfs.register_fs(container2_fs);
     container2_vfs.mount(container2_fs_id, "/")
         .expect("Failed to mount container2 filesystem");
@@ -887,7 +887,7 @@ fn test_vfs_manager_clone_behavior() {
     
     // Register and mount filesystem
     let device = Box::new(MockBlockDevice::new(1, "test_disk", 512, 100));
-    let fs = Box::new(TestFileSystem::new(0, "testfs", device, 512));
+    let fs = Box::new(TestFileSystem::new("testfs", device, 512));
     let fs_id = original_manager.register_fs(fs);
     original_manager.mount(fs_id, "/mnt").unwrap();
 
@@ -897,7 +897,7 @@ fn test_vfs_manager_clone_behavior() {
     // === Test 1: Mount point independence ===
     // Add new filesystem and mount point in cloned manager
     let device2 = Box::new(MockBlockDevice::new(2, "test_disk2", 512, 100));
-    let fs2 = Box::new(TestFileSystem::new(1, "testfs2", device2, 512));
+    let fs2 = Box::new(TestFileSystem::new("testfs2", device2, 512));
     let fs2_id = cloned_manager.register_fs(fs2);
     assert_eq!(fs2_id, 1); // New ID is assigned in cloned manager
     cloned_manager.mount(fs2_id, "/mnt2").unwrap();
@@ -938,12 +938,12 @@ fn test_proper_vfs_isolation_with_new_instances() {
     
     // Register independent filesystems for each
     let device1 = Box::new(MockBlockDevice::new(1, "disk1", 512, 100));
-    let fs1 = Box::new(TestFileSystem::new(0, "fs1", device1, 512));
+    let fs1 = Box::new(TestFileSystem::new("fs1", device1, 512));
     let fs1_id = manager1.register_fs(fs1);
     manager1.mount(fs1_id, "/mnt").unwrap();
     
     let device2 = Box::new(MockBlockDevice::new(2, "disk2", 512, 100));
-    let fs2 = Box::new(TestFileSystem::new(1, "fs2", device2, 512));
+    let fs2 = Box::new(TestFileSystem::new("fs2", device2, 512));
     let fs2_id = manager2.register_fs(fs2);
     manager2.mount(fs2_id, "/mnt").unwrap();
     
@@ -979,7 +979,7 @@ fn test_structured_parameters_tmpfs() {
     let mut manager = VfsManager::new();
     
     // Create TmpFS with specific parameters
-    let params = TmpFSParams::new(1024 * 1024, 42); // 1MB limit, fs_id=42
+    let params = TmpFSParams::with_memory_limit(1024 * 1024); // 1MB limit
     let fs_id = manager.create_and_register_fs_with_params("tmpfs", &params).unwrap();
     
     // Mount the filesystem
@@ -1004,7 +1004,7 @@ fn test_structured_parameters_testfs() {
     let mut manager = VfsManager::new();
     
     // Create TestFS with specific parameters
-    let params = BasicFSParams::new(123)
+    let params = BasicFSParams::new()
         .with_block_size(1024)
         .with_read_only(false);
     let fs_id = manager.create_and_register_fs_with_params("testfs", &params).unwrap();
@@ -1031,7 +1031,7 @@ fn test_structured_parameters_cpio_error() {
     let mut manager = VfsManager::new();
     
     // Try to create CPIO filesystem with parameters (should fail)
-    let params = CpioFSParams::new(456);
+    let params = CpioFSParams::new();
     let result = manager.create_and_register_fs_with_params("cpiofs", &params);
     
     // Should fail because CPIO requires memory area
@@ -1063,7 +1063,7 @@ fn test_structured_parameters_backward_compatibility() {
     assert!(entries.iter().any(|e| e.name == "test.txt"));
     
     // Test that structured parameters also work for the same driver
-    let params = BasicFSParams::new(789);
+    let params = BasicFSParams::new();
     let fs_id2 = manager.create_and_register_fs_with_params("testfs", &params).unwrap();
     
     let result = manager.mount(fs_id2, "/structured");
@@ -1080,7 +1080,7 @@ fn test_structured_parameters_driver_not_found() {
     let mut manager = VfsManager::new();
     
     // Try to create filesystem with non-existent driver
-    let params = BasicFSParams::new(999);
+    let params = BasicFSParams::new();
     let result = manager.create_and_register_fs_with_params("nonexistent", &params);
     
     assert!(result.is_err());

--- a/kernel/src/task/elf_loader/tests/mod.rs
+++ b/kernel/src/task/elf_loader/tests/mod.rs
@@ -95,7 +95,7 @@ fn test_load_elf() {
 
     let mut manager = VfsManager::new();
     let blk_dev = MockBlockDevice::new(0, "test_blk", 512, 1024);
-    let fs = TestFileSystem::new(0, "test_fs", Box::new(blk_dev), 512);
+    let fs = TestFileSystem::new("test_fs", Box::new(blk_dev), 512);
     let fs_id = manager.register_fs(Box::new(fs));
     manager.mount(fs_id, "/").expect("Failed to mount test filesystem");
     let file_path = "/test.elf";
@@ -132,7 +132,7 @@ fn test_load_elf_invalid_magic() {
 
     let mut manager = VfsManager::new();
     let blk_dev = MockBlockDevice::new(0, "test_blk", 512, 1024);
-    let fs = TestFileSystem::new(0, "test_fs", Box::new(blk_dev), 512);
+    let fs = TestFileSystem::new("test_fs", Box::new(blk_dev), 512);
     let fs_id = manager.register_fs(Box::new(fs));
     manager.mount(fs_id, "/").expect("Failed to mount test filesystem");
     let file_path = "/invalid.elf";
@@ -160,7 +160,7 @@ fn test_load_elf_invalid_alignment() {
 
     let mut manager = VfsManager::new();
     let blk_dev = MockBlockDevice::new(0, "test_blk", 512, 1024);
-    let fs = TestFileSystem::new(0, "test_fs", Box::new(blk_dev), 512);
+    let fs = TestFileSystem::new( "test_fs", Box::new(blk_dev), 512);
     let fs_id = manager.register_fs(Box::new(fs));
     manager.mount(fs_id, "/").expect("Failed to mount test filesystem");
     let file_path = "/invalid_align.elf";
@@ -212,7 +212,7 @@ fn test_load_elf_bss_zeroed() {
 
     let mut manager = VfsManager::new();
     let blk_dev = MockBlockDevice::new(0, "test_blk", 512, 1024);
-    let fs = TestFileSystem::new(0, "test_fs", Box::new(blk_dev), 512);
+    let fs = TestFileSystem::new( "test_fs", Box::new(blk_dev), 512);
     let fs_id = manager.register_fs(Box::new(fs));
     manager.mount(fs_id, "/").expect("Failed to mount test filesystem");
     let file_path = "/test_bss.elf";


### PR DESCRIPTION
- Eliminated the `id` field from `Cpiofs`, `GenericFileSystem`, `TestFileSystem`, and `TmpFS` structures.
- Updated `VfsManager` to manage filesystem IDs, ensuring unique IDs are assigned during registration.
- Adjusted related methods and parameters to reflect the removal of filesystem ID handling from individual filesystem implementations.

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には、英語の本文を全て述べた後に、日本語でも併記するようにして下さい -->