### PR TITLE
Preparing to run the kernel in the higher half in the future

### DIFF
--- a/docs/memory-map.md
+++ b/docs/memory-map.md
@@ -1,0 +1,203 @@
+# Virtual Memory Map
+
+This document describes the virtual memory address space layout for each supported architecture in Scarlet OS. The design follows a **Higher Half Kernel** architecture with **HHDM (Higher Half Direct Mapping)** for efficient physical memory access.
+
+## Design Principles
+
+### Higher Half Kernel
+- The kernel resides in the upper half of the virtual address space
+- User processes occupy the lower half
+- Clear separation improves security and simplifies memory management
+
+### HHDM (Higher Half Direct Mapping)
+- All physical memory is directly mapped into the kernel's virtual address space
+- Enables fast physical-to-virtual address translation via simple offset arithmetic
+- Simplifies kernel code that needs to access arbitrary physical memory
+
+## Address Space Layout
+
+### RISC-V 64-bit (Sv48)
+
+Sv48 provides a 48-bit virtual address space with 4-level page tables.
+
+```
+                            Sv48 Virtual Address Space
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Address                                                                 │
+│                                                                         │
+│ 0xFFFF_FFFF_FFFF_FFFF ─┬───────────────────────────────────────────────┤
+│                        │                                                │
+│                        │              Kernel Image                      │
+│                        │         (Code, RO-data, RW-data, BSS)          │
+│                        │                                                │
+│ 0xFFFFFFC0_80000000 ───┼─────────────┬──────────────────────────────────┤ ← KERNEL_BASE
+│                        │  (reserved) │                                  │
+│                        │             │                                  │
+│ 0xFFFF_C000_00000000 ──┼─────────────┼──────────────────────────────────┤
+│                        │  (gap)      │                                  │
+│                        │             │                                  │
+│ 0xFFFF_BFFF_FFFF_FFFF ─┼─────────────┼─┬────────────────────────────────┤ ← HHDM_END
+│                        │             │ │                                │
+│                        │   Kernel    │ │       HHDM Region (64 TB)      │
+│                        │   Space     │ │   Direct Physical Memory Map   │
+│                        │             │ │   VA = PA + HHDM_OFFSET        │
+│                        │             │ │                                │
+│ 0xFFFF_8000_0000_0000 ─┼─────────────┼─┴────────────────────────────────┤ ← HHDM_START (= HHDM_OFFSET)
+│                        │             │                                  │
+│                        │  (gap)      │     (Upper Half)                 │
+│                        │             │                                  │
+│ 0x0000_8000_0000_0000 ─┼─────────────┼──────────────────────────────────┤
+│                        │             │                                  │
+│                        │  (hole)     │     Non-canonical                │
+│                        │             │     (Invalid addresses)          │
+│                        │             │                                  │
+│ 0x0000_7FFF_FFFF_FFFF ─┼─────────────┼──────────────────────────────────┤ ← USER_SPACE_END
+│                        │             │                                  │
+│                        │   User      │       User Space (128 TB)        │
+│                        │   Space     │       (Lower Half)               │
+│                        │             │                                  │
+│ 0x0000_0000_0000_0000 ─┴─────────────┴──────────────────────────────────┤
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+#### Memory Regions
+
+| Region | Start Address | End Address | Size | Description |
+|--------|---------------|-------------|------|-------------|
+| User Space | `0x0000_0000_0000_0000` | `0x0000_7FFF_FFFF_FFFF` | 128 TB | User process virtual memory |
+| Non-canonical | `0x0000_8000_0000_0000` | `0xFFFF_7FFF_FFFF_FFFF` | - | Invalid (hole) |
+| Kernel Space | `0xFFFF_8000_0000_0000` | `0xFFFF_FFFF_FFFF_FFFF` | 128 TB | Entire upper half (HHDM + Kernel Image) |
+| ├─ HHDM | `0xFFFF_8000_0000_0000` | `0xFFFF_BFFF_FFFF_FFFF` | 64 TB | Direct physical memory mapping |
+| └─ Kernel Image | `0xFFFFFFC0_80000000` | `0xFFFF_FFFF_FFFF_FFFF` | ~1 TB | Kernel code, data, heap, stacks |
+
+#### Constants
+
+```rust
+// RISC-V Sv48
+pub const HHDM_OFFSET: usize        = 0xFFFF_8000_0000_0000;
+pub const HHDM_START: usize         = 0xFFFF_8000_0000_0000;
+pub const HHDM_END: usize           = 0xFFFF_BFFF_FFFF_FFFF;  // 64 TB max
+pub const KERNEL_BASE: usize        = 0xFFFFFFC0_80000000;    // Link address
+pub const USER_SPACE_END: usize     = 0x0000_7FFF_FFFF_FFFF;
+pub const KERNEL_SPACE_START: usize = 0xFFFF_8000_0000_0000;
+```
+
+### AArch64
+
+AArch64 uses a 48-bit (or 52-bit with LVA) virtual address space with up to 4-level page tables (with 4KB granule).
+
+```
+                          AArch64 Virtual Address Space
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Address                                                                 │
+│                                                                         │
+│ 0xFFFF_FFFF_FFFF_FFFF ─┬───────────────────────────────────────────────┤
+│                        │                                                │
+│                        │              Kernel Image                      │
+│                        │         (Code, RO-data, RW-data, BSS)          │
+│                        │                                                │
+│ 0xFFFF_0000_80000000 ──┼─────────────┬──────────────────────────────────┤ ← KERNEL_BASE
+│                        │  (reserved) │                                  │
+│                        │             │                                  │
+│ 0xFFFF_4000_00000000 ──┼─────────────┼──────────────────────────────────┤
+│                        │  (gap)      │                                  │
+│                        │             │                                  │
+│ 0xFFFF_BFFF_FFFF_FFFF ─┼─────────────┼─┬────────────────────────────────┤ ← HHDM_END
+│                        │             │ │                                │
+│                        │   Kernel    │ │       HHDM Region (64 TB)      │
+│                        │   Space     │ │   Direct Physical Memory Map   │
+│                        │             │ │   VA = PA + HHDM_OFFSET        │
+│                        │             │ │                                │
+│ 0xFFFF_8000_0000_0000 ─┼─────────────┼─┴────────────────────────────────┤ ← HHDM_START (= HHDM_OFFSET)
+│                        │             │                                  │
+│                        │  (gap)      │     (Upper Half)                 │
+│                        │             │                                  │
+│ 0x0001_0000_0000_0000 ─┼─────────────┼──────────────────────────────────┤
+│                        │             │                                  │
+│                        │  (hole)     │     Non-canonical                │
+│                        │             │     (Invalid addresses)          │
+│                        │             │                                  │
+│ 0x0000_FFFF_FFFF_FFFF ─┼─────────────┼──────────────────────────────────┤ ← USER_SPACE_END
+│                        │             │                                  │
+│                        │   User      │       User Space (256 TB)        │
+│                        │   Space     │       (Lower Half)               │
+│                        │             │                                  │
+│ 0x0000_0000_0000_0000 ─┴─────────────┴──────────────────────────────────┤
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+#### Memory Regions
+
+| Region | Start Address | End Address | Size | Description |
+|--------|---------------|-------------|------|-------------|
+| User Space | `0x0000_0000_0000_0000` | `0x0000_FFFF_FFFF_FFFF` | 256 TB | User process virtual memory |
+| Non-canonical | `0x0001_0000_0000_0000` | `0xFFFF_7FFF_FFFF_FFFF` | - | Invalid (hole) |
+| Kernel Space | `0xFFFF_0000_0000_0000` | `0xFFFF_FFFF_FFFF_FFFF` | 128 TB | Entire upper half (HHDM + Kernel Image) |
+| ├─ HHDM | `0xFFFF_8000_0000_0000` | `0xFFFF_BFFF_FFFF_FFFF` | 64 TB | Direct physical memory mapping |
+| └─ Kernel Image | `0xFFFF_0000_80000000` | `0xFFFF_7FFF_FFFF_FFFF` | ~128 TB | Kernel code, data, heap, stacks |
+
+#### Constants
+
+```rust
+// AArch64
+pub const HHDM_OFFSET: usize        = 0xFFFF_8000_0000_0000;
+pub const HHDM_START: usize         = 0xFFFF_8000_0000_0000;
+pub const HHDM_END: usize           = 0xFFFF_BFFF_FFFF_FFFF;  // 64 TB max
+pub const KERNEL_BASE: usize        = 0xFFFF_0000_80000000;    // Link address
+pub const USER_SPACE_END: usize     = 0x0000_FFFF_FFFF_FFFF;
+pub const KERNEL_SPACE_START: usize = 0xFFFF_0000_0000_0000;
+```
+
+## Address Translation Functions
+
+The kernel provides two core functions for address translation:
+
+```rust
+/// Convert virtual address to physical address
+/// For addresses within HHDM: PA = VA - HHDM_OFFSET
+pub const fn virt_to_phys(vaddr: usize) -> usize {
+    vaddr - HHDM_OFFSET
+}
+
+/// Convert physical address to virtual address
+/// Uses HHDM: VA = PA + HHDM_OFFSET
+pub const fn phys_to_virt(paddr: usize) -> usize {
+    paddr + HHDM_OFFSET
+}
+```
+
+### Usage Guidelines
+
+| Scenario | Function | Example |
+|----------|----------|---------|
+| Store heap pointer in `pmarea` | `virt_to_phys()` | `pmarea.start = virt_to_phys(pages as usize)` |
+| Access physical memory via pointer | `phys_to_virt()` | `ptr = phys_to_virt(paddr) as *mut u8` |
+| Device DMA address | Already PA | `desc.addr = translate_vaddr(vaddr)` (returns PA) |
+| Free raw pages | `phys_to_virt()` | `free_raw_pages(phys_to_virt(paddr), n)` |
+
+## Transition Plan
+
+### Current State
+- Identity mapping: `VA == PA`
+- `virt_to_phys()` and `phys_to_virt()` are identity functions
+- All conversion calls are in place
+
+### Target State
+- Higher Half Kernel with HHDM
+- Kernel linked at `KERNEL_BASE` (VMA) but loaded at physical address (LMA)
+- Boot code establishes HHDM mapping before jumping to kernel proper
+- `virt_to_phys()` and `phys_to_virt()` apply `HHDM_OFFSET`
+
+### Migration Steps
+
+1. **Update linker scripts** - Set kernel VMA to higher half address
+2. **Update `addr.rs`** - Add `HHDM_OFFSET` constant and implement real translation
+3. **Update boot code** - Create early page tables with HHDM mapping
+4. **Update `kernel_vm_init()`** - Set `vmarea != pmarea` using HHDM offset
+5. **Test thoroughly** - Verify all 527+ tests still pass
+
+## References
+
+- RISC-V Privileged Architecture (Sv48): https://riscv.org/technical/specifications/
+- ARM Architecture Reference Manual (AArch64)
+- Linux kernel memory layout documentation

--- a/docs/multi-architecture.md
+++ b/docs/multi-architecture.md
@@ -202,12 +202,14 @@ QEMU virt machine device trees:
 
 ## Key Differences Between Architectures
 
+> **Note**: For detailed virtual memory layout and HHDM design, see [memory-map.md](memory-map.md).
+
 ### RISC-V 64
 
 - Register naming: `x0-x31`, `pc`, CSRs
 - Calling convention: `a0-a7` (args), `t0-t6` (temp), `s0-s11` (saved)
 - Privilege levels: M-mode, S-mode, U-mode
-- Page table: Sv39 (3-level paging)
+- Page table: Sv48 (4-level paging, 48-bit VA)
 - Interrupt handling: PLIC (Platform-Level Interrupt Controller)
 
 ### AArch64

--- a/kernel/src/drivers/block/virtio_blk.rs
+++ b/kernel/src/drivers/block/virtio_blk.rs
@@ -35,6 +35,7 @@ use crate::drivers::virtio::features::{
     VIRTIO_F_ANY_LAYOUT, VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
 };
 use crate::object::capability::{MemoryMappingOps, Selectable};
+use crate::vm::addr::virt_to_phys;
 use crate::{
     device::block::{
         BlockDevice,
@@ -773,7 +774,7 @@ impl VirtioDevice for VirtioBlockDevice {
         }
 
         let virtqueues = self.virtqueues.lock();
-        Some(virtqueues[queue_idx].get_raw_ptr() as u64)
+        Some(virt_to_phys(virtqueues[queue_idx].get_raw_ptr() as usize) as u64)
     }
 
     fn get_queue_driver_addr(&self, queue_idx: usize) -> Option<u64> {
@@ -782,7 +783,7 @@ impl VirtioDevice for VirtioBlockDevice {
         }
 
         let virtqueues = self.virtqueues.lock();
-        Some(virtqueues[queue_idx].avail.flags as *const _ as u64)
+        Some(virt_to_phys(virtqueues[queue_idx].avail.flags as *const _ as usize) as u64)
     }
 
     fn get_queue_device_addr(&self, queue_idx: usize) -> Option<u64> {
@@ -791,7 +792,7 @@ impl VirtioDevice for VirtioBlockDevice {
         }
 
         let virtqueues = self.virtqueues.lock();
-        Some(virtqueues[queue_idx].used.flags as *const _ as u64)
+        Some(virt_to_phys(virtqueues[queue_idx].used.flags as *const _ as usize) as u64)
     }
 }
 

--- a/kernel/src/drivers/network/virtio_net.rs
+++ b/kernel/src/drivers/network/virtio_net.rs
@@ -35,6 +35,7 @@ use crate::network::config::apply_pending_ip_for_interface;
 use crate::network::ethernet_interface::EthernetNetworkInterface;
 use crate::network::get_network_manager;
 use crate::object::capability::{MemoryMappingOps, Selectable};
+use crate::vm::addr::{phys_to_virt, virt_to_phys};
 use crate::{
     device::network::{
         DevicePacket, EthernetDevice, MacAddress, NetworkDevice, NetworkInterfaceConfig,
@@ -452,7 +453,7 @@ impl VirtioNetDevice {
 
         // Process all completed RX descriptors
         while let Some((desc_idx, used_len)) = rx_queue.pop_used() {
-            let buffer_addr = rx_queue.desc[desc_idx].addr as *mut u8;
+            let buffer_addr = phys_to_virt(rx_queue.desc[desc_idx].addr as usize) as *mut u8;
             let buffer_len = rx_queue.desc[desc_idx].len as usize;
             let used_len = core::cmp::min(used_len as usize, buffer_len);
 
@@ -718,7 +719,7 @@ impl VirtioDevice for VirtioNetDevice {
         }
 
         let virtqueues = self.virtqueues.lock();
-        Some(virtqueues[queue_idx].get_raw_ptr() as u64)
+        Some(virt_to_phys(virtqueues[queue_idx].get_raw_ptr() as usize) as u64)
     }
 
     fn get_queue_driver_addr(&self, queue_idx: usize) -> Option<u64> {
@@ -727,7 +728,7 @@ impl VirtioDevice for VirtioNetDevice {
         }
 
         let virtqueues = self.virtqueues.lock();
-        Some(virtqueues[queue_idx].avail.flags as *const _ as u64)
+        Some(virt_to_phys(virtqueues[queue_idx].avail.flags as *const _ as usize) as u64)
     }
 
     fn get_queue_device_addr(&self, queue_idx: usize) -> Option<u64> {
@@ -736,7 +737,7 @@ impl VirtioDevice for VirtioNetDevice {
         }
 
         let virtqueues = self.virtqueues.lock();
-        Some(virtqueues[queue_idx].used.flags as *const _ as u64)
+        Some(virt_to_phys(virtqueues[queue_idx].used.flags as *const _ as usize) as u64)
     }
 }
 

--- a/kernel/src/ipc/shared_memory.rs
+++ b/kernel/src/ipc/shared_memory.rs
@@ -11,6 +11,7 @@ use crate::mem::page::{allocate_raw_pages, free_raw_pages};
 use crate::object::capability::memory_mapping::{
     AccessKind, MemoryMappingOps, ResolveFaultError, ResolveFaultResult,
 };
+use crate::vm::addr::{phys_to_virt, virt_to_phys};
 use crate::vm::vmem::VirtualMemoryMap;
 
 const LOG_SHARED_MEMORY_RESIZE: bool = false;
@@ -103,7 +104,7 @@ impl SharedMemory {
         if pages.is_null() {
             return Err("Failed to allocate physical memory for shared memory");
         }
-        let paddr = pages as usize;
+        let paddr = virt_to_phys(pages as usize);
 
         let state = SharedMemoryState::new(paddr, aligned_size, permissions, true);
         let id = format!("shmem_{:#x}", paddr);
@@ -189,7 +190,7 @@ impl SharedMemoryObject for SharedMemory {
         if copy_size > 0 {
             unsafe {
                 core::ptr::copy_nonoverlapping(
-                    state.paddr as *const u8,
+                    phys_to_virt(state.paddr) as *const u8,
                     pages as *mut u8,
                     copy_size,
                 );
@@ -202,12 +203,12 @@ impl SharedMemoryObject for SharedMemory {
             if state.mapping_count > 0 {
                 state.stale_pages.push((old_paddr, old_pages));
             } else {
-                let old_ptr = old_paddr as *mut crate::mem::page::Page;
+                let old_ptr = phys_to_virt(old_paddr) as *mut crate::mem::page::Page;
                 free_raw_pages(old_ptr, old_pages);
             }
         }
 
-        state.paddr = pages as usize;
+        state.paddr = virt_to_phys(pages as usize);
         state.size = aligned_size;
         state.capacity = aligned_size;
 
@@ -289,7 +290,7 @@ impl MemoryMappingOps for SharedMemory {
                 if pages == 0 {
                     continue;
                 }
-                let ptr = paddr as *mut crate::mem::page::Page;
+                let ptr = phys_to_virt(paddr) as *mut crate::mem::page::Page;
                 free_raw_pages(ptr, pages);
             }
         }
@@ -359,13 +360,13 @@ impl Drop for SharedMemory {
         // Only free the physical pages if this object owns them
         if state.owns_memory {
             let num_pages = (state.capacity + PAGE_SIZE - 1) / PAGE_SIZE;
-            let pages_ptr = state.paddr as *mut crate::mem::page::Page;
+            let pages_ptr = phys_to_virt(state.paddr) as *mut crate::mem::page::Page;
             free_raw_pages(pages_ptr, num_pages);
             for (paddr, pages) in &state.stale_pages {
                 if *pages == 0 {
                     continue;
                 }
-                let pages_ptr = *paddr as *mut crate::mem::page::Page;
+                let pages_ptr = phys_to_virt(*paddr) as *mut crate::mem::page::Page;
                 free_raw_pages(pages_ptr, *pages);
             }
         }

--- a/kernel/src/task/elf_loader/mod.rs
+++ b/kernel/src/task/elf_loader/mod.rs
@@ -44,6 +44,7 @@ use crate::environment::PAGE_SIZE;
 use crate::fs::{FileObject, SeekFrom};
 use crate::mem::page::{allocate_raw_pages, free_raw_pages};
 use crate::task::{ManagedPage, Task};
+use crate::vm::addr::phys_to_virt;
 use crate::vm::vmem::{MemoryArea, VirtualMemoryMap, VirtualMemoryPermission, VirtualMemoryRegion};
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
@@ -1057,7 +1058,7 @@ fn load_elf_into_task_static(
                     Some(paddr) => unsafe {
                         core::ptr::copy_nonoverlapping(
                             segment_data.as_ptr(),
-                            paddr as *mut u8,
+                            phys_to_virt(paddr) as *mut u8,
                             ph.p_filesz as usize,
                         );
                     },
@@ -1152,7 +1153,7 @@ fn load_program_headers_into_memory(
         Some(paddr) => unsafe {
             core::ptr::copy_nonoverlapping(
                 phdr_data.as_ptr(),
-                paddr as *mut u8,
+                phys_to_virt(paddr) as *mut u8,
                 phdr_table_size as usize,
             );
         },
@@ -1341,7 +1342,7 @@ pub fn setup_auxiliary_vector_on_stack(
         // Translate to physical address and write
         match task.vm_manager.translate_vaddr(vaddr) {
             Some(paddr) => unsafe {
-                let ptr = paddr as *mut AuxVec;
+                let ptr = phys_to_virt(paddr) as *mut AuxVec;
                 ptr.write(*entry);
             },
             None => {

--- a/kernel/src/task/elf_loader/tests/mod.rs
+++ b/kernel/src/task/elf_loader/tests/mod.rs
@@ -4,6 +4,7 @@
 
 use crate::fs::{FileType, SeekFrom, TmpFSParams, VfsManager, drivers::tmpfs::TmpFS};
 use crate::task::new_user_task;
+use crate::vm::addr::phys_to_virt;
 
 use super::*;
 
@@ -237,7 +238,7 @@ fn test_load_elf() {
     // Read the instruction at the entry point
     let instruction: u32;
     unsafe {
-        instruction = core::ptr::read(paddr as *const u32);
+        instruction = core::ptr::read(phys_to_virt(paddr) as *const u32);
     }
 
     // Expected instruction at the entry point (e.g., a jump instruction)
@@ -414,7 +415,7 @@ fn test_load_elf_bss_zeroed() {
     for i in 0..bss_size {
         let byte: u8;
         unsafe {
-            byte = core::ptr::read((paddr + i) as *const u8);
+            byte = core::ptr::read(phys_to_virt(paddr + i) as *const u8);
         }
         assert_eq!(
             byte, 0,

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -35,6 +35,7 @@ use crate::{
     sched::scheduler::{Scheduler, get_scheduler},
     timer::{TimerHandler, add_timer, get_tick},
     vm::{
+        addr::{phys_to_virt, virt_to_phys},
         manager::VirtualMemoryManager,
         user_kernel_vm_init, user_vm_init,
         vmem::{MemoryArea, VirtualMemoryMap, VirtualMemoryRegion},
@@ -806,7 +807,7 @@ impl Task {
 
         let pages = allocate_raw_pages(num_of_pages);
         let size = num_of_pages * PAGE_SIZE;
-        let paddr = pages as usize;
+        let paddr = virt_to_phys(pages as usize);
         let mmap = VirtualMemoryMap {
             pmarea: MemoryArea {
                 start: paddr,
@@ -1335,7 +1336,7 @@ impl Task {
                         let permissions = mmap.permissions;
                         let pages = allocate_raw_pages(num_pages);
                         let size = num_pages * PAGE_SIZE;
-                        let paddr = pages as usize;
+                        let paddr = virt_to_phys(pages as usize);
                         let new_mmap = VirtualMemoryMap {
                             pmarea: MemoryArea {
                                 start: paddr,
@@ -1352,8 +1353,8 @@ impl Task {
 
                         // Copy original contents page-by-page
                         for i in 0..num_pages {
-                            let src_page_addr = mmap.pmarea.start + i * PAGE_SIZE;
-                            let dst_page_addr = new_mmap.pmarea.start + i * PAGE_SIZE;
+                            let src_page_addr = phys_to_virt(mmap.pmarea.start + i * PAGE_SIZE);
+                            let dst_page_addr = phys_to_virt(new_mmap.pmarea.start + i * PAGE_SIZE);
                             unsafe {
                                 core::ptr::copy_nonoverlapping(
                                     src_page_addr as *const u8,
@@ -2011,6 +2012,7 @@ mod tests {
     use core::sync::atomic::Ordering;
 
     use crate::task::CloneFlags;
+    use crate::vm::addr::{phys_to_virt, virt_to_phys};
 
     #[test_case]
     fn test_set_brk() {
@@ -2226,8 +2228,8 @@ mod tests {
 
         // Verify the data was copied correctly
         unsafe {
-            let parent_ptr = parent_paddr as *const u8;
-            let child_ptr = child_mmap.pmarea.start as *const u8;
+            let parent_ptr = phys_to_virt(parent_paddr) as *const u8;
+            let child_ptr = phys_to_virt(child_mmap.pmarea.start) as *const u8;
 
             // Check that physical addresses are different (separate memory)
             assert_ne!(
@@ -2245,11 +2247,11 @@ mod tests {
 
         // Verify that modifying parent's memory doesn't affect child's memory
         unsafe {
-            let parent_ptr = mmap.pmarea.start as *mut u8;
+            let parent_ptr = phys_to_virt(mmap.pmarea.start) as *mut u8;
             let original_value = *parent_ptr;
             *parent_ptr = 0xFF; // Modify first byte in parent
 
-            let child_ptr = child_mmap.pmarea.start as *const u8;
+            let child_ptr = phys_to_virt(child_mmap.pmarea.start) as *const u8;
             let child_first_byte = *child_ptr;
 
             // Child's first byte should still be the original value
@@ -2405,7 +2407,7 @@ mod tests {
         let shared_vaddr = 0x5000;
         let num_pages = 1;
         let pages = allocate_raw_pages(num_pages);
-        let paddr = pages as usize;
+        let paddr = virt_to_phys(pages as usize);
 
         let shared_mmap = VirtualMemoryMap {
             pmarea: MemoryArea {
@@ -2431,7 +2433,7 @@ mod tests {
         // Write test data to shared memory
         let test_data: [u8; 8] = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22];
         unsafe {
-            let shared_ptr = paddr as *mut u8;
+            let shared_ptr = phys_to_virt(paddr) as *mut u8;
             core::ptr::copy_nonoverlapping(test_data.as_ptr(), shared_ptr, test_data.len());
         }
 

--- a/kernel/src/vm/addr.rs
+++ b/kernel/src/vm/addr.rs
@@ -6,28 +6,35 @@
 //!
 //! # Usage
 //!
-//! ```rust
+//! ```rust,ignore
 //! use crate::vm::addr::{virt_to_phys, phys_to_virt};
+//!
+//! // Example virtual address
+//! let vaddr: usize = 0x1000;
 //!
 //! // Convert virtual address to physical address
 //! let paddr = virt_to_phys(vaddr);
 //!
-//! // Convert physical address to virtual address
-//! let vaddr = phys_to_virt(paddr);
+//! // Convert physical address back to virtual address
+//! let vaddr_back = phys_to_virt(paddr);
 //! ```
 
 /// Converts a virtual address to a physical address.
+///
+/// **Note:** This function is specifically intended for addresses in the
+/// HHDM (Higher Half Direct Map) / direct-map region. It is **not** valid
+/// for arbitrary kernel virtual addresses (e.g., kernel image mappings).
 ///
 /// Currently assumes identity mapping (VA == PA).
 /// When Higher Half Kernel is enabled, this will subtract HHDM_OFFSET.
 ///
 /// # Arguments
 ///
-/// * `vaddr` - Virtual address to convert
+/// * `vaddr` - Virtual address in the direct-map region to convert
 ///
 /// # Returns
 ///
-/// Physical address corresponding to the given virtual address
+/// Physical address corresponding to the given direct-map virtual address
 #[inline(always)]
 pub const fn virt_to_phys(vaddr: usize) -> usize {
     // Identity mapping: VA == PA
@@ -38,6 +45,10 @@ pub const fn virt_to_phys(vaddr: usize) -> usize {
 
 /// Converts a physical address to a virtual address.
 ///
+/// **Note:** This function is specifically intended for producing addresses in
+/// the HHDM (Higher Half Direct Map) / direct-map region. It is **not** valid
+/// for obtaining arbitrary kernel virtual addresses (e.g., kernel image VAs).
+///
 /// Currently assumes identity mapping (VA == PA).
 /// When Higher Half Kernel is enabled, this will add HHDM_OFFSET.
 ///
@@ -47,7 +58,7 @@ pub const fn virt_to_phys(vaddr: usize) -> usize {
 ///
 /// # Returns
 ///
-/// Virtual address corresponding to the given physical address
+/// Direct-map virtual address corresponding to the given physical address
 #[inline(always)]
 pub const fn phys_to_virt(paddr: usize) -> usize {
     // Identity mapping: VA == PA
@@ -141,20 +152,35 @@ impl PhysAddr {
     }
 
     /// Returns true if the address is aligned to the given boundary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `align` is 0 or not a power of two.
     #[inline(always)]
     pub const fn is_aligned(&self, align: usize) -> bool {
-        self.0 % align == 0
+        assert!(align != 0 && align.is_power_of_two());
+        self.0 & (align - 1) == 0
     }
 
     /// Returns the address aligned down to the given boundary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `align` is 0 or not a power of two.
     #[inline(always)]
     pub const fn align_down(&self, align: usize) -> Self {
+        assert!(align != 0 && align.is_power_of_two());
         Self::new(self.0 & !(align - 1))
     }
 
     /// Returns the address aligned up to the given boundary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `align` is 0 or not a power of two.
     #[inline(always)]
     pub const fn align_up(&self, align: usize) -> Self {
+        assert!(align != 0 && align.is_power_of_two());
         Self::new((self.0 + align - 1) & !(align - 1))
     }
 }
@@ -185,22 +211,79 @@ impl VirtAddr {
         PhysAddr::new(virt_to_phys(self.0))
     }
 
-    /// Returns true if the address is aligned to the given boundary.
+    /// Returns `true` if the address is aligned to the given boundary.
+    ///
+    /// # Parameters
+    ///
+    /// * `align` - Alignment in bytes. Must be non-zero and a power of two.
+    ///
+    /// If `align` is zero or not a power of two, this function:
+    ///
+    /// * Returns `false` in release builds.
+    /// * Triggers a debug assertion in debug builds and returns `false`.
     #[inline(always)]
     pub const fn is_aligned(&self, align: usize) -> bool {
-        self.0 % align == 0
+        if !Self::is_valid_align(align) {
+            debug_assert!(
+                false,
+                "VirtAddr::is_aligned called with invalid alignment (must be non-zero power of two)",
+            );
+            return false;
+        }
+        (self.0 & (align - 1)) == 0
     }
 
     /// Returns the address aligned down to the given boundary.
+    ///
+    /// # Parameters
+    ///
+    /// * `align` - Alignment in bytes. Must be non-zero and a power of two.
+    ///
+    /// If `align` is zero or not a power of two, this function:
+    ///
+    /// * Returns the original address in release builds.
+    /// * Triggers a debug assertion in debug builds and returns the original address.
     #[inline(always)]
     pub const fn align_down(&self, align: usize) -> Self {
+        if !Self::is_valid_align(align) {
+            debug_assert!(
+                false,
+                "VirtAddr::align_down called with invalid alignment (must be non-zero power of two)",
+            );
+            return *self;
+        }
         Self::new(self.0 & !(align - 1))
     }
 
     /// Returns the address aligned up to the given boundary.
+    ///
+    /// # Parameters
+    ///
+    /// * `align` - Alignment in bytes. Must be non-zero and a power of two.
+    ///
+    /// If `align` is zero or not a power of two, this function:
+    ///
+    /// * Returns the original address in release builds.
+    /// * Triggers a debug assertion in debug builds and returns the original address.
     #[inline(always)]
     pub const fn align_up(&self, align: usize) -> Self {
+        if !Self::is_valid_align(align) {
+            debug_assert!(
+                false,
+                "VirtAddr::align_up called with invalid alignment (must be non-zero power of two)",
+            );
+            return *self;
+        }
         Self::new((self.0 + align - 1) & !(align - 1))
+    }
+
+    /// Returns `true` if an alignment value is valid for use with
+    /// [`VirtAddr::is_aligned`], [`VirtAddr::align_down`], and [`VirtAddr::align_up`].
+    ///
+    /// A valid alignment is non-zero and a power of two.
+    #[inline(always)]
+    const fn is_valid_align(align: usize) -> bool {
+        align != 0 && align.is_power_of_two()
     }
 }
 

--- a/kernel/src/vm/addr.rs
+++ b/kernel/src/vm/addr.rs
@@ -1,0 +1,263 @@
+//! Address translation utilities for virtual memory management.
+//!
+//! This module provides functions for converting between physical and virtual addresses.
+//! Currently, it assumes identity mapping (VA == PA), but is designed to be extended
+//! for Higher Half Kernel + HHDM (Higher Half Direct Mapping) in the future.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use crate::vm::addr::{virt_to_phys, phys_to_virt};
+//!
+//! // Convert virtual address to physical address
+//! let paddr = virt_to_phys(vaddr);
+//!
+//! // Convert physical address to virtual address
+//! let vaddr = phys_to_virt(paddr);
+//! ```
+
+/// Converts a virtual address to a physical address.
+///
+/// Currently assumes identity mapping (VA == PA).
+/// When Higher Half Kernel is enabled, this will subtract HHDM_OFFSET.
+///
+/// # Arguments
+///
+/// * `vaddr` - Virtual address to convert
+///
+/// # Returns
+///
+/// Physical address corresponding to the given virtual address
+#[inline(always)]
+pub const fn virt_to_phys(vaddr: usize) -> usize {
+    // Identity mapping: VA == PA
+    // Future: When Higher Half is enabled, this will be:
+    // vaddr - HHDM_OFFSET
+    vaddr
+}
+
+/// Converts a physical address to a virtual address.
+///
+/// Currently assumes identity mapping (VA == PA).
+/// When Higher Half Kernel is enabled, this will add HHDM_OFFSET.
+///
+/// # Arguments
+///
+/// * `paddr` - Physical address to convert
+///
+/// # Returns
+///
+/// Virtual address corresponding to the given physical address
+#[inline(always)]
+pub const fn phys_to_virt(paddr: usize) -> usize {
+    // Identity mapping: VA == PA
+    // Future: When Higher Half is enabled, this will be:
+    // paddr + HHDM_OFFSET
+    paddr
+}
+
+/// Converts a physical address to a virtual address for kernel use.
+///
+/// This is an alias for `phys_to_virt` but makes the intent clearer
+/// when accessing kernel memory.
+///
+/// # Arguments
+///
+/// * `paddr` - Physical address to convert
+///
+/// # Returns
+///
+/// Virtual address that can be used to access the physical memory
+#[inline(always)]
+pub const fn phys_to_kernel_virt(paddr: usize) -> usize {
+    phys_to_virt(paddr)
+}
+
+/// Converts a virtual address used by kernel to physical address.
+///
+/// This is an alias for `virt_to_phys` but makes the intent clearer
+/// when dealing with kernel virtual addresses.
+///
+/// # Arguments
+///
+/// * `vaddr` - Kernel virtual address to convert
+///
+/// # Returns
+///
+/// Physical address corresponding to the given kernel virtual address
+#[inline(always)]
+pub const fn kernel_virt_to_phys(vaddr: usize) -> usize {
+    virt_to_phys(vaddr)
+}
+
+/// Checks if the given virtual address is in the direct mapping region.
+///
+/// With identity mapping, all addresses are in the direct mapping region.
+/// When Higher Half is enabled, this will check if the address is in HHDM range.
+///
+/// # Arguments
+///
+/// * `vaddr` - Virtual address to check
+///
+/// # Returns
+///
+/// `true` if the address is in the direct mapping region
+#[inline(always)]
+pub const fn is_direct_mapped(_vaddr: usize) -> bool {
+    // With identity mapping, all addresses are direct mapped
+    // Future: When Higher Half is enabled:
+    // vaddr >= HHDM_OFFSET && vaddr < HHDM_OFFSET + MAX_PHYSICAL_MEMORY
+    true
+}
+
+// ============================================================================
+// Type-safe address wrappers (for future use)
+// ============================================================================
+
+/// A physical memory address.
+///
+/// This type provides type safety when working with physical addresses,
+/// preventing accidental mixing with virtual addresses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PhysAddr(pub usize);
+
+impl PhysAddr {
+    /// Creates a new physical address.
+    #[inline(always)]
+    pub const fn new(addr: usize) -> Self {
+        Self(addr)
+    }
+
+    /// Returns the raw address value.
+    #[inline(always)]
+    pub const fn as_usize(&self) -> usize {
+        self.0
+    }
+
+    /// Converts this physical address to a virtual address.
+    #[inline(always)]
+    pub const fn to_virt(&self) -> VirtAddr {
+        VirtAddr::new(phys_to_virt(self.0))
+    }
+
+    /// Returns true if the address is aligned to the given boundary.
+    #[inline(always)]
+    pub const fn is_aligned(&self, align: usize) -> bool {
+        self.0 % align == 0
+    }
+
+    /// Returns the address aligned down to the given boundary.
+    #[inline(always)]
+    pub const fn align_down(&self, align: usize) -> Self {
+        Self::new(self.0 & !(align - 1))
+    }
+
+    /// Returns the address aligned up to the given boundary.
+    #[inline(always)]
+    pub const fn align_up(&self, align: usize) -> Self {
+        Self::new((self.0 + align - 1) & !(align - 1))
+    }
+}
+
+/// A virtual memory address.
+///
+/// This type provides type safety when working with virtual addresses,
+/// preventing accidental mixing with physical addresses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct VirtAddr(pub usize);
+
+impl VirtAddr {
+    /// Creates a new virtual address.
+    #[inline(always)]
+    pub const fn new(addr: usize) -> Self {
+        Self(addr)
+    }
+
+    /// Returns the raw address value.
+    #[inline(always)]
+    pub const fn as_usize(&self) -> usize {
+        self.0
+    }
+
+    /// Converts this virtual address to a physical address.
+    #[inline(always)]
+    pub const fn to_phys(&self) -> PhysAddr {
+        PhysAddr::new(virt_to_phys(self.0))
+    }
+
+    /// Returns true if the address is aligned to the given boundary.
+    #[inline(always)]
+    pub const fn is_aligned(&self, align: usize) -> bool {
+        self.0 % align == 0
+    }
+
+    /// Returns the address aligned down to the given boundary.
+    #[inline(always)]
+    pub const fn align_down(&self, align: usize) -> Self {
+        Self::new(self.0 & !(align - 1))
+    }
+
+    /// Returns the address aligned up to the given boundary.
+    #[inline(always)]
+    pub const fn align_up(&self, align: usize) -> Self {
+        Self::new((self.0 + align - 1) & !(align - 1))
+    }
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test_case]
+    fn test_identity_mapping_virt_to_phys() {
+        let vaddr = 0x80000000usize;
+        let paddr = virt_to_phys(vaddr);
+        assert_eq!(paddr, vaddr);
+    }
+
+    #[test_case]
+    fn test_identity_mapping_phys_to_virt() {
+        let paddr = 0x80000000usize;
+        let vaddr = phys_to_virt(paddr);
+        assert_eq!(vaddr, paddr);
+    }
+
+    #[test_case]
+    fn test_roundtrip_conversion() {
+        let original = 0x80001234usize;
+        let paddr = virt_to_phys(original);
+        let vaddr = phys_to_virt(paddr);
+        assert_eq!(vaddr, original);
+    }
+
+    #[test_case]
+    fn test_phys_addr_type() {
+        let paddr = PhysAddr::new(0x80000000);
+        assert_eq!(paddr.as_usize(), 0x80000000);
+        assert_eq!(paddr.to_virt().as_usize(), 0x80000000);
+    }
+
+    #[test_case]
+    fn test_virt_addr_type() {
+        let vaddr = VirtAddr::new(0x80000000);
+        assert_eq!(vaddr.as_usize(), 0x80000000);
+        assert_eq!(vaddr.to_phys().as_usize(), 0x80000000);
+    }
+
+    #[test_case]
+    fn test_addr_alignment() {
+        let addr = PhysAddr::new(0x80001234);
+        assert!(!addr.is_aligned(0x1000));
+        assert_eq!(addr.align_down(0x1000).as_usize(), 0x80001000);
+        assert_eq!(addr.align_up(0x1000).as_usize(), 0x80002000);
+
+        let aligned = PhysAddr::new(0x80002000);
+        assert!(aligned.is_aligned(0x1000));
+        assert_eq!(aligned.align_down(0x1000).as_usize(), 0x80002000);
+        assert_eq!(aligned.align_up(0x1000).as_usize(), 0x80002000);
+    }
+}

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -3,6 +3,12 @@
 //! This module provides the virtual memory abstraction for the kernel. It
 //! includes functions for managing virtual address spaces.
 
+pub mod addr;
+pub mod manager;
+pub mod vmem;
+
+pub use addr::{PhysAddr, VirtAddr, phys_to_virt, virt_to_phys};
+
 use manager::VirtualMemoryManager;
 use vmem::MemoryArea;
 use vmem::VirtualMemoryMap;
@@ -30,9 +36,6 @@ use core::sync::atomic::Ordering;
 use spin::{Mutex, Once};
 
 extern crate alloc;
-
-pub mod manager;
-pub mod vmem;
 
 static KERNEL_VM_MANAGER: Once<VirtualMemoryManager> = Once::new();
 


### PR DESCRIPTION
将来的に他のアーキテクチャ(x86_64など)に移植する際や、実機で動かすにあたって、Limineなどの既存ブートローダを利用する形にしたい。その場合、Higher halfでカーネルが動くことが前提となる。
また、ユーザ空間とカーネル空間の遷移時のオーバヘッドも削減できる。

これを見据えて計画を練った。

1. PMM(物理メモリアロケータとヒープアロケータの分離
2. Limineブートに変更 (ここでHigher Half, HHDMでの動作に)

その準備段階として、phys_to_virt, virt_to_physをとりあえず用意し、既存の物理メモリへの直接アクセスをこれに置き換え