### PR TITLE
support m1 macbook

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -302,25 +302,25 @@ dependencies = ["build-initramfs-debug-aarch64"]
 description = "Run the kernel in release mode (RISC-V)"
 command = "cargo"
 args = ["run", "--manifest-path", "cargo-scarlet/Cargo.toml", "--", "run", "--project", "bsp/riscv64-limine", "--release"]
-dependencies = ["build-initramfs-release-riscv64", "build-rootfs-riscv64"]
+dependencies = ["build-initramfs-release-riscv64", "build-rootfs-riscv64", "build-boot-image-riscv64-release"]
 
 [tasks.run-aarch64]
 description = "Run the kernel in release mode (AArch64)"
 command = "cargo"
 args = ["run", "--manifest-path", "cargo-scarlet/Cargo.toml", "--", "run", "--project", "bsp/aarch64-limine", "--release"]
-dependencies = ["build-initramfs-release-aarch64", "build-rootfs-aarch64"]
+dependencies = ["build-initramfs-release-aarch64", "build-rootfs-aarch64", "build-boot-image-aarch64-release"]
 
 [tasks.run-debug-riscv64]
 description = "Run the kernel in debug mode (RISC-V)"
 command = "cargo"
 args = ["run", "--manifest-path", "cargo-scarlet/Cargo.toml", "--", "run", "--project", "bsp/riscv64-limine"]
-dependencies = ["build-initramfs-debug-riscv64", "build-rootfs-riscv64"]
+dependencies = ["build-initramfs-debug-riscv64", "build-rootfs-riscv64", "build-boot-image-riscv64"]
 
 [tasks.run-debug-aarch64]
 description = "Run the kernel in debug mode (AArch64)"
 command = "cargo"
 args = ["run", "--manifest-path", "cargo-scarlet/Cargo.toml", "--", "run", "--project", "bsp/aarch64-limine"]
-dependencies = ["build-initramfs-debug-aarch64", "build-rootfs-aarch64"]
+dependencies = ["build-initramfs-debug-aarch64", "build-rootfs-aarch64", "build-boot-image-aarch64"]
 
 [tasks.debug-riscv64]
 description = "Run the kernel in debug mode (RISC-V)"

--- a/kernel/src/arch/aarch64/boot/limine.rs
+++ b/kernel/src/arch/aarch64/boot/limine.rs
@@ -61,20 +61,12 @@ pub extern "C" fn limine_entry() -> ! {
     init_fdt(dtb_ptr);
 
     let usable_region = select_usable_region(memmap.entries());
+    let hhdm_offset = hhdm.offset() as usize;
     let relocated_fdt = relocate_fdt(phys_to_virt(usable_region.start) as *mut u8);
     let reserved_bytes = relocated_fdt.size();
-    let usable_memory_phys = reserve_front(usable_region, reserved_bytes);
-    let usable_memory = MemoryArea::new(
-        phys_to_virt(usable_memory_phys.start),
-        phys_to_virt(usable_memory_phys.end),
-    );
-    let direct_map_area = MemoryArea::new(
-        phys_to_virt(usable_region.start),
-        phys_to_virt(usable_region.end),
-    );
-    let initramfs_phys = module_area(MODULE_REQUEST.get_response());
-    let initramfs = initramfs_phys
-        .map(|area| MemoryArea::new(phys_to_virt(area.start), phys_to_virt(area.end)));
+    let usable_memory_paddr = reserve_front(usable_region, reserved_bytes);
+    let direct_map_paddr = usable_region;
+    let initramfs_paddr = module_area(MODULE_REQUEST.get_response());
     let fdt_manager = FdtManager::get_manager();
     let cpu_count = fdt_manager.get_cpu_count().unwrap_or(1);
     let cmdline = fdt_manager
@@ -85,12 +77,10 @@ pub extern "C" fn limine_entry() -> ! {
     let bootinfo = BootInfo::new(
         cpu_id,
         cpu_count,
-        usable_memory,
-        direct_map_area,
-        usable_memory_phys,
-        usable_region,
-        initramfs,
-        initramfs_phys,
+        usable_memory_paddr,
+        direct_map_paddr,
+        initramfs_paddr,
+        hhdm_offset,
         cmdline,
         DeviceSource::Fdt(relocated_fdt.start),
     );

--- a/kernel/src/arch/aarch64/boot/limine.rs
+++ b/kernel/src/arch/aarch64/boot/limine.rs
@@ -10,7 +10,7 @@ use crate::environment::STACK_SIZE;
 use crate::mem::{KERNEL_STACK, init_bss};
 use crate::vm::addr::{init_limine_addressing, phys_to_virt};
 use crate::vm::vmem::MemoryArea;
-use crate::{BootInfo, DeviceSource, start_ap, start_kernel};
+use crate::{BootInfo, DeviceSource, early_println, start_ap, start_kernel};
 use core::sync::atomic::compiler_fence;
 
 static mut EARLY_BOOTINFO: MaybeUninit<BootInfo> = MaybeUninit::uninit();
@@ -97,6 +97,13 @@ pub extern "C" fn limine_entry() -> ! {
 
     crate::arch::init_user_context_from_fdt();
     crate::arch::aarch64::init_arch(cpu_id);
+
+    let current_el = unsafe {
+        let el: usize;
+        asm!("mrs {0}, CurrentEL", out(reg) el, options(nostack));
+        el >> 2
+    };
+    early_println!("Current EL: EL{}", current_el);
 
     unsafe {
         let stack_top = (&raw const KERNEL_STACK) as *const _ as usize + STACK_SIZE * (cpu_id + 1);

--- a/kernel/src/arch/aarch64/boot/limine.rs
+++ b/kernel/src/arch/aarch64/boot/limine.rs
@@ -3,12 +3,13 @@ use core::mem::MaybeUninit;
 
 use crate::boot::limine::{
     DTB_REQUEST, EXECUTABLE_ADDRESS_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST, MODULE_REQUEST,
-    ensure_base_revision_supported, module_area, reserve_front, response, select_usable_region,
+    ensure_base_revision_supported, hhdm_physical_span, module_area, reserve_front, response,
+    select_usable_region,
 };
 use crate::device::fdt::{FdtManager, init_fdt, relocate_fdt};
 use crate::environment::STACK_SIZE;
 use crate::mem::{KERNEL_STACK, init_bss};
-use crate::vm::addr::{init_limine_addressing, phys_to_virt};
+use crate::vm::addr::{init_boot_direct_map_range, init_limine_addressing, phys_to_virt};
 use crate::vm::vmem::MemoryArea;
 use crate::{BootInfo, DeviceSource, early_println, start_ap, start_kernel};
 use core::sync::atomic::compiler_fence;
@@ -61,12 +62,14 @@ pub extern "C" fn limine_entry() -> ! {
     init_fdt(dtb_ptr);
 
     let usable_region = select_usable_region(memmap.entries());
+    let hhdm_phys_span = hhdm_physical_span(memmap.entries());
+    init_boot_direct_map_range(hhdm_phys_span.start, hhdm_phys_span.end);
     let hhdm_offset = hhdm.offset() as usize;
     let relocated_fdt = relocate_fdt(phys_to_virt(usable_region.start) as *mut u8);
     let relocated_fdt_paddr = usable_region.start;
     let reserved_bytes = relocated_fdt.size();
     let usable_memory_paddr = reserve_front(usable_region, reserved_bytes);
-    let direct_map_paddr = usable_region;
+    let direct_map_paddr = hhdm_phys_span;
     let initramfs_paddr = module_area(MODULE_REQUEST.get_response());
     let fdt_manager = FdtManager::get_manager();
     let cpu_count = fdt_manager.get_cpu_count().unwrap_or(1);

--- a/kernel/src/arch/aarch64/boot/limine.rs
+++ b/kernel/src/arch/aarch64/boot/limine.rs
@@ -2,9 +2,9 @@ use core::arch::{asm, naked_asm};
 use core::mem::MaybeUninit;
 
 use crate::boot::limine::{
-    DTB_REQUEST, EXECUTABLE_ADDRESS_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST, MODULE_REQUEST,
-    ensure_base_revision_supported, hhdm_physical_span, module_area, reserve_front, response,
-    select_usable_region,
+    DTB_REQUEST, EXECUTABLE_ADDRESS_REQUEST, FRAMEBUFFER_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST,
+    MODULE_REQUEST, ensure_base_revision_supported, framebuffer_area, hhdm_physical_span,
+    module_area, reserve_front, response, select_usable_region,
 };
 use crate::device::fdt::{FdtManager, init_fdt, relocate_fdt};
 use crate::environment::STACK_SIZE;
@@ -77,6 +77,7 @@ pub extern "C" fn limine_entry() -> ! {
         .get_fdt()
         .and_then(|fdt| fdt.chosen().bootargs());
     let cpu_id = current_cpu_id();
+    let framebuffer_paddr = framebuffer_area(FRAMEBUFFER_REQUEST.get_response());
 
     let bootinfo = BootInfo::new(
         cpu_id,
@@ -87,6 +88,7 @@ pub extern "C" fn limine_entry() -> ! {
         hhdm_offset,
         cmdline,
         DeviceSource::Fdt(relocated_fdt_paddr),
+        framebuffer_paddr,
     );
 
     crate::arch::init_user_context_from_fdt();

--- a/kernel/src/arch/aarch64/boot/limine.rs
+++ b/kernel/src/arch/aarch64/boot/limine.rs
@@ -63,6 +63,7 @@ pub extern "C" fn limine_entry() -> ! {
     let usable_region = select_usable_region(memmap.entries());
     let hhdm_offset = hhdm.offset() as usize;
     let relocated_fdt = relocate_fdt(phys_to_virt(usable_region.start) as *mut u8);
+    let relocated_fdt_paddr = usable_region.start;
     let reserved_bytes = relocated_fdt.size();
     let usable_memory_paddr = reserve_front(usable_region, reserved_bytes);
     let direct_map_paddr = usable_region;
@@ -82,7 +83,7 @@ pub extern "C" fn limine_entry() -> ! {
         initramfs_paddr,
         hhdm_offset,
         cmdline,
-        DeviceSource::Fdt(relocated_fdt.start),
+        DeviceSource::Fdt(relocated_fdt_paddr),
     );
 
     crate::arch::init_user_context_from_fdt();

--- a/kernel/src/arch/aarch64/interrupt/mod.rs
+++ b/kernel/src/arch/aarch64/interrupt/mod.rs
@@ -3,9 +3,47 @@
 //! Interrupt handling for AArch64 architecture.
 
 use core::arch::asm;
+use core::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 
 use crate::arch::get_cpu;
 use crate::interrupt::{InterruptError, InterruptManager, controllers::LocalInterruptType};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimerInterruptRoute {
+    Unknown,
+    ExternalControllerIrq,
+    FastInterrupt,
+}
+
+static TIMER_INTERRUPT_ROUTE: AtomicU8 = AtomicU8::new(TimerInterruptRoute::Unknown as u8);
+static TIMER_EXTERNAL_INTERRUPT_ID: AtomicU32 = AtomicU32::new(u32::MAX);
+
+pub fn configure_timer_interrupt_route(
+    route: TimerInterruptRoute,
+    external_interrupt_id: Option<u32>,
+) {
+    TIMER_INTERRUPT_ROUTE.store(route as u8, Ordering::Relaxed);
+    TIMER_EXTERNAL_INTERRUPT_ID.store(external_interrupt_id.unwrap_or(u32::MAX), Ordering::Relaxed);
+}
+
+pub fn timer_interrupt_route() -> TimerInterruptRoute {
+    match TIMER_INTERRUPT_ROUTE.load(Ordering::Relaxed) {
+        x if x == TimerInterruptRoute::ExternalControllerIrq as u8 => {
+            TimerInterruptRoute::ExternalControllerIrq
+        }
+        x if x == TimerInterruptRoute::FastInterrupt as u8 => TimerInterruptRoute::FastInterrupt,
+        _ => TimerInterruptRoute::Unknown,
+    }
+}
+
+pub fn timer_external_interrupt_id() -> Option<u32> {
+    let interrupt_id = TIMER_EXTERNAL_INTERRUPT_ID.load(Ordering::Relaxed);
+    (interrupt_id != u32::MAX).then_some(interrupt_id)
+}
+
+pub fn is_arch_timer_external_interrupt(interrupt_id: u32) -> bool {
+    timer_external_interrupt_id() == Some(interrupt_id)
+}
 
 pub fn interrupt_init() {
     // TODO: Initialize AArch64 interrupts
@@ -145,20 +183,24 @@ pub fn enable_arch_timer_interrupt() -> Result<(), &'static str> {
     })
     .map_err(|_| "failed to enable local timer interrupt")?;
 
-    // Attempt to enable at external controller level (PPI 27)
-    // This succeeds on GIC, fails gracefully on AIC (timer uses FIQ, not AIC)
-    InterruptManager::with_manager(|mgr| {
-        mgr.enable_external_interrupt(crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ, cpu_id)
-    })
-    .or_else(|e| {
-        // InvalidInterruptId means the external controller doesn't have this IRQ
-        // (e.g., AIC where timer bypasses the controller via FIQ)
-        if matches!(e, InterruptError::InvalidInterruptId) {
-            Ok(())
-        } else {
-            Err("failed to enable timer PPI in external controller")
+    match timer_interrupt_route() {
+        TimerInterruptRoute::FastInterrupt => {}
+        TimerInterruptRoute::ExternalControllerIrq => {
+            let interrupt_id = timer_external_interrupt_id()
+                .ok_or("external timer interrupt route is not configured")?;
+            InterruptManager::with_manager(|mgr| {
+                mgr.enable_external_interrupt(interrupt_id, cpu_id)
+            })
+            .or_else(|e| {
+                if matches!(e, InterruptError::InvalidInterruptId) {
+                    Ok(())
+                } else {
+                    Err("failed to enable timer PPI in external controller")
+                }
+            })?;
         }
-    })?;
+        TimerInterruptRoute::Unknown => return Err("timer interrupt route is not configured"),
+    }
 
     Ok(())
 }
@@ -172,18 +214,33 @@ pub fn disable_arch_timer_interrupt() -> Result<(), &'static str> {
     })
     .map_err(|_| "failed to disable local timer interrupt")?;
 
-    InterruptManager::with_manager(|mgr| {
-        mgr.disable_external_interrupt(crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ, cpu_id)
-    })
-    .or_else(|e| {
-        if matches!(e, InterruptError::InvalidInterruptId) {
-            Ok(())
-        } else {
-            Err("failed to disable timer PPI in external controller")
+    match timer_interrupt_route() {
+        TimerInterruptRoute::FastInterrupt => {}
+        TimerInterruptRoute::ExternalControllerIrq => {
+            let interrupt_id = timer_external_interrupt_id()
+                .ok_or("external timer interrupt route is not configured")?;
+            InterruptManager::with_manager(|mgr| {
+                mgr.disable_external_interrupt(interrupt_id, cpu_id)
+            })
+            .or_else(|e| {
+                if matches!(e, InterruptError::InvalidInterruptId) {
+                    Ok(())
+                } else {
+                    Err("failed to disable timer PPI in external controller")
+                }
+            })?;
         }
-    })?;
+        TimerInterruptRoute::Unknown => return Err("timer interrupt route is not configured"),
+    }
 
     Ok(())
+}
+
+pub fn is_arch_timer_pending() -> bool {
+    InterruptManager::with_manager(|mgr| {
+        let cpu_id = get_cpu().get_cpuid() as u32;
+        mgr.is_local_interrupt_pending(cpu_id, LocalInterruptType::Timer)
+    })
 }
 
 pub fn with_interrupts_disabled<F, R>(f: F) -> R

--- a/kernel/src/arch/aarch64/interrupt/mod.rs
+++ b/kernel/src/arch/aarch64/interrupt/mod.rs
@@ -5,7 +5,7 @@
 use core::arch::asm;
 
 use crate::arch::get_cpu;
-use crate::interrupt::{InterruptManager, controllers::LocalInterruptType};
+use crate::interrupt::{InterruptError, InterruptManager, controllers::LocalInterruptType};
 
 pub fn interrupt_init() {
     // TODO: Initialize AArch64 interrupts
@@ -125,6 +125,65 @@ pub fn disable_timer_source_interrupt() {
         asm!("msr cntv_ctl_el0, {0}", in(reg) ctl, options(nostack));
         asm!("isb", options(nostack));
     }
+}
+
+/// Enable the architectural timer interrupt for the current CPU.
+///
+/// This is a platform-agnostic helper that:
+/// 1. Enables the timer at the local controller level (CNTV_CTL_EL0)
+/// 2. Attempts to enable the timer PPI at the external controller level
+///
+/// On GIC-based systems, the timer uses PPI 27 which must be enabled in the
+/// distributor. On Apple Silicon (AIC), the timer bypasses the AIC entirely
+/// (it's wired to FIQ), so the external enable gracefully fails and is ignored.
+pub fn enable_arch_timer_interrupt() -> Result<(), &'static str> {
+    let cpu_id = get_cpu().get_cpuid() as u32;
+
+    // Enable at local controller level (CNTV_CTL_EL0)
+    InterruptManager::with_manager(|mgr| {
+        mgr.enable_local_interrupt(cpu_id, LocalInterruptType::Timer)
+    })
+    .map_err(|_| "failed to enable local timer interrupt")?;
+
+    // Attempt to enable at external controller level (PPI 27)
+    // This succeeds on GIC, fails gracefully on AIC (timer uses FIQ, not AIC)
+    InterruptManager::with_manager(|mgr| {
+        mgr.enable_external_interrupt(crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ, cpu_id)
+    })
+    .or_else(|e| {
+        // InvalidInterruptId means the external controller doesn't have this IRQ
+        // (e.g., AIC where timer bypasses the controller via FIQ)
+        if matches!(e, InterruptError::InvalidInterruptId) {
+            Ok(())
+        } else {
+            Err("failed to enable timer PPI in external controller")
+        }
+    })?;
+
+    Ok(())
+}
+
+/// Disable the architectural timer interrupt for the current CPU.
+pub fn disable_arch_timer_interrupt() -> Result<(), &'static str> {
+    let cpu_id = get_cpu().get_cpuid() as u32;
+
+    InterruptManager::with_manager(|mgr| {
+        mgr.disable_local_interrupt(cpu_id, LocalInterruptType::Timer)
+    })
+    .map_err(|_| "failed to disable local timer interrupt")?;
+
+    InterruptManager::with_manager(|mgr| {
+        mgr.disable_external_interrupt(crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ, cpu_id)
+    })
+    .or_else(|e| {
+        if matches!(e, InterruptError::InvalidInterruptId) {
+            Ok(())
+        } else {
+            Err("failed to disable timer PPI in external controller")
+        }
+    })?;
+
+    Ok(())
 }
 
 pub fn with_interrupts_disabled<F, R>(f: F) -> R

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -406,13 +406,16 @@ pub fn configure_user_entry(trapframe: &mut Trapframe, options: crate::arch::Use
 
     // DAIF bits in PSTATE/SPSR: D=9, A=8, I=7, F=6. 1 means masked.
     const DAIF_I: u64 = 1 << 7;
+    const DAIF_F: u64 = 1 << 6;
     match options.irq_policy {
         UserReturnIrqPolicy::Inherit => {}
         UserReturnIrqPolicy::Enable => {
             trapframe.spsr &= !DAIF_I;
+            trapframe.spsr &= !DAIF_F;
         }
         UserReturnIrqPolicy::Disable => {
             trapframe.spsr |= DAIF_I;
+            trapframe.spsr |= DAIF_F;
         }
     }
 

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -92,15 +92,14 @@ pub fn first_switch_to_user(task: &mut Task) -> ! {
         panic!("Task has no kernel stack window");
     };
 
+    // Update trampoline-visible CPU struct.
+    let cpu = crate::arch::get_cpu();
     crate::println!(
         "[aarch64] CPU {}: First switch to user task PID {} with kernel SP {:#x}",
-        crate::arch::get_current_cpu_id(),
+        cpu.get_cpuid(),
         task.get_id(),
         kernel_sp,
     );
-
-    // Update trampoline-visible CPU struct.
-    let cpu = crate::arch::get_cpu();
     cpu.set_kernel_stack(kernel_sp);
     cpu.set_trap_handler(get_user_trap_handler());
     cpu.set_next_address_space(task.vm_manager.get_asid());
@@ -128,7 +127,7 @@ pub fn first_switch_to_user(task: &mut Task) -> ! {
     let trap_exit_addr = trampoline_base.wrapping_add(trap_exit_offset);
 
     // Program per-CPU arch pointer and VBAR to the trampoline right before the jump.
-    let cpu_id = get_current_cpu_id();
+    let cpu_id = cpu.get_cpuid();
     set_arch(crate::vm::get_trampoline_arch(cpu_id));
     set_trapvector(trampoline_base);
 
@@ -420,7 +419,7 @@ pub fn configure_user_entry(trapframe: &mut Trapframe, options: crate::arch::Use
     // Configure EL0 FP/SIMD access for the next user return.
     // DTB-driven runtime gating complements the build-time feature.
     if crate::arch::user_fpu_enabled() {
-        let cpu_id = crate::arch::get_current_cpu_id();
+        let cpu_id = get_cpu().get_cpuid();
         if let Some(task) = crate::sched::scheduler::get_scheduler().get_current_task(cpu_id) {
             crate::arch::fpu::set_user_fpu_enabled(task.vcpu.lock().fpu_used);
         } else {
@@ -472,19 +471,6 @@ pub fn get_cpu() -> &'static mut Aarch64 {
 
     // Kernel context always has access to this mapping.
     return unsafe { transmute(tpidr_el1) };
-}
-
-/// Get current CPU core ID from MPIDR_EL1 register
-pub fn get_current_cpu_id() -> usize {
-    let mpidr: u64;
-    unsafe {
-        asm!(
-            "mrs {0}, MPIDR_EL1",
-            out(reg) mpidr,
-        );
-    }
-    // Extract Aff0 field (bits 7:0) which contains the core ID
-    (mpidr & 0xFF) as usize
 }
 
 pub fn set_next_mode(_mode: crate::arch::Mode) {
@@ -723,7 +709,7 @@ mod tests {
         set_next_mode(Mode::User);
 
         // Test AArch64-specific CPU ID retrieval
-        let cpu_id = get_current_cpu_id();
+        let cpu_id = get_cpu().get_cpuid();
         assert!(
             cpu_id < crate::environment::MAX_NUM_CPUS,
             "AArch64 CPU ID should be within valid range"

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -257,6 +257,7 @@ pub struct Trapframe {
     pub tpidrro_el0: u64,
     // exception information
     pub esr_el1: u64,
+    pub _padding: u64, // must be 304 bytes to match trampoline's sub sp, sp, #304
 }
 
 impl Trapframe {
@@ -269,6 +270,7 @@ impl Trapframe {
             tpidr_el0: 0,
             tpidrro_el0: 0,
             esr_el1: 0,
+            _padding: 0,
         }
     }
 

--- a/kernel/src/arch/aarch64/timer.rs
+++ b/kernel/src/arch/aarch64/timer.rs
@@ -4,11 +4,7 @@
 
 use core::arch::asm;
 
-use crate::{
-    arch::get_cpu,
-    arch::interrupt,
-    interrupt::{InterruptManager, controllers::LocalInterruptType},
-};
+use crate::{arch::get_cpu, arch::interrupt, interrupt::InterruptManager};
 
 pub fn timer_init() {
     // Local controller registration happens via early initcall.
@@ -87,26 +83,20 @@ impl ArchTimer {
         // Program the next event before unmasking interrupts.
         self.set_timer(next);
 
-        // Only perform GIC configuration on first start
+        // Only perform interrupt controller configuration on first start
         if !self.initialized {
             // CRITICAL: Mask IRQs before configuring the interrupt controller to avoid deadlock
             // (an interrupt firing during InterruptManager access could try to re-lock it).
             interrupt::disable_external_interrupts();
 
-            // Enable timer at two levels:
-            // - core-local interrupt (InterruptManager local controller)
-            // - external PPI line in the GIC distributor
-            interrupt::enable_core_local_interrupt(LocalInterruptType::Timer)
-                .unwrap_or_else(|e| panic!("Failed to enable local timer interrupt: {e}"));
-
-            interrupt::enable_external_interrupt_line(
-                crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ,
-            )
-            .unwrap_or_else(|e| panic!("Failed to enable timer PPI in GIC: {e}"));
+            // Enable timer interrupt at both local and external controller levels.
+            // This is platform-agnostic: GIC enables PPI 27, AIC gracefully ignores it.
+            interrupt::enable_arch_timer_interrupt()
+                .unwrap_or_else(|e| panic!("Failed to enable timer interrupt: {e}"));
 
             // CRITICAL: Set initialized flag BEFORE unmasking interrupts
             // Otherwise, if an interrupt fires immediately after unmask, it will
-            // see initialized=false and reconfigure GIC again
+            // see initialized=false and reconfigure again
             self.initialized = true;
 
             // Ensure IRQ is unmasked at CPU level (first time only)
@@ -123,13 +113,12 @@ impl ArchTimer {
     pub fn stop(&mut self) {
         self.running = false;
 
+        // Disable timer interrupt at both local and external controller levels.
+        // This is platform-agnostic: GIC disables PPI 27, AIC gracefully ignores it.
+        let _ = interrupt::disable_arch_timer_interrupt();
+
         InterruptManager::with_manager(|mgr| {
             let cpu_id = get_cpu().get_cpuid() as u32;
-            let _ = mgr.disable_local_interrupt(cpu_id, LocalInterruptType::Timer);
-            let _ = mgr.disable_external_interrupt(
-                crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ,
-                cpu_id,
-            );
             let _ = mgr.set_timer(cpu_id, u64::MAX);
         });
     }

--- a/kernel/src/arch/aarch64/timer.rs
+++ b/kernel/src/arch/aarch64/timer.rs
@@ -85,36 +85,22 @@ impl ArchTimer {
 
         // Only perform interrupt controller configuration on first start
         if !self.initialized {
-            // CRITICAL: Mask IRQs before configuring the interrupt controller to avoid deadlock
-            // (an interrupt firing during InterruptManager access could try to re-lock it).
             interrupt::disable_external_interrupts();
 
-            // Enable timer interrupt at both local and external controller levels.
-            // This is platform-agnostic: GIC enables PPI 27, AIC gracefully ignores it.
             interrupt::enable_arch_timer_interrupt()
                 .unwrap_or_else(|e| panic!("Failed to enable timer interrupt: {e}"));
 
-            // CRITICAL: Set initialized flag BEFORE unmasking interrupts
-            // Otherwise, if an interrupt fires immediately after unmask, it will
-            // see initialized=false and reconfigure again
             self.initialized = true;
 
-            // Ensure IRQ is unmasked at CPU level (first time only)
             interrupt::enable_external_interrupts();
         }
 
-        // Finally, unmask the timer interrupt at the timer source itself.
-        // (This is analogous to a per-source enable bit like RISC-V STIE.)
         interrupt::enable_timer_source_interrupt();
-        // Note: Subsequent calls just update CVAL, no DAIF/GIC manipulation
-        // This prevents nested interrupts during tick handling
     }
 
     pub fn stop(&mut self) {
         self.running = false;
 
-        // Disable timer interrupt at both local and external controller levels.
-        // This is platform-agnostic: GIC disables PPI 27, AIC gracefully ignores it.
         let _ = interrupt::disable_arch_timer_interrupt();
 
         InterruptManager::with_manager(|mgr| {

--- a/kernel/src/arch/aarch64/trap/exception.rs
+++ b/kernel/src/arch/aarch64/trap/exception.rs
@@ -157,34 +157,16 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, trap_kind: usize) {
         }
 
         // SVC from AArch64 user mode (syscall)
-        ExceptionClass::SvcAarch64 => {
-            // Minimal syscall trace for debugging AArch64 SVC path.
-            // AArch64 syscall number: x8, args: x0-x5.
-            // crate::println!(
-            //     "[syscall/aarch64] nr={} x0={:#x} x1={:#x} x2={:#x} x3={:#x} x4={:#x} x5={:#x} sp={:#x} elr={:#x}",
-            //     trapframe.get_syscall_number(),
-            //     trapframe.get_arg(0),
-            //     trapframe.get_arg(1),
-            //     trapframe.get_arg(2),
-            //     trapframe.get_arg(3),
-            //     trapframe.get_arg(4),
-            //     trapframe.get_arg(5),
-            //     trapframe.sp,
-            //     trapframe.elr,
-            // );
-            // panic!("AArch64 syscall handler not implemented");
-            match syscall_dispatcher(trapframe) {
-                Ok(ret) => {
-                    // crate::println!("[syscall/aarch64] -> ret={:#x}", ret);
-                    trapframe.set_return_value(ret);
-                }
-                Err(msg) => {
-                    println!("Syscall error: {}", msg);
-                    trapframe.set_return_value(usize::MAX);
-                    trapframe.increment_pc_next(mytask().unwrap());
-                }
+        ExceptionClass::SvcAarch64 => match syscall_dispatcher(trapframe) {
+            Ok(ret) => {
+                trapframe.set_return_value(ret);
             }
-        }
+            Err(msg) => {
+                println!("Syscall error: {}", msg);
+                trapframe.set_return_value(usize::MAX);
+                trapframe.increment_pc_next(mytask().unwrap());
+            }
+        },
 
         // Instruction abort from lower EL
         ExceptionClass::InstructionAbortLowerEl => {

--- a/kernel/src/arch/aarch64/trap/interrupt.rs
+++ b/kernel/src/arch/aarch64/trap/interrupt.rs
@@ -8,8 +8,13 @@ use crate::interrupt::InterruptManager;
 /// On QEMU virt (GICv2), the virtual timer arrives as a PPI (typically ID 27).
 /// The generic InterruptManager path will acknowledge+EOI the interrupt, but the
 /// kernel still needs to run the timer tick logic to advance scheduling.
-pub fn arch_irq_handler(trapframe: &mut Trapframe) {
+pub fn arch_irq_handler(trapframe: &mut Trapframe, trap_kind: usize) {
     let cpu_id = get_cpu().get_cpuid() as u32;
+
+    if trap_kind == 2 && crate::arch::interrupt::is_arch_timer_pending() {
+        crate::timer::tick(trapframe);
+        return;
+    }
 
     let claimed =
         InterruptManager::with_manager(|mgr| mgr.claim_and_handle_external_interrupt(cpu_id));
@@ -21,9 +26,7 @@ pub fn arch_irq_handler(trapframe: &mut Trapframe) {
             }
         }
         Ok(None) => {
-            // Fallback: if the architectural timer is pending, run tick.
-            // (This can help when the IRQ path didn't surface through the external controller.)
-            if crate::drivers::pic::arm_generic_timer::ArmGenericTimer::is_timer_pending() {
+            if crate::arch::interrupt::is_arch_timer_pending() {
                 crate::timer::tick(trapframe);
             }
         }

--- a/kernel/src/arch/aarch64/trap/kernel.rs
+++ b/kernel/src/arch/aarch64/trap/kernel.rs
@@ -186,9 +186,8 @@ pub extern "C" fn _kernel_trap_entry() {
 // 戻り値なし(void)にする = 普通に関数から戻る
 #[unsafe(export_name = "arch_kernel_trap_handler")]
 pub extern "C" fn arch_kernel_trap_handler(trapframe: &mut Trapframe, trap_kind: usize) {
-    if trap_kind == 1 {
-        // IRQ
-        arch_irq_handler(trapframe);
+    if trap_kind == 1 || trap_kind == 2 {
+        arch_irq_handler(trapframe, trap_kind);
     } else {
         // Exception (Sync/SError/FIQ)
         arch_exception_handler(trapframe, trap_kind);

--- a/kernel/src/arch/aarch64/trap/user.rs
+++ b/kernel/src/arch/aarch64/trap/user.rs
@@ -13,9 +13,7 @@ use core::arch::{asm, naked_asm};
 
 use super::exception::arch_exception_handler;
 use super::interrupt::arch_irq_handler;
-use crate::arch::{
-    Trapframe, get_current_cpu_id, get_kernel_trapvector_paddr, set_arch, set_trapvector,
-};
+use crate::arch::{Trapframe, get_kernel_trapvector_paddr, set_arch, set_trapvector};
 use crate::vm::get_trampoline_trap_vector;
 
 #[unsafe(export_name = "aarch64_first_switch_to_user_naked")]

--- a/kernel/src/arch/aarch64/trap/user.rs
+++ b/kernel/src/arch/aarch64/trap/user.rs
@@ -285,8 +285,8 @@ pub extern "C" fn arch_user_trap_handler(trapframe: &mut Trapframe, trap_kind: u
     set_trapvector(get_kernel_trapvector_paddr());
 
     // trap_kind is now passed in x1 (argument 2), so no need to read from memory!
-    if trap_kind == 1 {
-        arch_irq_handler(trapframe);
+    if trap_kind == 1 || trap_kind == 2 {
+        arch_irq_handler(trapframe, trap_kind);
     } else {
         arch_exception_handler(trapframe, trap_kind);
     }

--- a/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
+++ b/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
@@ -16,6 +16,10 @@ use crate::vm::addr::{phys_to_virt, virt_to_phys};
 use crate::vm::vmem::VirtualMemoryMap;
 use crate::vm::vmem::VirtualMemoryPermission;
 
+const SCARLET_MAIR_EL1: u64 = 0x44ff00;
+const SCARLET_TCR_EL1: u64 = 0x1_B510_3510;
+const SCTLR_EL1_ENABLE_MASK: u64 = 1 | (1 << 2) | (1 << 12);
+
 /// Maximum paging levels for AArch64 4KB granule (4 levels: 0-3)
 const MAX_PAGING_LEVEL: usize = 3;
 
@@ -250,22 +254,40 @@ impl PageTable {
         crate::arch::aarch64::get_cpu().set_kernel_ttbr0(ttbr_val);
 
         unsafe {
-            // Update TTBR0 (user translation base) only.
-            // TTBR1 is managed separately and is expected to stay fixed to the kernel table.
-            asm!(
-                "msr ttbr0_el1, {ttbr}",
-                "isb",
-                "tlbi vmalle1is",
-                "dsb ish",
-                "isb",
-                ttbr = in(reg) ttbr_val,
-            );
-
-            // Enable MMU if not already enabled
             let mut sctlr: u64;
-            asm!("mrs {}, sctlr_el1", out(reg) sctlr);
+            asm!("mrs {sctlr}, sctlr_el1", sctlr = out(reg) sctlr, options(nostack));
             if sctlr & 1 == 0 {
-                init_mmu_registers();
+                asm!(
+                    "msr mair_el1, {mair}",
+                    "msr tcr_el1, {tcr}",
+                    "isb",
+                    "msr ttbr0_el1, {ttbr}",
+                    "isb",
+                    "tlbi vmalle1is",
+                    "dsb ish",
+                    "isb",
+                    "mrs {tmp}, sctlr_el1",
+                    "orr {tmp}, {tmp}, {sctlr_flags}",
+                    "msr sctlr_el1, {tmp}",
+                    "dsb sy",
+                    "isb",
+                    mair = in(reg) SCARLET_MAIR_EL1,
+                    tcr = in(reg) SCARLET_TCR_EL1,
+                    ttbr = in(reg) ttbr_val,
+                    sctlr_flags = in(reg) SCTLR_EL1_ENABLE_MASK,
+                    tmp = lateout(reg) _,
+                    options(nostack),
+                );
+            } else {
+                asm!(
+                    "msr ttbr0_el1, {ttbr}",
+                    "isb",
+                    "tlbi vmalle1is",
+                    "dsb ish",
+                    "isb",
+                    ttbr = in(reg) ttbr_val,
+                    options(nostack),
+                );
             }
         }
     }
@@ -281,6 +303,7 @@ impl PageTable {
                 "dsb ish",
                 "isb",
                 ttbr = in(reg) ttbr_val,
+                options(nostack),
             );
         }
     }
@@ -511,33 +534,57 @@ impl PageTable {
 /// Initialize MMU registers
 pub fn init_mmu_registers() {
     unsafe {
-        // MAIR_EL1: memory attribute configuration
-        // Index 0: Device-nGnRnE (0x00)
-        // Index 1: Normal, Write-Back (0xFF)
-        // Index 2: Normal, Non-Cacheable (0x44)
-        let mair_val: u64 = 0x44ff00;
-        asm!("msr mair_el1, {}", in(reg) mair_val);
+        asm!(
+            "msr mair_el1, {mair}",
+            "msr tcr_el1, {tcr}",
+            "isb",
+            "mrs {tmp}, sctlr_el1",
+            "orr {tmp}, {tmp}, {sctlr_flags}",
+            "msr sctlr_el1, {tmp}",
+            "dsb sy",
+            "isb",
+            mair = in(reg) SCARLET_MAIR_EL1,
+            tcr = in(reg) SCARLET_TCR_EL1,
+            sctlr_flags = in(reg) SCTLR_EL1_ENABLE_MASK,
+            tmp = lateout(reg) _,
+            options(nostack),
+        );
+    }
+}
 
-        // TCR_EL1: Translation Control Register
-        // T0SZ = 16 (48-bit VA for TTBR0)
-        // T1SZ = 16 (48-bit VA for TTBR1)
-        // TG0 = 0b00 (4KB granule for TTBR0)
-        // TG1 = 0b10 (4KB granule for TTBR1)
-        // SH0/SH1 = 0b11 (Inner Shareable)
-        // ORGN0/ORGN1 = 0b01 (Write-Back)
-        // IRGN0/IRGN1 = 0b01 (Write-Back)
-        // IPS = 0b001 (36-bit PA, supports up to 64GB) - bit[34:32]
-        let tcr_val: u64 = 0x1_B510_3510;
-        asm!("msr tcr_el1, {}", in(reg) tcr_val);
-
-        // SCTLR_EL1: System Control Register
+pub fn sync_el1_translation_registers_if_needed() {
+    unsafe {
         let mut sctlr: u64;
-        asm!("mrs {}, sctlr_el1", out(reg) sctlr);
-        sctlr |= 1; // M: MMU enable
-        sctlr |= 1 << 2; // C: Data cache enable
-        sctlr |= 1 << 12; // I: Instruction cache enable
-        asm!("msr sctlr_el1, {}", in(reg) sctlr);
-        asm!("dsb sy", "isb");
+        asm!("mrs {sctlr}, sctlr_el1", sctlr = out(reg) sctlr, options(nostack));
+        if sctlr & 1 == 0 {
+            return;
+        }
+
+        let mut mair: u64;
+        let mut tcr: u64;
+        asm!(
+            "mrs {mair}, mair_el1",
+            "mrs {tcr}, tcr_el1",
+            mair = out(reg) mair,
+            tcr = out(reg) tcr,
+            options(nostack),
+        );
+
+        if mair == SCARLET_MAIR_EL1 && tcr == SCARLET_TCR_EL1 {
+            return;
+        }
+
+        asm!(
+            "msr mair_el1, {mair}",
+            "msr tcr_el1, {tcr}",
+            "isb",
+            "tlbi vmalle1is",
+            "dsb ish",
+            "isb",
+            mair = in(reg) SCARLET_MAIR_EL1,
+            tcr = in(reg) SCARLET_TCR_EL1,
+            options(nostack),
+        );
     }
 }
 

--- a/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
+++ b/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
@@ -19,6 +19,7 @@ use crate::vm::vmem::VirtualMemoryPermission;
 const SCARLET_MAIR_EL1: u64 = 0x44ff00;
 const SCARLET_TCR_EL1: u64 = 0x1_B510_3510;
 const SCTLR_EL1_ENABLE_MASK: u64 = 1 | (1 << 2) | (1 << 12);
+const DEBUG_DEVICE_FAULT_VA: usize = 0xffff_0008_3afd_b000;
 
 /// Maximum paging levels for AArch64 4KB granule (4 levels: 0-3)
 const MAX_PAGING_LEVEL: usize = 3;
@@ -417,6 +418,19 @@ impl PageTable {
         // Execute permission
         if !VirtualMemoryPermission::Execute.contained_in(permissions) {
             entry |= (1 << 54) | (1 << 53);
+        }
+
+        #[cfg(any(debug_assertions, test))]
+        if vaddr == DEBUG_DEVICE_FAULT_VA {
+            crate::early_println!(
+                "[vm-map] target va={:#x} paddr={:#x} perms={:#x} is_user={} is_device={} entry={:#x}",
+                vaddr,
+                paddr,
+                permissions,
+                is_user,
+                is_device,
+                entry,
+            );
         }
 
         pte.set_entry(entry);

--- a/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
+++ b/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
@@ -314,6 +314,29 @@ impl PageTable {
         }
     }
 
+    pub fn switch_for_boot(&self, asid: u16) {
+        let ttbr_val = self.get_val_for_ttbr(asid);
+        crate::arch::aarch64::get_cpu().set_kernel_ttbr0(ttbr_val);
+        unsafe {
+            asm!(
+                "msr mair_el1, {mair}",
+                "msr tcr_el1, {tcr}",
+                "isb",
+                "dsb ishst",
+                "msr ttbr1_el1, {ttbr}",
+                "msr ttbr0_el1, {ttbr}",
+                "isb",
+                "tlbi vmalle1is",
+                "dsb ish",
+                "isb",
+                mair = in(reg) SCARLET_MAIR_EL1,
+                tcr = in(reg) SCARLET_TCR_EL1,
+                ttbr = in(reg) ttbr_val,
+                options(nostack),
+            );
+        }
+    }
+
     /// Get TTBR value (like RISC-V's get_val_for_satp())
     pub fn get_val_for_ttbr(&self, asid: u16) -> u64 {
         let baddr = (virt_to_phys(self as *const _ as usize) as u64) & 0xffffffffffff;

--- a/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
+++ b/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
@@ -117,6 +117,11 @@ impl PageTableEntry {
         self
     }
 
+    pub fn set_entry(&mut self, entry: u64) -> &mut Self {
+        self.entry = entry;
+        self
+    }
+
     // Test helper methods
     pub fn get_flags(&self) -> u64 {
         self.entry & 0xfff
@@ -374,22 +379,25 @@ impl PageTable {
             None => panic!("map: walk() couldn't allocate page-table page"),
         };
 
-        pte.clear_all();
-
-        // Set as L3 page descriptor
-        pte.set_page();
-        pte.set_ppn(paddr >> 12);
-
         let is_user = VirtualMemoryPermission::User.contained_in(permissions);
         let is_device = !is_user && (IOREMAP_START..=IOREMAP_END).contains(&vaddr);
-
-        if is_device {
-            pte.set_memory_attr(MemoryAttribute::Device as u8);
-            pte.set_shareability(Shareability::OuterShareable as u8);
+        let memory_attr = if is_device {
+            MemoryAttribute::Device as u64
         } else {
-            pte.set_memory_attr(MemoryAttribute::Normal as u8);
-            pte.set_shareability(Shareability::InnerShareable as u8);
-        }
+            MemoryAttribute::Normal as u64
+        };
+        let shareability = if is_device {
+            Shareability::OuterShareable as u64
+        } else {
+            Shareability::InnerShareable as u64
+        };
+
+        let mut entry = 0u64;
+        entry |= 0x3;
+        entry |= 1 << 10;
+        entry |= ((paddr >> 12) as u64 & 0xfffffffff) << 12;
+        entry |= memory_attr << 2;
+        entry |= shareability << 8;
 
         // AP[7:6] encoding
         let is_write = VirtualMemoryPermission::Write.contained_in(permissions);
@@ -399,19 +407,19 @@ impl PageTable {
             (false, false) => 0b10,
             (true, false) => 0b11,
         };
-        pte.set_ap(ap);
+        entry |= (ap as u64) << 6;
 
         // nG bit for user pages (ASID-tagged)
         if is_user {
-            pte.set_non_global();
-        } else {
-            pte.set_global();
+            entry |= 1 << 11;
         }
 
         // Execute permission
-        if VirtualMemoryPermission::Execute.contained_in(permissions) {
-            pte.executable();
+        if !VirtualMemoryPermission::Execute.contained_in(permissions) {
+            entry |= (1 << 54) | (1 << 53);
         }
+
+        pte.set_entry(entry);
 
         // Ensure the updated PTE is visible to the hardware table walker.
         crate::arch::aarch64::clean_dcache_to_poc_range(
@@ -624,5 +632,20 @@ mod tests {
         let ttbr_val = page_table.get_val_for_ttbr(asid);
         let expected_asid = ((ttbr_val >> 48) & 0xffff) as u16;
         assert_eq!(expected_asid, asid);
+    }
+
+    #[test_case]
+    fn test_kernel_normal_leaf_encoding() {
+        let mut page_table = PageTable::new();
+        page_table.map(
+            1,
+            0xffff_ffff_8000_0000,
+            0x8000_0000,
+            0x01 | 0x02 | 0x04,
+            true,
+            true,
+        );
+        let pte = page_table.walk(0xffff_ffff_8000_0000, false, 1).unwrap();
+        assert_eq!(pte.entry & 0xfff, 0x707);
     }
 }

--- a/kernel/src/arch/aarch64/vm/mod.rs
+++ b/kernel/src/arch/aarch64/vm/mod.rs
@@ -275,6 +275,29 @@ fn setup_trampoline_at_end(manager: &VirtualMemoryManager, trampoline_vaddr_end:
 }
 
 pub fn setup_trampoline_for_kernel(manager: &VirtualMemoryManager) {
+    #[cfg(any(debug_assertions, test))]
+    fn log_early_console_pte(stage: &str, manager: &VirtualMemoryManager) {
+        let console_vaddr = crate::earlyfb::console_lock_addr();
+        let leaf = manager
+            .get_root_page_table()
+            .and_then(|root| root.walk(console_vaddr, false, manager.get_asid()))
+            .map(|pte| pte.entry & 0xfff);
+
+        match leaf {
+            Some(bits) => crate::early_println!(
+                "[vm] {} EARLY_CONSOLE leaf bits: {:#x} (va={:#x})",
+                stage,
+                bits,
+                console_vaddr
+            ),
+            None => crate::early_println!(
+                "[vm] {} EARLY_CONSOLE leaf missing (va={:#x})",
+                stage,
+                console_vaddr
+            ),
+        }
+    }
+
     setup_trampoline_at_end(manager, TRAMPOLINE_VA_END);
 
     // Sanity check: the per-task kernel stack windows are part of the same high-VA
@@ -293,11 +316,15 @@ pub fn setup_trampoline_for_kernel(manager: &VirtualMemoryManager) {
     // Keep TTBR1 fixed to the kernel page table (trampoline/high-VA live there).
     #[cfg(any(debug_assertions, test))]
     crate::early_println!("[vm] setup_trampoline_for_kernel: switch_ttbr1...");
+    #[cfg(any(debug_assertions, test))]
+    log_early_console_pte("pre-switch", manager);
     mmu::sync_el1_translation_registers_if_needed();
     manager
         .get_root_page_table()
         .expect("Kernel root page table not set")
         .switch_ttbr1(manager.get_asid());
+    #[cfg(any(debug_assertions, test))]
+    log_early_console_pte("post-switch", manager);
     #[cfg(any(debug_assertions, test))]
     crate::early_println!("[vm] setup_trampoline_for_kernel: switch_ttbr1 ok");
 }

--- a/kernel/src/arch/aarch64/vm/mod.rs
+++ b/kernel/src/arch/aarch64/vm/mod.rs
@@ -281,7 +281,7 @@ pub fn setup_trampoline_for_kernel(manager: &VirtualMemoryManager) {
     // (trampoline-managed) TTBR1 address space.
     #[cfg(any(debug_assertions, test))]
     {
-        crate::println!(
+        crate::early_println!(
             "[vm] aarch64 high-va(kstack) region: {:#x}-{:#x}",
             KERNEL_KSTACK_REGION_START,
             KERNEL_KSTACK_REGION_END
@@ -292,13 +292,13 @@ pub fn setup_trampoline_for_kernel(manager: &VirtualMemoryManager) {
 
     // Keep TTBR1 fixed to the kernel page table (trampoline/high-VA live there).
     #[cfg(any(debug_assertions, test))]
-    crate::println!("[vm] setup_trampoline_for_kernel: switch_ttbr1...");
+    crate::early_println!("[vm] setup_trampoline_for_kernel: switch_ttbr1...");
     manager
         .get_root_page_table()
         .expect("Kernel root page table not set")
         .switch_ttbr1(manager.get_asid());
     #[cfg(any(debug_assertions, test))]
-    crate::println!("[vm] setup_trampoline_for_kernel: switch_ttbr1 ok");
+    crate::early_println!("[vm] setup_trampoline_for_kernel: switch_ttbr1 ok");
 }
 
 /// AArch64: trampoline/high-VA live in the fixed TTBR1 kernel mapping.

--- a/kernel/src/arch/aarch64/vm/mod.rs
+++ b/kernel/src/arch/aarch64/vm/mod.rs
@@ -293,6 +293,7 @@ pub fn setup_trampoline_for_kernel(manager: &VirtualMemoryManager) {
     // Keep TTBR1 fixed to the kernel page table (trampoline/high-VA live there).
     #[cfg(any(debug_assertions, test))]
     crate::early_println!("[vm] setup_trampoline_for_kernel: switch_ttbr1...");
+    mmu::sync_el1_translation_registers_if_needed();
     manager
         .get_root_page_table()
         .expect("Kernel root page table not set")

--- a/kernel/src/arch/riscv64/boot/limine.rs
+++ b/kernel/src/arch/riscv64/boot/limine.rs
@@ -70,6 +70,7 @@ pub fn limine_entry() -> ! {
     let usable_region = select_usable_region(memmap.entries());
     let hhdm_offset = hhdm.offset() as usize;
     let relocated_fdt = relocate_fdt(phys_to_virt(usable_region.start) as *mut u8);
+    let relocated_fdt_paddr = usable_region.start;
     let reserved_bytes = relocated_fdt.size();
     let usable_memory_paddr = reserve_front(usable_region, reserved_bytes);
     let direct_map_paddr = usable_region;
@@ -94,7 +95,7 @@ pub fn limine_entry() -> ! {
         initramfs_paddr,
         hhdm_offset,
         cmdline,
-        DeviceSource::Fdt(relocated_fdt.start),
+        DeviceSource::Fdt(relocated_fdt_paddr),
     );
 
     crate::arch::init_user_context_from_fdt();

--- a/kernel/src/arch/riscv64/boot/limine.rs
+++ b/kernel/src/arch/riscv64/boot/limine.rs
@@ -89,6 +89,7 @@ pub fn limine_entry() -> ! {
         hhdm_offset,
         cmdline,
         DeviceSource::Fdt(relocated_fdt_paddr),
+        None, // RISC-V uses SBI debug console, not framebuffer
     );
 
     crate::arch::init_user_context_from_fdt();

--- a/kernel/src/arch/riscv64/boot/limine.rs
+++ b/kernel/src/arch/riscv64/boot/limine.rs
@@ -1,5 +1,3 @@
-use core::arch::naked_asm;
-
 use crate::environment::STACK_SIZE;
 
 use limine::paging;
@@ -7,12 +5,12 @@ use limine::request::{BspHartidRequest, PagingModeRequest};
 
 use crate::boot::limine::{
     DTB_REQUEST, EXECUTABLE_ADDRESS_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST, MODULE_REQUEST,
-    ensure_base_revision_supported, module_area, reserve_front, response, select_usable_region,
+    ensure_base_revision_supported, hhdm_physical_span, module_area, reserve_front, response,
+    select_usable_region,
 };
 use crate::device::fdt::{FdtManager, init_fdt, relocate_fdt};
 use crate::mem::{KERNEL_STACK, init_bss};
-use crate::vm::addr::{init_limine_addressing, phys_to_virt};
-use crate::vm::vmem::MemoryArea;
+use crate::vm::addr::{init_boot_direct_map_range, init_limine_addressing, phys_to_virt};
 use crate::{BootInfo, DeviceSource, start_kernel};
 
 static mut EARLY_BOOTINFO: Option<BootInfo> = None;
@@ -68,25 +66,20 @@ pub fn limine_entry() -> ! {
     init_fdt(dtb.dtb_ptr() as usize);
 
     let usable_region = select_usable_region(memmap.entries());
+    let hhdm_phys_span = hhdm_physical_span(memmap.entries());
+    init_boot_direct_map_range(hhdm_phys_span.start, hhdm_phys_span.end);
     let hhdm_offset = hhdm.offset() as usize;
     let relocated_fdt = relocate_fdt(phys_to_virt(usable_region.start) as *mut u8);
     let relocated_fdt_paddr = usable_region.start;
     let reserved_bytes = relocated_fdt.size();
     let usable_memory_paddr = reserve_front(usable_region, reserved_bytes);
-    let direct_map_paddr = usable_region;
+    let direct_map_paddr = hhdm_phys_span;
     let initramfs_paddr = module_area(MODULE_REQUEST.get_response());
     let fdt_manager = FdtManager::get_manager();
     let cpu_count = fdt_manager.get_cpu_count().unwrap_or(1);
     let cmdline = fdt_manager
         .get_fdt()
         .and_then(|fdt| fdt.chosen().bootargs());
-
-    crate::early_println!(
-        "[limine] bootinfo usable_memory_paddr={:#x}..={:#x}",
-        usable_memory_paddr.start,
-        usable_memory_paddr.end
-    );
-    crate::early_println!("[limine] before init_user_context_from_fdt");
     let bootinfo = BootInfo::new(
         bsp.bsp_hartid() as usize,
         cpu_count,
@@ -99,9 +92,7 @@ pub fn limine_entry() -> ! {
     );
 
     crate::arch::init_user_context_from_fdt();
-    crate::early_println!("[limine] before init_boot_cpu");
     crate::arch::riscv64::boot::init_boot_cpu(bootinfo.cpu_id);
-    crate::early_println!("[limine] before stack handoff");
 
     unsafe {
         let stack_top = (&raw const KERNEL_STACK) as *const _ as usize + STACK_SIZE;

--- a/kernel/src/arch/riscv64/boot/limine.rs
+++ b/kernel/src/arch/riscv64/boot/limine.rs
@@ -68,20 +68,12 @@ pub fn limine_entry() -> ! {
     init_fdt(dtb.dtb_ptr() as usize);
 
     let usable_region = select_usable_region(memmap.entries());
+    let hhdm_offset = hhdm.offset() as usize;
     let relocated_fdt = relocate_fdt(phys_to_virt(usable_region.start) as *mut u8);
     let reserved_bytes = relocated_fdt.size();
-    let usable_memory_phys = reserve_front(usable_region, reserved_bytes);
-    let usable_memory = MemoryArea::new(
-        phys_to_virt(usable_memory_phys.start),
-        phys_to_virt(usable_memory_phys.end),
-    );
-    let direct_map_area = MemoryArea::new(
-        phys_to_virt(usable_region.start),
-        phys_to_virt(usable_region.end),
-    );
-    let initramfs_phys = module_area(MODULE_REQUEST.get_response());
-    let initramfs = initramfs_phys
-        .map(|area| MemoryArea::new(phys_to_virt(area.start), phys_to_virt(area.end)));
+    let usable_memory_paddr = reserve_front(usable_region, reserved_bytes);
+    let direct_map_paddr = usable_region;
+    let initramfs_paddr = module_area(MODULE_REQUEST.get_response());
     let fdt_manager = FdtManager::get_manager();
     let cpu_count = fdt_manager.get_cpu_count().unwrap_or(1);
     let cmdline = fdt_manager
@@ -89,20 +81,18 @@ pub fn limine_entry() -> ! {
         .and_then(|fdt| fdt.chosen().bootargs());
 
     crate::early_println!(
-        "[limine] bootinfo usable_memory={:#x}..={:#x}",
-        usable_memory.start,
-        usable_memory.end
+        "[limine] bootinfo usable_memory_paddr={:#x}..={:#x}",
+        usable_memory_paddr.start,
+        usable_memory_paddr.end
     );
     crate::early_println!("[limine] before init_user_context_from_fdt");
     let bootinfo = BootInfo::new(
         bsp.bsp_hartid() as usize,
         cpu_count,
-        usable_memory,
-        direct_map_area,
-        usable_memory_phys,
-        usable_region,
-        initramfs,
-        initramfs_phys,
+        usable_memory_paddr,
+        direct_map_paddr,
+        initramfs_paddr,
+        hhdm_offset,
         cmdline,
         DeviceSource::Fdt(relocated_fdt.start),
     );

--- a/kernel/src/arch/riscv64/vm/mmu/sv48.rs
+++ b/kernel/src/arch/riscv64/vm/mmu/sv48.rs
@@ -136,6 +136,12 @@ impl PageTable {
         }
     }
 
+    /// Switch page table for boot-time initialization.
+    /// On RISC-V, this just calls switch() (no TTBR1 equivalent).
+    pub fn switch_for_boot(&self, asid: u16) {
+        self.switch(asid);
+    }
+
     /// Get the value for the satp register.
     ///
     /// # Note

--- a/kernel/src/boot/limine.rs
+++ b/kernel/src/boot/limine.rs
@@ -126,3 +126,19 @@ pub fn reserve_front(area: MemoryArea, reserved_bytes: usize) -> MemoryArea {
 
     MemoryArea::new(reserved_end, area.end)
 }
+
+/// Get framebuffer physical memory area from Limine response.
+///
+/// Returns the framebuffer's physical address range for use in early console
+/// after page table transition.
+pub fn framebuffer_area(
+    fb_response: Option<&'static limine::response::FramebufferResponse>,
+) -> Option<MemoryArea> {
+    let fb = fb_response?.framebuffers().next()?;
+    let addr = fb.addr() as usize;
+    // Calculate size: pitch * height (pitch is bytes per row)
+    let size = fb.pitch() as usize * fb.height() as usize;
+    let start = boot_virt_to_phys(addr);
+    let end = start + size - 1;
+    Some(MemoryArea::new(start, end))
+}

--- a/kernel/src/boot/limine.rs
+++ b/kernel/src/boot/limine.rs
@@ -5,7 +5,7 @@ use limine::request::{
     MemoryMapRequest, ModuleRequest, RequestsEndMarker, RequestsStartMarker,
 };
 
-use crate::vm::addr::virt_to_phys;
+use crate::vm::addr::boot_virt_to_phys;
 use crate::vm::vmem::MemoryArea;
 
 #[unsafe(link_section = ".limine_requests_start")]
@@ -78,11 +78,33 @@ pub fn select_usable_region(memmap: &[&Entry]) -> MemoryArea {
     best.expect("no usable Limine memmap region")
 }
 
+pub fn hhdm_physical_span(memmap: &[&Entry]) -> MemoryArea {
+    let mut start = usize::MAX;
+    let mut end = 0usize;
+
+    for entry in memmap {
+        if entry.length == 0 {
+            continue;
+        }
+
+        let entry_start = entry.base as usize;
+        let entry_end = (entry.base + entry.length - 1) as usize;
+        start = start.min(entry_start);
+        end = end.max(entry_end);
+    }
+
+    if start == usize::MAX {
+        panic!("no Limine memmap entries available for HHDM span");
+    }
+
+    MemoryArea::new(start, end)
+}
+
 pub fn module_area(
     module_response: Option<&'static limine::response::ModuleResponse>,
 ) -> Option<MemoryArea> {
     let file = module_response?.modules().first()?;
-    let start = virt_to_phys(file.addr() as usize);
+    let start = boot_virt_to_phys(file.addr() as usize);
     let end = start + file.size() as usize - 1;
     Some(MemoryArea::new(start, end))
 }

--- a/kernel/src/device/fdt.rs
+++ b/kernel/src/device/fdt.rs
@@ -539,7 +539,7 @@ pub fn create_bootinfo_from_fdt(cpu_id: usize, relocated_fdt_addr: usize) -> Boo
         cpu_id,
         cpu_count,
         usable_memory,
-        usable_memory,
+        dram_area,
         relocated_initramfs,
         hhdm_offset,
         cmdline,

--- a/kernel/src/device/fdt.rs
+++ b/kernel/src/device/fdt.rs
@@ -544,6 +544,7 @@ pub fn create_bootinfo_from_fdt(cpu_id: usize, relocated_fdt_addr: usize) -> Boo
         hhdm_offset,
         cmdline,
         DeviceSource::Fdt(relocated_fdt_addr),
+        None,
     )
 }
 

--- a/kernel/src/device/fdt.rs
+++ b/kernel/src/device/fdt.rs
@@ -533,15 +533,15 @@ pub fn create_bootinfo_from_fdt(cpu_id: usize, relocated_fdt_addr: usize) -> Boo
 
     let cpu_count = fdt_manager.get_cpu_count().unwrap_or(1);
 
+    let hhdm_offset = 0xffff_8000_0000_0000_usize;
+
     BootInfo::new(
         cpu_id,
         cpu_count,
         usable_memory,
         usable_memory,
-        usable_memory,
-        usable_memory,
         relocated_initramfs,
-        relocated_initramfs,
+        hhdm_offset,
         cmdline,
         DeviceSource::Fdt(relocated_fdt_addr),
     )

--- a/kernel/src/device/graphics/framebuffer_device.rs
+++ b/kernel/src/device/graphics/framebuffer_device.rs
@@ -20,8 +20,8 @@ use core::any::Any;
 use spin::RwLock;
 
 use crate::device::{
-    char::CharDevice, graphics::manager::FramebufferResource, manager::DeviceManager, Device,
-    DeviceType,
+    Device, DeviceType, char::CharDevice, graphics::manager::FramebufferResource,
+    manager::DeviceManager,
 };
 use crate::object::capability::selectable::Selectable;
 use crate::object::capability::{ControlOps, MemoryMappingOps};
@@ -936,10 +936,10 @@ impl FramebufferCharDevice {
 mod tests {
     use super::*;
     use crate::device::{
-        graphics::{
-            manager::GraphicsManager, FramebufferConfig, GenericGraphicsDevice, PixelFormat,
-        },
         Device,
+        graphics::{
+            FramebufferConfig, GenericGraphicsDevice, PixelFormat, manager::GraphicsManager,
+        },
     };
     use alloc::{string::ToString, sync::Arc};
     use spin::RwLock;

--- a/kernel/src/device/graphics/framebuffer_device.rs
+++ b/kernel/src/device/graphics/framebuffer_device.rs
@@ -20,8 +20,8 @@ use core::any::Any;
 use spin::RwLock;
 
 use crate::device::{
-    Device, DeviceType, char::CharDevice, graphics::manager::FramebufferResource,
-    manager::DeviceManager,
+    char::CharDevice, graphics::manager::FramebufferResource, manager::DeviceManager, Device,
+    DeviceType,
 };
 use crate::object::capability::selectable::Selectable;
 use crate::object::capability::{ControlOps, MemoryMappingOps};
@@ -653,7 +653,7 @@ impl FramebufferCharDevice {
             }
             super::PixelFormat::XRGB2101010 => {
                 var_info.red = FbBitfield {
-                    offset: 0,
+                    offset: 20,
                     length: 10,
                     msb_right: 0,
                 };
@@ -663,7 +663,7 @@ impl FramebufferCharDevice {
                     msb_right: 0,
                 };
                 var_info.blue = FbBitfield {
-                    offset: 20,
+                    offset: 0,
                     length: 10,
                     msb_right: 0,
                 };
@@ -936,10 +936,10 @@ impl FramebufferCharDevice {
 mod tests {
     use super::*;
     use crate::device::{
-        Device,
         graphics::{
-            FramebufferConfig, GenericGraphicsDevice, PixelFormat, manager::GraphicsManager,
+            manager::GraphicsManager, FramebufferConfig, GenericGraphicsDevice, PixelFormat,
         },
+        Device,
     };
     use alloc::{string::ToString, sync::Arc};
     use spin::RwLock;

--- a/kernel/src/device/graphics/framebuffer_device.rs
+++ b/kernel/src/device/graphics/framebuffer_device.rs
@@ -607,6 +607,50 @@ impl FramebufferCharDevice {
                     msb_right: 0,
                 };
             }
+            super::PixelFormat::XRGB8888 => {
+                var_info.red = FbBitfield {
+                    offset: 0,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 8,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 16,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 24,
+                    length: 0,
+                    msb_right: 0,
+                };
+            }
+            super::PixelFormat::XBGR8888 => {
+                var_info.blue = FbBitfield {
+                    offset: 0,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 8,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.red = FbBitfield {
+                    offset: 16,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 24,
+                    length: 0,
+                    msb_right: 0,
+                };
+            }
             super::PixelFormat::RGB888 => {
                 var_info.red = FbBitfield {
                     offset: 0,
@@ -647,6 +691,50 @@ impl FramebufferCharDevice {
                 };
                 var_info.transp = FbBitfield {
                     offset: 0,
+                    length: 0,
+                    msb_right: 0,
+                };
+            }
+            super::PixelFormat::ARGB1555 => {
+                var_info.red = FbBitfield {
+                    offset: 10,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 5,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 0,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 15,
+                    length: 1,
+                    msb_right: 0,
+                };
+            }
+            super::PixelFormat::XRGB1555 => {
+                var_info.red = FbBitfield {
+                    offset: 10,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 5,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 0,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 15,
                     length: 0,
                     msb_right: 0,
                 };

--- a/kernel/src/device/graphics/framebuffer_device.rs
+++ b/kernel/src/device/graphics/framebuffer_device.rs
@@ -651,6 +651,28 @@ impl FramebufferCharDevice {
                     msb_right: 0,
                 };
             }
+            super::PixelFormat::XRGB2101010 => {
+                var_info.red = FbBitfield {
+                    offset: 0,
+                    length: 10,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 10,
+                    length: 10,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 20,
+                    length: 10,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 30,
+                    length: 0,
+                    msb_right: 0,
+                };
+            }
             super::PixelFormat::RGB888 => {
                 var_info.red = FbBitfield {
                     offset: 0,

--- a/kernel/src/device/graphics/mod.rs
+++ b/kernel/src/device/graphics/mod.rs
@@ -40,6 +40,7 @@ pub enum PixelFormat {
     BGRA8888,
     XRGB8888,
     XBGR8888,
+    XRGB2101010,
     /// 24-bit RGB (8 bits per channel)
     RGB888,
     /// 16-bit RGB (5-6-5 bits)
@@ -55,7 +56,8 @@ impl PixelFormat {
             PixelFormat::RGBA8888
             | PixelFormat::BGRA8888
             | PixelFormat::XRGB8888
-            | PixelFormat::XBGR8888 => 4,
+            | PixelFormat::XBGR8888
+            | PixelFormat::XRGB2101010 => 4,
             PixelFormat::RGB888 => 3,
             PixelFormat::RGB565 | PixelFormat::ARGB1555 | PixelFormat::XRGB1555 => 2,
         }

--- a/kernel/src/device/graphics/mod.rs
+++ b/kernel/src/device/graphics/mod.rs
@@ -38,19 +38,26 @@ pub enum PixelFormat {
     RGBA8888,
     /// 32-bit BGRA (8 bits per channel)  
     BGRA8888,
+    XRGB8888,
+    XBGR8888,
     /// 24-bit RGB (8 bits per channel)
     RGB888,
     /// 16-bit RGB (5-6-5 bits)
     RGB565,
+    ARGB1555,
+    XRGB1555,
 }
 
 impl PixelFormat {
     /// Get bytes per pixel for this format
     pub fn bytes_per_pixel(&self) -> usize {
         match self {
-            PixelFormat::RGBA8888 | PixelFormat::BGRA8888 => 4,
+            PixelFormat::RGBA8888
+            | PixelFormat::BGRA8888
+            | PixelFormat::XRGB8888
+            | PixelFormat::XBGR8888 => 4,
             PixelFormat::RGB888 => 3,
-            PixelFormat::RGB565 => 2,
+            PixelFormat::RGB565 | PixelFormat::ARGB1555 | PixelFormat::XRGB1555 => 2,
         }
     }
 }

--- a/kernel/src/device/graphics/tests/integration_tests.rs
+++ b/kernel/src/device/graphics/tests/integration_tests.rs
@@ -561,8 +561,8 @@ mod integration_tests {
             .expect("Failed to initialize VirtIO GPU device");
         // Get framebuffer configuration
         let config = device.get_framebuffer_config().unwrap();
-        assert_eq!(config.width, 1024);
-        assert_eq!(config.height, 768);
+        assert_eq!(config.width, 1920);
+        assert_eq!(config.height, 1080);
         assert_eq!(config.format, PixelFormat::BGRA8888);
         let shared_device = Arc::new(device);
 

--- a/kernel/src/device/graphics/tests/mod.rs
+++ b/kernel/src/device/graphics/tests/mod.rs
@@ -180,8 +180,13 @@ fn test_pixel_format_operations() {
     let formats = [
         PixelFormat::RGBA8888,
         PixelFormat::BGRA8888,
+        PixelFormat::XRGB8888,
+        PixelFormat::XBGR8888,
+        PixelFormat::XRGB2101010,
         PixelFormat::RGB888,
         PixelFormat::RGB565,
+        PixelFormat::ARGB1555,
+        PixelFormat::XRGB1555,
     ];
 
     for format in formats {
@@ -189,11 +194,7 @@ fn test_pixel_format_operations() {
         device.set_framebuffer_config(config.clone());
 
         let fb_size = config.size();
-        let expected_size = match format {
-            PixelFormat::RGBA8888 | PixelFormat::BGRA8888 => 100 * 100 * 4,
-            PixelFormat::RGB888 => 100 * 100 * 3,
-            PixelFormat::RGB565 => 100 * 100 * 2,
-        };
+        let expected_size = 100 * 100 * format.bytes_per_pixel();
         assert_eq!(fb_size, expected_size);
 
         // Allocate and set framebuffer
@@ -202,23 +203,41 @@ fn test_pixel_format_operations() {
         device.set_framebuffer_address(fb_addr);
 
         // Test pixel writing based on format
-        match format {
-            PixelFormat::RGBA8888 => {
-                unsafe {
+        // SAFETY: fb_addr is a valid pointer to allocated framebuffer memory with sufficient size
+        // for the configured pixel format. The pointer arithmetic stays within bounds.
+        unsafe {
+            match format {
+                PixelFormat::RGBA8888 => {
                     let fb_ptr = fb_addr as *mut u32;
                     *fb_ptr = 0xFF00FF80; // Semi-transparent red-green
                     assert_eq!(*fb_ptr, 0xFF00FF80);
                 }
-            }
-            PixelFormat::BGRA8888 => {
-                unsafe {
+                PixelFormat::BGRA8888 => {
                     let fb_ptr = fb_addr as *mut u32;
                     *fb_ptr = 0x80FF0080; // Semi-transparent in BGRA
                     assert_eq!(*fb_ptr, 0x80FF0080);
                 }
-            }
-            PixelFormat::RGB888 => {
-                unsafe {
+                PixelFormat::XRGB8888 => {
+                    let fb_ptr = fb_addr as *mut u32;
+                    // XRGB8888: bits 0-7 Blue, 8-15 Green, 16-23 Red, 24-31 unused (X)
+                    *fb_ptr = 0x00FF8040; // Red=0xFF, Green=0x80, Blue=0x40, X=0x00
+                    assert_eq!(*fb_ptr, 0x00FF8040);
+                }
+                PixelFormat::XBGR8888 => {
+                    let fb_ptr = fb_addr as *mut u32;
+                    // XBGR8888: bits 0-7 Red, 8-15 Green, 16-23 Blue, 24-31 unused (X)
+                    *fb_ptr = 0x004080FF; // Blue=0xFF, Green=0x80, Red=0x40, X=0x00
+                    assert_eq!(*fb_ptr, 0x004080FF);
+                }
+                PixelFormat::XRGB2101010 => {
+                    let fb_ptr = fb_addr as *mut u32;
+                    // XRGB2101010: 2-bit X, 10-bit R, 10-bit G, 10-bit B (MSB to LSB)
+                    // Red=0x3FF (1023), Green=0x200 (512), Blue=0x100 (256)
+                    let pixel: u32 = (0x3FF << 20) | (0x200 << 10) | 0x100;
+                    *fb_ptr = pixel;
+                    assert_eq!(*fb_ptr, pixel);
+                }
+                PixelFormat::RGB888 => {
                     let fb_ptr = fb_addr as *mut u8;
                     *fb_ptr = 0xFF; // R
                     *fb_ptr.add(1) = 0x80; // G
@@ -227,12 +246,25 @@ fn test_pixel_format_operations() {
                     assert_eq!(*fb_ptr.add(1), 0x80);
                     assert_eq!(*fb_ptr.add(2), 0x40);
                 }
-            }
-            PixelFormat::RGB565 => {
-                unsafe {
+                PixelFormat::RGB565 => {
                     let fb_ptr = fb_addr as *mut u16;
-                    *fb_ptr = 0xF800; // Red in RGB565 format
+                    // RGB565: 5-bit R, 6-bit G, 5-bit B
+                    *fb_ptr = 0xF800; // Red=0x1F (31), Green=0x00, Blue=0x00
                     assert_eq!(*fb_ptr, 0xF800);
+                }
+                PixelFormat::ARGB1555 => {
+                    let fb_ptr = fb_addr as *mut u16;
+                    // ARGB1555: 1-bit A, 5-bit R, 5-bit G, 5-bit B
+                    // A=1 (opaque), R=0x1F (31), G=0x00, B=0x00
+                    *fb_ptr = 0xFC00; // Opaque red
+                    assert_eq!(*fb_ptr, 0xFC00);
+                }
+                PixelFormat::XRGB1555 => {
+                    let fb_ptr = fb_addr as *mut u16;
+                    // XRGB1555: 1-bit X (unused), 5-bit R, 5-bit G, 5-bit B
+                    // X=0, R=0x1F (31), G=0x00, B=0x00
+                    *fb_ptr = 0x7C00; // Red with unused bit = 0
+                    assert_eq!(*fb_ptr, 0x7C00);
                 }
             }
         }

--- a/kernel/src/device/manager.rs
+++ b/kernel/src/device/manager.rs
@@ -196,6 +196,26 @@ impl DeviceManager {
         });
     }
 
+    fn mem_resource_from_region(
+        region: fdt::standard_nodes::MemoryRegion,
+    ) -> Option<PlatformDeviceResource> {
+        let start = region.starting_address as usize;
+        let size = region.size?;
+
+        if size == 0 {
+            return None;
+        }
+
+        let end = start.checked_add(size - 1)?;
+
+        Some(PlatformDeviceResource {
+            res_type: PlatformDeviceResourceType::MEM,
+            start,
+            end,
+            irq_metadata: None,
+        })
+    }
+
     /// Register a device with the manager
     ///
     /// # Arguments
@@ -511,13 +531,9 @@ impl DeviceManager {
         // Add memory regions
         if let Some(regions) = child.reg() {
             for region in regions {
-                let res = PlatformDeviceResource {
-                    res_type: PlatformDeviceResourceType::MEM,
-                    start: region.starting_address as usize,
-                    end: region.starting_address as usize + region.size.unwrap() - 1,
-                    irq_metadata: None, // No IRQ metadata for memory regions
-                };
-                resources.push(res);
+                if let Some(res) = Self::mem_resource_from_region(region) {
+                    resources.push(res);
+                }
             }
         }
 
@@ -940,5 +956,29 @@ mod tests {
         let manager = DeviceManager::new();
         let device = manager.get_device_by_name("non_existent");
         assert!(device.is_none());
+    }
+
+    #[test_case]
+    fn test_mem_resource_from_region_without_size() {
+        let region = fdt::standard_nodes::MemoryRegion {
+            starting_address: 0x1000 as *const u8,
+            size: None,
+        };
+
+        assert!(DeviceManager::mem_resource_from_region(region).is_none());
+    }
+
+    #[test_case]
+    fn test_mem_resource_from_region_with_size() {
+        let region = fdt::standard_nodes::MemoryRegion {
+            starting_address: 0x1000 as *const u8,
+            size: Some(0x100),
+        };
+
+        let resource = DeviceManager::mem_resource_from_region(region).unwrap();
+        assert_eq!(resource.start, 0x1000);
+        assert_eq!(resource.end, 0x10ff);
+        assert_eq!(resource.res_type, PlatformDeviceResourceType::MEM);
+        assert!(resource.irq_metadata.is_none());
     }
 }

--- a/kernel/src/device/manager.rs
+++ b/kernel/src/device/manager.rs
@@ -144,6 +144,57 @@ impl DeviceManager {
         &MANAGER
     }
 
+    fn read_be_u32(bytes: &[u8]) -> Option<u32> {
+        if bytes.len() < 4 {
+            return None;
+        }
+        Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn get_u32_prop<'a, 'b>(node: &fdt::node::FdtNode<'a, 'b>, name: &str) -> Option<u32> {
+        let prop = node.property(name)?;
+        Self::read_be_u32(prop.value)
+    }
+
+    fn find_node_by_phandle<'a>(
+        fdt: &'a fdt::Fdt<'a>,
+        phandle: u32,
+    ) -> Option<fdt::node::FdtNode<'a, 'a>> {
+        let mut stack: Vec<fdt::node::FdtNode<'a, 'a>> = Vec::new();
+        stack.push(fdt.find_node("/")?);
+
+        while let Some(node) = stack.pop() {
+            if let Some(p) = Self::get_u32_prop(&node, "phandle") {
+                if p == phandle {
+                    return Some(node);
+                }
+            }
+            if let Some(p) = Self::get_u32_prop(&node, "linux,phandle") {
+                if p == phandle {
+                    return Some(node);
+                }
+            }
+            for child in node.children() {
+                stack.push(child);
+            }
+        }
+
+        None
+    }
+
+    fn push_irq_resource(
+        resources: &mut Vec<PlatformDeviceResource>,
+        irq_num: usize,
+        metadata: Option<crate::device::platform::resource::IrqMetadata>,
+    ) {
+        resources.push(PlatformDeviceResource {
+            res_type: PlatformDeviceResourceType::IRQ,
+            start: irq_num,
+            end: irq_num,
+            irq_metadata: metadata,
+        });
+    }
+
     /// Register a device with the manager
     ///
     /// # Arguments
@@ -434,115 +485,180 @@ impl DeviceManager {
         }
 
         // Add IRQs
+        let mut parsed_any_irq = false;
+
         if let Some(irqs) = child.interrupts() {
             // Standard path: fdt-rs successfully parsed interrupts
             for irq in irqs {
-                let res = PlatformDeviceResource {
-                    res_type: PlatformDeviceResourceType::IRQ,
-                    start: irq,
-                    end: irq,
-                    irq_metadata: None, // No metadata when fdt-rs handles it
-                };
-                resources.push(res);
+                Self::push_irq_resource(&mut resources, irq, None);
+                parsed_any_irq = true;
             }
-        } else if let Some(prop) = child.property("interrupts") {
-            // Fallback: Parse raw interrupts property when fdt-rs fails
-            // This preserves interrupt controller metadata for later translation
-            let value = prop.value;
+        }
 
-            // Detect cell format based on property length
-            let cell_size = if value.len() % 12 == 0 {
-                3 // 3-cell format (e.g., ARM GIC: <type, number, flags>)
-            } else if value.len() % 8 == 0 {
-                2 // 2-cell format
-            } else if value.len() % 4 == 0 {
-                1 // 1-cell format (just interrupt number)
-            } else {
-                return resources; // Unknown format, skip
-            };
+        if !parsed_any_irq {
+            if let Some(prop) = child.property("interrupts-extended") {
+                if let Some(fdt) = crate::device::fdt::FdtManager::get_manager().get_fdt() {
+                    let bytes = prop.value;
+                    let mut offset = 0usize;
 
-            let num_irqs = value.len() / (cell_size * 4);
+                    while offset + 4 <= bytes.len() {
+                        let phandle = match Self::read_be_u32(&bytes[offset..offset + 4]) {
+                            Some(v) => v,
+                            None => break,
+                        };
+                        offset += 4;
 
-            for i in 0..num_irqs {
-                let offset = i * cell_size * 4;
+                        let intc_node = Self::find_node_by_phandle(fdt, phandle);
+                        let interrupt_cells = intc_node
+                            .as_ref()
+                            .and_then(|n| Self::get_u32_prop(n, "#interrupt-cells"))
+                            .unwrap_or(1) as usize;
 
-                let (irq_num, metadata) = match cell_size {
-                    3 => {
-                        // 3-cell format: <type, number, flags>
-                        let irq_type = u32::from_be_bytes([
-                            value[offset],
-                            value[offset + 1],
-                            value[offset + 2],
-                            value[offset + 3],
-                        ]);
-                        let irq_number = u32::from_be_bytes([
-                            value[offset + 4],
-                            value[offset + 5],
-                            value[offset + 6],
-                            value[offset + 7],
-                        ]);
-                        let irq_flags = u32::from_be_bytes([
-                            value[offset + 8],
-                            value[offset + 9],
-                            value[offset + 10],
-                            value[offset + 11],
-                        ]);
+                        if interrupt_cells == 0 {
+                            break;
+                        }
 
-                        // Store raw number, let interrupt controller translate
-                        (
-                            irq_number as usize,
-                            Some(crate::device::platform::resource::IrqMetadata {
-                                irq_type,
-                                irq_number,
-                                irq_flags,
-                            }),
-                        )
+                        let needed = interrupt_cells.saturating_mul(4);
+                        if offset + needed > bytes.len() {
+                            break;
+                        }
+
+                        let cell0 = Self::read_be_u32(&bytes[offset..offset + 4]).unwrap_or(0);
+                        let cell1 = if interrupt_cells >= 2 {
+                            Self::read_be_u32(&bytes[offset + 4..offset + 8]).unwrap_or(0)
+                        } else {
+                            0
+                        };
+                        let cell2 = if interrupt_cells >= 3 {
+                            Self::read_be_u32(&bytes[offset + 8..offset + 12]).unwrap_or(0)
+                        } else {
+                            0
+                        };
+
+                        let (irq_num, metadata) = match interrupt_cells {
+                            3 => (
+                                cell1 as usize,
+                                Some(crate::device::platform::resource::IrqMetadata {
+                                    irq_type: cell0,
+                                    irq_number: cell1,
+                                    irq_flags: cell2,
+                                }),
+                            ),
+                            2 => (
+                                cell0 as usize,
+                                Some(crate::device::platform::resource::IrqMetadata {
+                                    irq_type: 0,
+                                    irq_number: cell0,
+                                    irq_flags: cell1,
+                                }),
+                            ),
+                            1 => (cell0 as usize, None),
+                            _ => (cell0 as usize, None),
+                        };
+
+                        Self::push_irq_resource(&mut resources, irq_num, metadata);
+                        parsed_any_irq = true;
+                        offset += needed;
                     }
-                    2 => {
-                        // 2-cell format: <number, flags>
-                        let irq_number = u32::from_be_bytes([
-                            value[offset],
-                            value[offset + 1],
-                            value[offset + 2],
-                            value[offset + 3],
-                        ]);
-                        let irq_flags = u32::from_be_bytes([
-                            value[offset + 4],
-                            value[offset + 5],
-                            value[offset + 6],
-                            value[offset + 7],
-                        ]);
+                }
+            }
+        }
 
-                        (
-                            irq_number as usize,
-                            Some(crate::device::platform::resource::IrqMetadata {
-                                irq_type: 0, // No type in 2-cell format
-                                irq_number,
-                                irq_flags,
-                            }),
-                        )
-                    }
-                    1 => {
-                        // 1-cell format: just interrupt number
-                        let irq_number = u32::from_be_bytes([
-                            value[offset],
-                            value[offset + 1],
-                            value[offset + 2],
-                            value[offset + 3],
-                        ]);
+        if !parsed_any_irq {
+            if let Some(prop) = child.property("interrupts") {
+                // Fallback: Parse raw interrupts property when fdt-rs fails
+                // This preserves interrupt controller metadata for later translation
+                let value = prop.value;
 
-                        (irq_number as usize, None)
-                    }
-                    _ => unreachable!(),
+                // Detect cell format based on property length
+                let cell_size = if value.len() % 12 == 0 {
+                    3 // 3-cell format (e.g., ARM GIC: <type, number, flags>)
+                } else if value.len() % 8 == 0 {
+                    2 // 2-cell format
+                } else if value.len() % 4 == 0 {
+                    1 // 1-cell format (just interrupt number)
+                } else {
+                    return resources; // Unknown format, skip
                 };
 
-                let res = PlatformDeviceResource {
-                    res_type: PlatformDeviceResourceType::IRQ,
-                    start: irq_num,
-                    end: irq_num,
-                    irq_metadata: metadata,
-                };
-                resources.push(res);
+                let num_irqs = value.len() / (cell_size * 4);
+
+                for i in 0..num_irqs {
+                    let offset = i * cell_size * 4;
+
+                    let (irq_num, metadata) = match cell_size {
+                        3 => {
+                            // 3-cell format: <type, number, flags>
+                            let irq_type = u32::from_be_bytes([
+                                value[offset],
+                                value[offset + 1],
+                                value[offset + 2],
+                                value[offset + 3],
+                            ]);
+                            let irq_number = u32::from_be_bytes([
+                                value[offset + 4],
+                                value[offset + 5],
+                                value[offset + 6],
+                                value[offset + 7],
+                            ]);
+                            let irq_flags = u32::from_be_bytes([
+                                value[offset + 8],
+                                value[offset + 9],
+                                value[offset + 10],
+                                value[offset + 11],
+                            ]);
+
+                            // Store raw number, let interrupt controller translate
+                            (
+                                irq_number as usize,
+                                Some(crate::device::platform::resource::IrqMetadata {
+                                    irq_type,
+                                    irq_number,
+                                    irq_flags,
+                                }),
+                            )
+                        }
+                        2 => {
+                            // 2-cell format: <number, flags>
+                            let irq_number = u32::from_be_bytes([
+                                value[offset],
+                                value[offset + 1],
+                                value[offset + 2],
+                                value[offset + 3],
+                            ]);
+                            let irq_flags = u32::from_be_bytes([
+                                value[offset + 4],
+                                value[offset + 5],
+                                value[offset + 6],
+                                value[offset + 7],
+                            ]);
+
+                            (
+                                irq_number as usize,
+                                Some(crate::device::platform::resource::IrqMetadata {
+                                    irq_type: 0, // No type in 2-cell format
+                                    irq_number,
+                                    irq_flags,
+                                }),
+                            )
+                        }
+                        1 => {
+                            // 1-cell format: just interrupt number
+                            let irq_number = u32::from_be_bytes([
+                                value[offset],
+                                value[offset + 1],
+                                value[offset + 2],
+                                value[offset + 3],
+                            ]);
+
+                            (irq_number as usize, None)
+                        }
+                        _ => unreachable!(),
+                    };
+
+                    Self::push_irq_resource(&mut resources, irq_num, metadata);
+                    parsed_any_irq = true;
+                }
             }
         }
 

--- a/kernel/src/device/manager.rs
+++ b/kernel/src/device/manager.rs
@@ -51,6 +51,7 @@ use alloc::vec::Vec;
 use spin::mutex::Mutex;
 
 use crate::device::platform::PlatformDeviceInfo;
+use crate::device::platform::PlatformDeviceProperty;
 use crate::device::platform::resource::PlatformDeviceResource;
 use crate::device::platform::resource::PlatformDeviceResourceType;
 use crate::early_println;
@@ -423,9 +424,14 @@ impl DeviceManager {
 
         let mut idx = 0;
 
-        // Process each child node separately to reduce stack usage
         for child in parent_node.children() {
             self.process_single_device_node(child, priority, &mut idx);
+        }
+
+        if let Some(chosen_node) = fdt.find_node("/chosen") {
+            for child in chosen_node.children() {
+                self.process_single_device_node(child, priority, &mut idx);
+            }
         }
     }
 
@@ -458,10 +464,28 @@ impl DeviceManager {
 
         // Build resources separately to reduce stack usage
         let resources = self.build_minimal_resources(&child);
+        let properties = self.build_device_properties(&child);
 
         // Try to match with drivers
         let compatible_vec: alloc::vec::Vec<&str> = compatible_iter.collect();
-        self.try_match_and_probe_device(child, priority, idx, compatible_vec, resources);
+        self.try_match_and_probe_device(
+            child,
+            priority,
+            idx,
+            compatible_vec,
+            resources,
+            properties,
+        );
+    }
+
+    fn build_device_properties(
+        &self,
+        child: &fdt::node::FdtNode,
+    ) -> alloc::vec::Vec<PlatformDeviceProperty> {
+        child
+            .properties()
+            .map(|property| PlatformDeviceProperty::new(property.name, property.value))
+            .collect()
     }
 
     /// Build device resources with minimal stack allocation
@@ -673,6 +697,7 @@ impl DeviceManager {
         idx: &mut usize,
         compatible: alloc::vec::Vec<&str>,
         resources: alloc::vec::Vec<PlatformDeviceResource>,
+        properties: alloc::vec::Vec<PlatformDeviceProperty>,
     ) {
         let drivers = self.drivers.lock();
         if let Some(driver_list) = drivers.get(&priority) {
@@ -695,6 +720,7 @@ impl DeviceManager {
                         *idx,
                         static_compatible,
                         resources,
+                        properties,
                     ));
 
                     match driver.probe(&*device) {

--- a/kernel/src/device/manager.rs
+++ b/kernel/src/device/manager.rs
@@ -425,20 +425,33 @@ impl DeviceManager {
         let mut idx = 0;
 
         for child in parent_node.children() {
-            self.process_single_device_node(child, priority, &mut idx);
+            self.process_device_subtree(&child, priority, &mut idx);
         }
 
         if let Some(chosen_node) = fdt.find_node("/chosen") {
             for child in chosen_node.children() {
-                self.process_single_device_node(child, priority, &mut idx);
+                self.process_device_subtree(&child, priority, &mut idx);
             }
+        }
+    }
+
+    fn process_device_subtree(
+        &self,
+        node: &fdt::node::FdtNode,
+        priority: DriverPriority,
+        idx: &mut usize,
+    ) {
+        self.process_single_device_node(node, priority, idx);
+
+        for child in node.children() {
+            self.process_device_subtree(&child, priority, idx);
         }
     }
 
     /// Process a single device node with minimal stack usage
     fn process_single_device_node(
         &self,
-        child: fdt::node::FdtNode,
+        child: &fdt::node::FdtNode,
         priority: DriverPriority,
         idx: &mut usize,
     ) {
@@ -692,7 +705,7 @@ impl DeviceManager {
     /// Try to match device with drivers and probe if successful
     fn try_match_and_probe_device(
         &self,
-        child: fdt::node::FdtNode,
+        child: &fdt::node::FdtNode,
         priority: DriverPriority,
         idx: &mut usize,
         compatible: alloc::vec::Vec<&str>,

--- a/kernel/src/device/platform/mod.rs
+++ b/kernel/src/device/platform/mod.rs
@@ -55,10 +55,48 @@
 pub mod resource;
 
 extern crate alloc;
+use alloc::string::String;
 use alloc::vec::Vec;
 
 use super::*;
 use resource::*;
+
+#[derive(Debug, Clone)]
+pub struct PlatformDeviceProperty {
+    name: String,
+    value: Vec<u8>,
+}
+
+impl PlatformDeviceProperty {
+    pub fn new(name: &str, value: &[u8]) -> Self {
+        Self {
+            name: name.into(),
+            value: value.to_vec(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn value(&self) -> &[u8] {
+        &self.value
+    }
+
+    pub fn as_usize(&self) -> Option<usize> {
+        match self.value.len() {
+            4 => Some(u32::from_be_bytes(self.value.as_slice().try_into().ok()?) as usize),
+            8 => Some(u64::from_be_bytes(self.value.as_slice().try_into().ok()?) as usize),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        core::str::from_utf8(&self.value)
+            .ok()
+            .map(|value| value.trim_end_matches('\0'))
+    }
+}
 
 /// Struct representing platform device information.
 #[derive(Debug)]
@@ -67,6 +105,7 @@ pub struct PlatformDeviceInfo {
     id: usize,
     compatible: Vec<&'static str>,
     resources: Vec<PlatformDeviceResource>,
+    properties: Vec<PlatformDeviceProperty>,
 }
 
 /// Information about a platform device.
@@ -107,12 +146,14 @@ impl PlatformDeviceInfo {
         id: usize,
         compatible: Vec<&'static str>,
         resources: Vec<PlatformDeviceResource>,
+        properties: Vec<PlatformDeviceProperty>,
     ) -> Self {
         Self {
             name,
             id,
             compatible,
             resources,
+            properties,
         }
     }
 
@@ -124,6 +165,16 @@ impl PlatformDeviceInfo {
     ///
     pub fn get_resources(&self) -> &Vec<PlatformDeviceResource> {
         &self.resources
+    }
+
+    pub fn property(&self, name: &str) -> Option<&PlatformDeviceProperty> {
+        self.properties
+            .iter()
+            .find(|property| property.name() == name)
+    }
+
+    pub fn properties(&self) -> &[PlatformDeviceProperty] {
+        &self.properties
     }
 }
 
@@ -200,7 +251,8 @@ mod tests {
 
     #[test_case]
     fn test_probe_success() {
-        let device = PlatformDeviceInfo::new("test_device", 1, vec!["test,compatible"], vec![]);
+        let device =
+            PlatformDeviceInfo::new("test_device", 1, vec!["test,compatible"], vec![], vec![]);
         let driver = PlatformDeviceDriver::new(
             "test_driver",
             |device_info| {

--- a/kernel/src/device/platform/mod.rs
+++ b/kernel/src/device/platform/mod.rs
@@ -96,6 +96,21 @@ impl PlatformDeviceProperty {
             .ok()
             .map(|value| value.trim_end_matches('\0'))
     }
+
+    pub fn as_string_list(&self) -> Option<Vec<&str>> {
+        if self.value.is_empty() {
+            return Some(Vec::new());
+        }
+
+        let mut out = Vec::new();
+        for part in self.value.split(|byte| *byte == 0) {
+            if part.is_empty() {
+                continue;
+            }
+            out.push(core::str::from_utf8(part).ok()?);
+        }
+        Some(out)
+    }
 }
 
 /// Struct representing platform device information.

--- a/kernel/src/drivers/graphics/mod.rs
+++ b/kernel/src/drivers/graphics/mod.rs
@@ -2,4 +2,5 @@
 //!
 //! This module contains graphics device drivers for the Scarlet kernel.
 
+pub mod simple_framebuffer;
 pub mod virtio_gpu;

--- a/kernel/src/drivers/graphics/simple_framebuffer.rs
+++ b/kernel/src/drivers/graphics/simple_framebuffer.rs
@@ -138,12 +138,62 @@ fn property_str<'a>(device: &'a PlatformDeviceInfo, name: &str) -> Result<&'a st
         .ok_or("Missing framebuffer string property")
 }
 
+fn log_probe_properties(device: &PlatformDeviceInfo) {
+    let status = device
+        .property("status")
+        .and_then(|property| property.as_str())
+        .unwrap_or("<missing>");
+    let width = device
+        .property("width")
+        .and_then(|property| property.as_usize());
+    let height = device
+        .property("height")
+        .and_then(|property| property.as_usize());
+    let stride = device
+        .property("stride")
+        .and_then(|property| property.as_usize());
+    let format = device
+        .property("format")
+        .and_then(|property| property.as_str())
+        .unwrap_or("<missing>");
+    let mem_resource = device
+        .get_resources()
+        .iter()
+        .find(|resource| matches!(resource.res_type, PlatformDeviceResourceType::MEM));
+
+    match mem_resource {
+        Some(resource) => crate::println!(
+            "[simplefb] probe name={} compatible={:?} status={} reg={:#x}..={:#x} width={:?} height={:?} stride={:?} format={}",
+            device.name(),
+            device.compatible(),
+            status,
+            resource.start,
+            resource.end,
+            width,
+            height,
+            stride,
+            format,
+        ),
+        None => crate::println!(
+            "[simplefb] probe name={} compatible={:?} status={} reg=<missing> width={:?} height={:?} stride={:?} format={}",
+            device.name(),
+            device.compatible(),
+            status,
+            width,
+            height,
+            stride,
+            format,
+        ),
+    }
+}
+
 fn parse_pixel_format(device: &PlatformDeviceInfo) -> Result<PixelFormat, &'static str> {
     match property_str(device, "format")? {
         "a8r8g8b8" => Ok(PixelFormat::RGBA8888),
         "a8b8g8r8" => Ok(PixelFormat::BGRA8888),
         "x8r8g8b8" => Ok(PixelFormat::XRGB8888),
         "x8b8g8r8" => Ok(PixelFormat::XBGR8888),
+        "x2r10g10b10" => Ok(PixelFormat::XRGB2101010),
         "r8g8b8" => Ok(PixelFormat::RGB888),
         "r5g6b5" => Ok(PixelFormat::RGB565),
         "a1r5g5b5" | "r5g5b5a1" => Ok(PixelFormat::ARGB1555),

--- a/kernel/src/drivers/graphics/simple_framebuffer.rs
+++ b/kernel/src/drivers/graphics/simple_framebuffer.rs
@@ -1,0 +1,239 @@
+use alloc::{boxed::Box, string::String, sync::Arc};
+
+use crate::{
+    device::{
+        Device, DeviceInfo, DeviceType,
+        graphics::{FramebufferConfig, GraphicsDevice, PixelFormat},
+        manager::{DeviceManager, DriverPriority},
+        platform::{
+            PlatformDeviceDriver, PlatformDeviceInfo, resource::PlatformDeviceResourceType,
+        },
+    },
+    early_initcall,
+    object::capability::{ControlOps, MemoryMappingOps, Selectable},
+};
+
+pub struct SimpleFramebufferDevice {
+    name: &'static str,
+    display_name: &'static str,
+    config: FramebufferConfig,
+    framebuffer_addr: usize,
+}
+
+impl SimpleFramebufferDevice {
+    fn new(
+        name: &'static str,
+        display_name: &'static str,
+        config: FramebufferConfig,
+        framebuffer_addr: usize,
+    ) -> Self {
+        Self {
+            name,
+            display_name,
+            config,
+            framebuffer_addr,
+        }
+    }
+}
+
+impl Device for SimpleFramebufferDevice {
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Graphics
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+        self
+    }
+
+    fn as_graphics_device(&self) -> Option<&dyn GraphicsDevice> {
+        Some(self)
+    }
+}
+
+impl ControlOps for SimpleFramebufferDevice {
+    fn control(&self, _command: u32, _arg: usize) -> Result<i32, &'static str> {
+        Err("Control operations not supported")
+    }
+}
+
+impl MemoryMappingOps for SimpleFramebufferDevice {
+    fn get_mapping_info(
+        &self,
+        _offset: usize,
+        _length: usize,
+    ) -> Result<(usize, usize, bool), &'static str> {
+        Err("Memory mapping not supported by simple framebuffer device")
+    }
+
+    fn on_mapped(&self, _vaddr: usize, _paddr: usize, _length: usize, _offset: usize) {}
+
+    fn on_unmapped(&self, _vaddr: usize, _length: usize) {}
+
+    fn supports_mmap(&self) -> bool {
+        false
+    }
+}
+
+impl Selectable for SimpleFramebufferDevice {
+    fn wait_until_ready(
+        &self,
+        _interest: crate::object::capability::selectable::ReadyInterest,
+        _trapframe: &mut crate::arch::Trapframe,
+        _timeout_ticks: Option<u64>,
+    ) -> crate::object::capability::selectable::SelectWaitOutcome {
+        crate::object::capability::selectable::SelectWaitOutcome::Ready
+    }
+}
+
+impl GraphicsDevice for SimpleFramebufferDevice {
+    fn get_display_name(&self) -> &'static str {
+        self.display_name
+    }
+
+    fn get_framebuffer_config(&self) -> Result<FramebufferConfig, &'static str> {
+        Ok(self.config.clone())
+    }
+
+    fn get_framebuffer_address(&self) -> Result<usize, &'static str> {
+        Ok(self.framebuffer_addr)
+    }
+
+    fn flush_framebuffer(
+        &self,
+        _x: u32,
+        _y: u32,
+        _width: u32,
+        _height: u32,
+    ) -> Result<(), &'static str> {
+        Ok(())
+    }
+
+    fn init_graphics(&self) -> Result<(), &'static str> {
+        Ok(())
+    }
+}
+
+fn property_u32(device: &PlatformDeviceInfo, name: &str) -> Result<u32, &'static str> {
+    let property = device
+        .property(name)
+        .ok_or("Missing framebuffer property")?;
+    let value = property
+        .as_usize()
+        .ok_or("Invalid framebuffer property value")?;
+    u32::try_from(value).map_err(|_| "Framebuffer property out of range")
+}
+
+fn property_str<'a>(device: &'a PlatformDeviceInfo, name: &str) -> Result<&'a str, &'static str> {
+    device
+        .property(name)
+        .and_then(|property| property.as_str())
+        .ok_or("Missing framebuffer string property")
+}
+
+fn parse_pixel_format(device: &PlatformDeviceInfo) -> Result<PixelFormat, &'static str> {
+    match property_str(device, "format")? {
+        "a8r8g8b8" => Ok(PixelFormat::RGBA8888),
+        "a8b8g8r8" => Ok(PixelFormat::BGRA8888),
+        "x8r8g8b8" => Ok(PixelFormat::XRGB8888),
+        "x8b8g8r8" => Ok(PixelFormat::XBGR8888),
+        "r8g8b8" => Ok(PixelFormat::RGB888),
+        "r5g6b5" => Ok(PixelFormat::RGB565),
+        "a1r5g5b5" | "r5g5b5a1" => Ok(PixelFormat::ARGB1555),
+        "x1r5g5b5" => Ok(PixelFormat::XRGB1555),
+        _ => Err("Unsupported simple framebuffer pixel format"),
+    }
+}
+
+fn framebuffer_resource(device: &PlatformDeviceInfo) -> Result<(usize, usize), &'static str> {
+    let resource = device
+        .get_resources()
+        .iter()
+        .find(|resource| matches!(resource.res_type, PlatformDeviceResourceType::MEM))
+        .ok_or("No framebuffer memory resource found")?;
+    Ok((resource.start, resource.end - resource.start + 1))
+}
+
+fn device_status_allows_probe(device: &PlatformDeviceInfo) -> bool {
+    match device
+        .property("status")
+        .and_then(|property| property.as_str())
+    {
+        Some("disabled") => false,
+        Some(_) | None => true,
+    }
+}
+
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    if !device_status_allows_probe(device) {
+        return Err("simple framebuffer is disabled");
+    }
+
+    let (framebuffer_addr, framebuffer_size) = framebuffer_resource(device)?;
+    let width = property_u32(device, "width")?;
+    let height = property_u32(device, "height")?;
+    let stride = property_u32(device, "stride")?;
+    let format = parse_pixel_format(device)?;
+
+    let config = FramebufferConfig {
+        width,
+        height,
+        format,
+        stride,
+    };
+
+    if config.size() > framebuffer_size {
+        return Err("simple framebuffer memory resource is too small");
+    }
+
+    let display_name = match device.compatible().as_slice() {
+        compatibles if compatibles.contains(&"apple,simple-framebuffer") => {
+            "apple-simple-framebuffer"
+        }
+        _ => "simple-framebuffer",
+    };
+
+    let graphics_device = Arc::new(SimpleFramebufferDevice::new(
+        device.name(),
+        display_name,
+        config,
+        framebuffer_addr,
+    ));
+    let registered_name = String::from(device.name());
+
+    let device_id = DeviceManager::get_manager()
+        .register_device_with_name(registered_name, graphics_device.clone());
+
+    crate::device::graphics::manager::GraphicsManager::get_manager()
+        .register_framebuffer_from_device(device_id, graphics_device)?;
+
+    if crate::earlyfb::is_initialized() {
+        crate::earlyfb::deactivate();
+    }
+
+    Ok(())
+}
+
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    Ok(())
+}
+
+fn register_driver() {
+    let driver = PlatformDeviceDriver::new(
+        "simple-framebuffer",
+        probe_fn,
+        remove_fn,
+        alloc::vec!["apple,simple-framebuffer", "simple-framebuffer"],
+    );
+
+    DeviceManager::get_manager().register_driver(Box::new(driver), DriverPriority::Late);
+}
+
+early_initcall!(register_driver);

--- a/kernel/src/drivers/graphics/virtio_gpu.rs
+++ b/kernel/src/drivers/graphics/virtio_gpu.rs
@@ -336,8 +336,8 @@ impl VirtioGpuDeviceCore {
                 r: VirtioGpuRect {
                     x: 0,
                     y: 0,
-                    width: 1024,
-                    height: 768,
+                    width: 1920,
+                    height: 1080,
                 },
                 enabled: 1,
                 flags: 0,
@@ -891,8 +891,8 @@ mod tests {
 
         // Get framebuffer configuration
         let config = device.get_framebuffer_config().unwrap();
-        assert_eq!(config.width, 1024);
-        assert_eq!(config.height, 768);
+        assert_eq!(config.width, 1920);
+        assert_eq!(config.height, 1080);
         assert_eq!(config.format, PixelFormat::BGRA8888);
 
         // Get framebuffer address

--- a/kernel/src/drivers/mod.rs
+++ b/kernel/src/drivers/mod.rs
@@ -11,3 +11,4 @@ pub mod uart;
 pub mod virtio;
 pub mod virtio_input;
 pub mod virtio_rng;
+pub mod watchdog;

--- a/kernel/src/drivers/pic/aic.rs
+++ b/kernel/src/drivers/pic/aic.rs
@@ -1,0 +1,667 @@
+//! Apple Interrupt Controller (AIC) driver
+//!
+//! AIC v1 as found on Apple M1 series SoCs. Based on the Asahi Linux implementation.
+//!
+//! # Features
+//!
+//! - Up to 896 level-triggered hardware IRQs
+//! - Single mask bit per IRQ (auto-masked on event delivery)
+//! - Per-IRQ CPU affinity via AIC_TARGET_CPU
+//! - 2 per-CPU IPIs (self and other)
+//! - Event-driven claim mechanism (no EOI register)
+//!
+//! # Implementation Notes
+//!
+//! - AIC auto-masks an IRQ when it's delivered via AIC_EVENT. The `complete_interrupt()`
+//!   implementation unmasks the IRQ to re-enable it.
+//! - AIC has no per-IRQ priority registers; prioritization is automatic (lower IRQ = higher priority).
+//! - Timer interrupts on Apple Silicon arrive as FIQ, not through AIC. The ArmGenericTimer
+//!   handles those separately.
+
+use crate::{
+    arch::mmio,
+    device::{
+        DeviceInfo,
+        manager::{DeviceManager, DriverPriority},
+        platform::{
+            PlatformDeviceDriver, PlatformDeviceInfo, resource::PlatformDeviceResourceType,
+        },
+    },
+    early_initcall,
+    interrupt::{
+        CpuId, InterruptError, InterruptId, InterruptManager, InterruptResult, Priority,
+        controllers::ExternalInterruptController,
+    },
+};
+use alloc::boxed::Box;
+
+// =============================================================================
+// Register Offsets
+// =============================================================================
+
+/// AIC Info register - contains NR_HW in bits [15:0]
+const AIC_INFO: usize = 0x0004;
+/// AIC Configuration register
+const AIC_CONFIG: usize = 0x0010;
+/// AIC WHOAMI register - returns current CPU ID
+const AIC_WHOAMI: usize = 0x2000;
+/// AIC Event register - event type in [31:16], event number in [15:0]
+const AIC_EVENT: usize = 0x2004;
+/// AIC IPI Send register
+const AIC_IPI_SEND: usize = 0x2008;
+/// AIC IPI Acknowledge register
+const AIC_IPI_ACK: usize = 0x200C;
+/// AIC IPI Mask Set register
+const AIC_IPI_MASK_SET: usize = 0x2024;
+/// AIC IPI Mask Clear register
+const AIC_IPI_MASK_CLR: usize = 0x2028;
+/// AIC Target CPU base - one 32-bit register per IRQ
+const AIC_TARGET_CPU: usize = 0x3000;
+/// AIC Software Set base - software trigger set
+const AIC_SW_SET: usize = 0x4000;
+/// AIC Software Clear base - software trigger clear
+const AIC_SW_CLR: usize = 0x4080;
+/// AIC Mask Set base - IRQ mask set
+const AIC_MASK_SET: usize = 0x4100;
+/// AIC Mask Clear base - IRQ mask clear
+const AIC_MASK_CLR: usize = 0x4180;
+
+// =============================================================================
+// Event Types (from AIC_EVENT register)
+// =============================================================================
+
+/// No event pending
+const AIC_EVENT_TYPE_NONE: u32 = 0;
+/// Hardware IRQ event
+const AIC_EVENT_TYPE_HW: u32 = 1;
+/// IPI event
+const AIC_EVENT_TYPE_IPI: u32 = 4;
+
+/// IPI "other" type in event number field
+const AIC_EVENT_IPI_OTHER: u32 = 1;
+/// IPI "self" type in event number field
+const AIC_EVENT_IPI_SELF: u32 = 2;
+
+// =============================================================================
+// IPI Bits
+// =============================================================================
+
+/// Bit for "other" IPI (from other CPUs)
+const AIC_IPI_OTHER: u32 = 1 << 0;
+/// Bit for "self" IPI
+const AIC_IPI_SELF: u32 = 1 << 31;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Maximum number of CPUs supported by AIC (31 bits in IPI SEND, bit 31 is self)
+const AIC_MAX_CPUS: CpuId = 31;
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/// Calculate the mask register offset for a given IRQ.
+///
+/// AIC uses 32 IRQs per 32-bit register.
+#[inline]
+const fn mask_reg(irq: InterruptId) -> usize {
+    4 * (irq as usize >> 5)
+}
+
+/// Calculate the bit position within a mask register for a given IRQ.
+#[inline]
+const fn mask_bit(irq: InterruptId) -> u32 {
+    1 << (irq & 0x1f)
+}
+
+// =============================================================================
+// AIC Driver Structure
+// =============================================================================
+
+/// Apple Interrupt Controller (AIC) driver.
+///
+/// Implements the `ExternalInterruptController` trait for Apple Silicon SoCs.
+pub struct Aic {
+    /// Base address of the AIC MMIO region
+    base_addr: usize,
+    /// Number of hardware IRQs supported (read from AIC_INFO)
+    num_irqs: InterruptId,
+    /// Maximum number of CPUs supported
+    max_cpus: CpuId,
+}
+
+impl Aic {
+    /// Create a new AIC instance.
+    ///
+    /// Reads the number of hardware IRQs from the AIC_INFO register.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_addr` - Virtual address of the AIC MMIO region
+    /// * `max_cpus` - Maximum number of CPUs to support
+    ///
+    /// # Returns
+    ///
+    /// A new `Aic` instance with `num_irqs` populated from hardware.
+    pub fn new(base_addr: usize, max_cpus: CpuId) -> Self {
+        // Read AIC_INFO to get number of hardware IRQs
+        let info = unsafe { mmio::read32(base_addr + AIC_INFO) };
+        let num_irqs = info & 0xFFFF; // bits [15:0] = NR_HW
+
+        crate::early_println!(
+            "[AIC] new: base_addr={:#x}, num_irqs={}, max_cpus={}",
+            base_addr,
+            num_irqs,
+            max_cpus
+        );
+
+        Self {
+            base_addr,
+            num_irqs,
+            max_cpus: max_cpus.min(AIC_MAX_CPUS),
+        }
+    }
+
+    /// Get the address of a register.
+    #[inline]
+    fn reg_addr(&self, offset: usize) -> usize {
+        self.base_addr + offset
+    }
+
+    /// Validate an interrupt ID.
+    ///
+    /// AIC IRQs are 0-indexed, so valid IDs are 0..num_irqs.
+    fn validate_interrupt_id(&self, interrupt_id: InterruptId) -> InterruptResult<()> {
+        if interrupt_id >= self.num_irqs {
+            Err(InterruptError::InvalidInterruptId)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Validate a CPU ID.
+    fn validate_cpu_id(&self, cpu_id: CpuId) -> InterruptResult<()> {
+        if cpu_id >= self.max_cpus {
+            Err(InterruptError::InvalidCpuId)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Initialize the AIC hardware.
+    ///
+    /// - Masks all IRQs
+    /// - Clears all software triggers
+    /// - Sets default CPU affinity (CPU 0)
+    /// - Masks IPIs initially
+    fn init_hw(&self) {
+        // Calculate number of mask registers needed
+        let num_mask_regs = ((self.num_irqs as usize) + 31) / 32;
+
+        // Mask all IRQs
+        for i in 0..num_mask_regs {
+            unsafe {
+                mmio::write32(self.reg_addr(AIC_MASK_SET + i * 4), 0xFFFF_FFFF);
+            }
+        }
+
+        // Clear all software triggers
+        for i in 0..num_mask_regs {
+            unsafe {
+                mmio::write32(self.reg_addr(AIC_SW_CLR + i * 4), 0xFFFF_FFFF);
+            }
+        }
+
+        for irq in 0..self.num_irqs {
+            unsafe {
+                mmio::write32(self.reg_addr(AIC_TARGET_CPU + irq as usize * 4), 1);
+            }
+        }
+
+        // Mask IPIs initially (will be unmasked when needed)
+        unsafe {
+            mmio::write32(
+                self.reg_addr(AIC_IPI_MASK_SET),
+                AIC_IPI_SELF | AIC_IPI_OTHER,
+            );
+        }
+
+        // Ack any pending IPIs
+        unsafe {
+            mmio::write32(self.reg_addr(AIC_IPI_ACK), AIC_IPI_SELF | AIC_IPI_OTHER);
+        }
+
+        crate::early_println!(
+            "[AIC] init_hw: masked {} IRQs, cleared software triggers",
+            self.num_irqs
+        );
+    }
+
+    // =========================================================================
+    // IPI Support Methods
+    // =========================================================================
+
+    /// Send an IPI to a specific CPU.
+    ///
+    /// # Arguments
+    ///
+    /// * `target_cpu` - CPU ID to send the IPI to
+    pub fn send_ipi(&self, target_cpu: CpuId) {
+        if target_cpu >= self.max_cpus {
+            return;
+        }
+        let bit = AIC_IPI_SEND_CPU(target_cpu);
+        unsafe {
+            mmio::write32(self.reg_addr(AIC_IPI_SEND), bit);
+        }
+    }
+
+    /// Send a "self" IPI to the current CPU.
+    pub fn send_ipi_self(&self) {
+        unsafe {
+            mmio::write32(self.reg_addr(AIC_IPI_SEND), AIC_IPI_SELF);
+        }
+    }
+
+    /// Acknowledge pending IPIs.
+    ///
+    /// Returns the IPI bits that were pending.
+    pub fn ack_ipi(&self) -> u32 {
+        unsafe {
+            let pending = mmio::read32(self.reg_addr(AIC_IPI_ACK));
+            mmio::write32(self.reg_addr(AIC_IPI_ACK), pending);
+            pending
+        }
+    }
+
+    /// Unmask IPIs for the current CPU.
+    pub fn unmask_ipis(&self) {
+        unsafe {
+            mmio::write32(
+                self.reg_addr(AIC_IPI_MASK_CLR),
+                AIC_IPI_SELF | AIC_IPI_OTHER,
+            );
+        }
+    }
+
+    /// Mask IPIs for the current CPU.
+    pub fn mask_ipis(&self) {
+        unsafe {
+            mmio::write32(
+                self.reg_addr(AIC_IPI_MASK_SET),
+                AIC_IPI_SELF | AIC_IPI_OTHER,
+            );
+        }
+    }
+
+    /// Get the current CPU ID from AIC_WHOAMI.
+    pub fn whoami(&self) -> CpuId {
+        unsafe { mmio::read32(self.reg_addr(AIC_WHOAMI)) }
+    }
+}
+
+/// Helper to create CPU bit for IPI send register.
+const fn AIC_IPI_SEND_CPU(cpu: CpuId) -> u32 {
+    1u32 << cpu
+}
+
+// =============================================================================
+// ExternalInterruptController Trait Implementation
+// =============================================================================
+
+impl ExternalInterruptController for Aic {
+    /// Initialize the AIC.
+    fn init(&mut self) -> InterruptResult<()> {
+        crate::early_println!("[AIC] init: initializing hardware...");
+
+        // Initialize hardware
+        self.init_hw();
+
+        // Verify CPU ID matches
+        let cpu_id = self.whoami();
+        crate::early_println!("[AIC] init: WHOAMI={}", cpu_id);
+
+        Ok(())
+    }
+
+    /// Enable a specific interrupt for a CPU.
+    ///
+    /// This sets the CPU affinity and unmasks the IRQ.
+    fn enable_interrupt(
+        &mut self,
+        interrupt_id: InterruptId,
+        cpu_id: CpuId,
+    ) -> InterruptResult<()> {
+        self.validate_interrupt_id(interrupt_id)?;
+        self.validate_cpu_id(cpu_id)?;
+
+        // Set CPU affinity
+        let target_addr = self.reg_addr(AIC_TARGET_CPU + interrupt_id as usize * 4);
+        unsafe {
+            mmio::write32(target_addr, 1 << cpu_id);
+        }
+
+        // Unmask the IRQ
+        let mask_addr = self.reg_addr(AIC_MASK_CLR + mask_reg(interrupt_id));
+        unsafe {
+            mmio::write32(mask_addr, mask_bit(interrupt_id));
+        }
+
+        Ok(())
+    }
+
+    /// Disable a specific interrupt for a CPU.
+    fn disable_interrupt(
+        &mut self,
+        interrupt_id: InterruptId,
+        _cpu_id: CpuId,
+    ) -> InterruptResult<()> {
+        self.validate_interrupt_id(interrupt_id)?;
+
+        // Mask the IRQ
+        let mask_addr = self.reg_addr(AIC_MASK_SET + mask_reg(interrupt_id));
+        unsafe {
+            mmio::write32(mask_addr, mask_bit(interrupt_id));
+        }
+
+        Ok(())
+    }
+
+    /// Set priority for a specific interrupt.
+    ///
+    /// AIC has automatic prioritization (lower IRQ = higher priority).
+    /// This is a no-op that always succeeds.
+    fn set_priority(
+        &mut self,
+        interrupt_id: InterruptId,
+        _priority: Priority,
+    ) -> InterruptResult<()> {
+        self.validate_interrupt_id(interrupt_id)?;
+        // AIC has automatic prioritization, no per-IRQ priority registers
+        Ok(())
+    }
+
+    /// Get priority for a specific interrupt.
+    ///
+    /// Returns 0 since AIC has automatic prioritization.
+    fn get_priority(&self, interrupt_id: InterruptId) -> InterruptResult<Priority> {
+        self.validate_interrupt_id(interrupt_id)?;
+        // AIC has automatic prioritization, return 0 as default
+        Ok(0)
+    }
+
+    /// Set priority threshold for a CPU.
+    ///
+    /// AIC does not support priority thresholds.
+    /// This is a no-op that always succeeds.
+    fn set_threshold(&mut self, cpu_id: CpuId, _threshold: Priority) -> InterruptResult<()> {
+        self.validate_cpu_id(cpu_id)?;
+        // AIC does not support priority thresholds
+        Ok(())
+    }
+
+    /// Get priority threshold for a CPU.
+    ///
+    /// Returns 0 since AIC does not support priority thresholds.
+    fn get_threshold(&self, cpu_id: CpuId) -> InterruptResult<Priority> {
+        self.validate_cpu_id(cpu_id)?;
+        // AIC does not support priority thresholds
+        Ok(0)
+    }
+
+    /// Claim an interrupt (acknowledge and get the interrupt ID).
+    ///
+    /// Reads the AIC_EVENT register to determine the interrupt type and number.
+    /// For hardware IRQs, returns the interrupt ID.
+    /// For IPIs, acknowledges them internally and returns None.
+    fn claim_interrupt(&mut self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>> {
+        self.validate_cpu_id(cpu_id)?;
+
+        // Read the event register
+        let event = unsafe { mmio::read32(self.reg_addr(AIC_EVENT)) };
+
+        // Extract event type and number
+        let event_type = (event >> 16) & 0xFFFF;
+        let event_num = event & 0xFFFF;
+
+        match event_type {
+            AIC_EVENT_TYPE_HW => {
+                // Hardware IRQ - the IRQ is auto-masked by hardware
+                Ok(Some(event_num))
+            }
+            AIC_EVENT_TYPE_IPI => {
+                // IPI - acknowledge it internally
+                match event_num {
+                    AIC_EVENT_IPI_OTHER | AIC_EVENT_IPI_SELF => {
+                        // Ack the IPI
+                        unsafe {
+                            let ack_bit = if event_num == AIC_EVENT_IPI_OTHER {
+                                AIC_IPI_OTHER
+                            } else {
+                                AIC_IPI_SELF
+                            };
+                            mmio::write32(self.reg_addr(AIC_IPI_ACK), ack_bit);
+                            // Unmask the IPI to allow future IPIs
+                            mmio::write32(self.reg_addr(AIC_IPI_MASK_CLR), ack_bit);
+                        }
+                    }
+                    _ => {}
+                }
+                Ok(None)
+            }
+            AIC_EVENT_TYPE_NONE | _ => {
+                // No event or unknown type
+                Ok(None)
+            }
+        }
+    }
+
+    /// Complete an interrupt (signal that handling is finished).
+    ///
+    /// AIC auto-masks IRQs on delivery. To "complete" the interrupt,
+    /// we unmask it to re-enable future occurrences.
+    fn complete_interrupt(
+        &mut self,
+        cpu_id: CpuId,
+        interrupt_id: InterruptId,
+    ) -> InterruptResult<()> {
+        self.validate_cpu_id(cpu_id)?;
+        self.validate_interrupt_id(interrupt_id)?;
+
+        // Unmask the IRQ to re-enable it
+        let mask_addr = self.reg_addr(AIC_MASK_CLR + mask_reg(interrupt_id));
+        unsafe {
+            mmio::write32(mask_addr, mask_bit(interrupt_id));
+        }
+
+        Ok(())
+    }
+
+    /// Check if a specific interrupt is pending.
+    ///
+    /// Note: AIC does not have a dedicated pending register like GIC.
+    /// AIC is event-driven - use claim_interrupt() to discover pending events.
+    /// This implementation conservatively returns false.
+    fn is_pending(&self, interrupt_id: InterruptId) -> bool {
+        if self.validate_interrupt_id(interrupt_id).is_err() {
+            return false;
+        }
+        // AIC is event-driven without a dedicated pending register.
+        // Return false conservatively - use claim_interrupt() to discover events.
+        false
+    }
+
+    /// Get the maximum number of interrupts supported.
+    fn max_interrupts(&self) -> InterruptId {
+        self.num_irqs
+    }
+
+    /// Get the number of CPUs supported.
+    fn max_cpus(&self) -> CpuId {
+        self.max_cpus
+    }
+}
+
+// =============================================================================
+// Safety: AIC can be sent between threads safely
+// =============================================================================
+
+unsafe impl Send for Aic {}
+unsafe impl Sync for Aic {}
+
+// =============================================================================
+// Platform Device Driver Registration
+// =============================================================================
+
+/// Probe function for AIC platform device.
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    crate::early_println!("[AIC] probe: probing device {}", device.name());
+
+    // Get memory resources
+    let mem_resources: alloc::vec::Vec<_> = device
+        .get_resources()
+        .iter()
+        .filter(|r| matches!(r.res_type, PlatformDeviceResourceType::MEM))
+        .collect();
+
+    let paddr = mem_resources
+        .get(0)
+        .map(|r| r.start)
+        .ok_or("No memory resource found for AIC")?;
+    let size = mem_resources
+        .get(0)
+        .map(|r| r.end - r.start + 1)
+        .unwrap_or(0x8000);
+
+    crate::early_println!(
+        "[AIC] probe: physical address={:#x}, size={:#x}",
+        paddr,
+        size
+    );
+
+    // Map the AIC MMIO region
+    let base_addr = crate::vm::ioremap(paddr, size).map_err(|e| {
+        crate::early_println!("[AIC] probe: ioremap failed: {}", e);
+        e
+    })?;
+
+    crate::early_println!("[AIC] probe: mapped to virtual address={:#x}", base_addr);
+
+    // Determine max_cpus from environment
+    let max_cpus = crate::environment::MAX_NUM_CPUS as CpuId;
+
+    crate::early_println!("[AIC] probe: max_cpus={}", max_cpus);
+
+    let aic = Box::new(Aic::new(base_addr, max_cpus));
+
+    // Register with interrupt manager
+    match InterruptManager::with_manager(|manager| {
+        manager
+            .register_external_controller(aic)
+            .map_err(|_| "Failed to register AIC")
+    }) {
+        Ok(()) => {
+            crate::early_println!("[AIC] probe: AIC registered successfully");
+            Ok(())
+        }
+        Err(e) => {
+            crate::early_println!("[AIC] probe: registration failed: {}", e);
+            // Clean up the ioremap
+            crate::vm::iounmap(base_addr);
+            Err(e)
+        }
+    }
+}
+
+/// Remove function for AIC platform device.
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    // Nothing to clean up currently
+    Ok(())
+}
+
+/// Register the AIC driver with the device manager.
+fn register_driver() {
+    crate::early_println!("[AIC] register_driver: registering AIC driver");
+
+    let driver = PlatformDeviceDriver::new(
+        "apple,aic",
+        probe_fn,
+        remove_fn,
+        alloc::vec![
+            "apple,aic",
+            "apple,t8103-aic",
+            "apple,t6000-aic",
+            "apple,t8112-aic",
+        ],
+    );
+
+    DeviceManager::get_manager().register_driver(Box::new(driver), DriverPriority::Critical);
+}
+
+early_initcall!(register_driver);
+
+// =============================================================================
+// Unit Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test_case]
+    fn test_mask_reg_calculation() {
+        // First register (IRQs 0-31)
+        assert_eq!(mask_reg(0), 0);
+        assert_eq!(mask_reg(1), 0);
+        assert_eq!(mask_reg(31), 0);
+
+        // Second register (IRQs 32-63)
+        assert_eq!(mask_reg(32), 4);
+        assert_eq!(mask_reg(63), 4);
+
+        // Third register (IRQs 64-95)
+        assert_eq!(mask_reg(64), 8);
+        assert_eq!(mask_reg(95), 8);
+
+        // IRQ 895 (in word 27)
+        assert_eq!(mask_reg(895), 4 * 27);
+    }
+
+    #[test_case]
+    fn test_mask_bit_calculation() {
+        assert_eq!(mask_bit(0), 1);
+        assert_eq!(mask_bit(1), 2);
+        assert_eq!(mask_bit(2), 4);
+        assert_eq!(mask_bit(31), 1 << 31);
+
+        // Wraps to bit 0 of next word
+        assert_eq!(mask_bit(32), 1);
+        assert_eq!(mask_bit(33), 2);
+        assert_eq!(mask_bit(63), 1 << 31);
+    }
+
+    #[test_case]
+    fn test_event_type_extraction() {
+        // Simulate AIC_EVENT register values
+        let hw_event: u32 = (AIC_EVENT_TYPE_HW << 16) | 42;
+        assert_eq!((hw_event >> 16) & 0xFFFF, AIC_EVENT_TYPE_HW);
+        assert_eq!(hw_event & 0xFFFF, 42);
+
+        let ipi_event: u32 = (AIC_EVENT_TYPE_IPI << 16) | AIC_EVENT_IPI_OTHER;
+        assert_eq!((ipi_event >> 16) & 0xFFFF, AIC_EVENT_TYPE_IPI);
+        assert_eq!(ipi_event & 0xFFFF, AIC_EVENT_IPI_OTHER);
+
+        let no_event: u32 = 0;
+        assert_eq!((no_event >> 16) & 0xFFFF, AIC_EVENT_TYPE_NONE);
+    }
+
+    #[test_case]
+    fn test_ipi_send_cpu_bit() {
+        assert_eq!(AIC_IPI_SEND_CPU(0), 1);
+        assert_eq!(AIC_IPI_SEND_CPU(1), 2);
+        assert_eq!(AIC_IPI_SEND_CPU(2), 4);
+        assert_eq!(AIC_IPI_SEND_CPU(30), 1u32 << 30);
+    }
+}

--- a/kernel/src/drivers/pic/aic.rs
+++ b/kernel/src/drivers/pic/aic.rs
@@ -575,6 +575,10 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
             .map_err(|_| "Failed to register AIC")
     }) {
         Ok(()) => {
+            crate::arch::interrupt::configure_timer_interrupt_route(
+                crate::arch::interrupt::TimerInterruptRoute::FastInterrupt,
+                None,
+            );
             crate::early_println!("[AIC] probe: AIC registered successfully");
             Ok(())
         }

--- a/kernel/src/drivers/pic/aic.rs
+++ b/kernel/src/drivers/pic/aic.rs
@@ -45,7 +45,7 @@ const AIC_INFO: usize = 0x0004;
 const AIC_CONFIG: usize = 0x0010;
 /// AIC WHOAMI register - returns current CPU ID
 const AIC_WHOAMI: usize = 0x2000;
-/// AIC Event register - event type in [31:16], event number in [15:0]
+/// AIC Event register - DIE in [31:24], type in [23:16], number in [15:0]
 const AIC_EVENT: usize = 0x2004;
 /// AIC IPI Send register
 const AIC_IPI_SEND: usize = 0x2008;
@@ -323,6 +323,10 @@ impl ExternalInterruptController for Aic {
         let cpu_id = self.whoami();
         crate::early_println!("[AIC] init: WHOAMI={}", cpu_id);
 
+        // Unmask IPIs for the current CPU so they can be delivered
+        self.unmask_ipis();
+        crate::early_println!("[AIC] init: IPIs unmasked for CPU {}", cpu_id);
+
         Ok(())
     }
 
@@ -423,8 +427,16 @@ impl ExternalInterruptController for Aic {
         let event = unsafe { mmio::read32(self.reg_addr(AIC_EVENT)) };
 
         // Extract event type and number
-        let event_type = (event >> 16) & 0xFFFF;
+        // EVENT format: [31:24]=DIE, [23:16]=TYPE, [15:0]=NUMBER
+        let event_die = (event >> 24) & 0xFF;
+        let event_type = (event >> 16) & 0xFF;
         let event_num = event & 0xFFFF;
+
+        // For AIC v1 (single-die), DIE should always be 0
+        // If DIE is non-zero on v1 hardware, treat as spurious
+        if event_die != 0 {
+            return Ok(None);
+        }
 
         match event_type {
             AIC_EVENT_TYPE_HW => {

--- a/kernel/src/drivers/pic/gic.rs
+++ b/kernel/src/drivers/pic/gic.rs
@@ -523,6 +523,11 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
         Ok(())
     })?;
 
+    crate::arch::interrupt::configure_timer_interrupt_route(
+        crate::arch::interrupt::TimerInterruptRoute::ExternalControllerIrq,
+        Some(crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ),
+    );
+
     Ok(())
 }
 

--- a/kernel/src/drivers/pic/gicv3.rs
+++ b/kernel/src/drivers/pic/gicv3.rs
@@ -503,6 +503,11 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
         Ok(())
     })?;
 
+    crate::arch::interrupt::configure_timer_interrupt_route(
+        crate::arch::interrupt::TimerInterruptRoute::ExternalControllerIrq,
+        Some(crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ),
+    );
+
     Ok(())
 }
 

--- a/kernel/src/drivers/pic/mod.rs
+++ b/kernel/src/drivers/pic/mod.rs
@@ -5,6 +5,8 @@
 
 // pub mod clint; // Currently not used
 #[cfg(target_arch = "aarch64")]
+pub mod aic;
+#[cfg(target_arch = "aarch64")]
 pub mod arm_generic_timer;
 #[cfg(target_arch = "aarch64")]
 pub mod gic;
@@ -15,6 +17,8 @@ pub mod plic;
 #[cfg(target_arch = "riscv64")]
 pub mod sbi_clint;
 
+#[cfg(target_arch = "aarch64")]
+pub use aic::Aic;
 #[cfg(target_arch = "aarch64")]
 pub use gic::Gic;
 #[cfg(target_arch = "aarch64")]

--- a/kernel/src/drivers/uart/mod.rs
+++ b/kernel/src/drivers/uart/mod.rs
@@ -1,3 +1,5 @@
 #[cfg(target_arch = "aarch64")]
 pub mod pl011;
+#[cfg(target_arch = "aarch64")]
+pub mod s5l_uart;
 pub mod virt;

--- a/kernel/src/drivers/uart/s5l_uart.rs
+++ b/kernel/src/drivers/uart/s5l_uart.rs
@@ -370,6 +370,14 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
             crate::early_println!("[S5L] probe: failed to enable interrupts: {}", e);
         } else {
             crate::early_println!("[S5L] probe: interrupts enabled");
+
+            if let Err(e) = InterruptManager::with_manager(|mgr| {
+                mgr.register_interrupt_device(interrupt_id, uart.clone())
+            }) {
+                crate::early_println!("[S5L] probe: failed to register interrupt device: {}", e);
+            } else {
+                crate::early_println!("[S5L] probe: interrupt device registered");
+            }
         }
     } else {
         crate::early_println!("[S5L] probe: no interrupt resource, polling mode");

--- a/kernel/src/drivers/uart/s5l_uart.rs
+++ b/kernel/src/drivers/uart/s5l_uart.rs
@@ -1,0 +1,401 @@
+//! Apple S5L UART driver for Apple Silicon platforms
+//!
+//! This UART is based on Samsung's S3C/S5L UART design, used in Apple SoCs.
+//! It differs from PL011 in register layout and interrupt handling.
+//!
+//! Reference: Linux kernel drivers/tty/serial/samsung_tty.c
+
+use alloc::{boxed::Box, collections::VecDeque, sync::Arc, vec};
+use core::fmt;
+use spin::{Mutex, RwLock};
+
+use crate::{
+    arch::mmio,
+    device::{
+        Device, DeviceCapability, DeviceInfo, DeviceType,
+        char::CharDevice,
+        events::{
+            DeviceEventEmitter, DeviceEventListener, EventCapableDevice, InputEvent,
+            InterruptCapableDevice,
+        },
+        manager::{DeviceManager, DriverPriority},
+        platform::{
+            PlatformDeviceDriver, PlatformDeviceInfo, resource::PlatformDeviceResourceType,
+        },
+    },
+    driver_initcall,
+    interrupt::{InterruptId, InterruptManager, InterruptResult},
+    object::capability::{ControlOps, MemoryMappingOps, Selectable},
+    traits::serial::Serial,
+};
+
+// =============================================================================
+// S5L UART Register Offsets
+// =============================================================================
+
+const ULCON: usize = 0x000; // Line Control Register
+const UCON: usize = 0x004; // Control Register
+const UFCON: usize = 0x008; // FIFO Control Register
+const UMCON: usize = 0x00C; // Modem Control Register
+const UTRSTAT: usize = 0x010; // TX/RX Status Register
+const UERSTAT: usize = 0x014; // Error Status Register
+const UFSTAT: usize = 0x018; // FIFO Status Register
+const UMSTAT: usize = 0x01C; // Modem Status Register
+const UTXH: usize = 0x020; // TX Holding Register (write)
+const URXH: usize = 0x024; // RX Holding Register (read)
+const UBRDIV: usize = 0x028; // Baud Rate Divisor Register
+const UFRACVAL: usize = 0x02C; // Fractional Baud Rate Register
+
+// =============================================================================
+// UCON (Control Register) bits
+// =============================================================================
+
+const UCON_TXTHRESH_ENA: u32 = 1 << 13;
+const UCON_RXTHRESH_ENA: u32 = 1 << 12;
+const UCON_RXTO_ENA: u32 = 1 << 9;
+const UCON_TXMODE_MASK: u32 = 0x0C;
+const UCON_RXMODE_MASK: u32 = 0x03;
+const UCON_MODE_IRQ: u32 = 1;
+
+// =============================================================================
+// UTRSTAT (TX/RX Status Register) bits
+// =============================================================================
+
+const UTRSTAT_RXTO: u32 = 1 << 9;
+const UTRSTAT_TXTHRESH: u32 = 1 << 5;
+const UTRSTAT_RXTHRESH: u32 = 1 << 4;
+const UTRSTAT_TXE: u32 = 1 << 2;
+const UTRSTAT_TXBE: u32 = 1 << 1;
+const UTRSTAT_RXD: u32 = 1 << 0;
+
+// =============================================================================
+// UFSTAT (FIFO Status Register) bits
+// =============================================================================
+
+const UFSTAT_TXFULL: u32 = 1 << 9;
+const UFSTAT_RXFULL: u32 = 1 << 8;
+const UFSTAT_TXCNT_SHIFT: u32 = 4;
+const UFSTAT_TXCNT_MASK: u32 = 0xF0;
+const UFSTAT_RXCNT_MASK: u32 = 0x0F;
+
+// =============================================================================
+// S5L UART Device
+// =============================================================================
+
+static S5L_CAPS: [DeviceCapability; 1] = [DeviceCapability::Serial];
+
+pub struct S5lUart {
+    base: usize,
+    interrupt_id: RwLock<Option<InterruptId>>,
+    rx_buffer: Mutex<VecDeque<u8>>,
+    event_emitter: Mutex<DeviceEventEmitter>,
+}
+
+impl S5lUart {
+    pub fn new(base: usize) -> Self {
+        S5lUart {
+            base,
+            interrupt_id: RwLock::new(None),
+            rx_buffer: Mutex::new(VecDeque::new()),
+            event_emitter: Mutex::new(DeviceEventEmitter::new()),
+        }
+    }
+
+    pub fn init(&self) {
+        let ucon = (UCON_MODE_IRQ << 2) | UCON_MODE_IRQ;
+        self.reg_write(UCON, ucon);
+
+        self.reg_write(UFCON, 0x07);
+
+        self.reg_write(ULCON, 0x03);
+
+        self.reg_write(UBRDIV, 13);
+        self.reg_write(UFRACVAL, 1);
+    }
+
+    pub fn enable_interrupts(&self, interrupt_id: InterruptId) -> Result<(), &'static str> {
+        self.interrupt_id.write().replace(interrupt_id);
+
+        let ucon = self.reg_read(UCON);
+        self.reg_write(UCON, ucon | UCON_RXTHRESH_ENA | UCON_RXTO_ENA);
+
+        InterruptManager::with_manager(|mgr| mgr.enable_external_interrupt(interrupt_id, 0))
+            .map_err(|_| "Failed to enable interrupt")?;
+
+        Ok(())
+    }
+
+    fn reg_write(&self, offset: usize, value: u32) {
+        let addr = self.base + offset;
+        unsafe { mmio::write32(addr, value) }
+    }
+
+    fn reg_read(&self, offset: usize) -> u32 {
+        let addr = self.base + offset;
+        unsafe { mmio::read32(addr) }
+    }
+
+    fn write_byte_internal(&self, byte: u8) {
+        while self.reg_read(UFSTAT) & UFSTAT_TXFULL != 0 {
+            core::hint::spin_loop();
+        }
+        self.reg_write(UTXH, byte as u32);
+    }
+
+    fn read_byte_internal(&self) -> Option<u8> {
+        let ufstat = self.reg_read(UFSTAT);
+        if ufstat & UFSTAT_RXCNT_MASK != 0 {
+            let data = self.reg_read(URXH);
+            Some(data as u8)
+        } else {
+            None
+        }
+    }
+
+    fn can_read(&self) -> bool {
+        !self.rx_buffer.lock().is_empty()
+    }
+
+    fn can_write_hw(&self) -> bool {
+        self.reg_read(UFSTAT) & UFSTAT_TXFULL == 0
+    }
+}
+
+impl Serial for S5lUart {
+    fn put(&self, c: char) -> fmt::Result {
+        self.write_byte_internal(c as u8);
+        Ok(())
+    }
+
+    fn get(&self) -> Option<char> {
+        let mut buffer = self.rx_buffer.lock();
+        if let Some(byte) = buffer.pop_front() {
+            return Some(byte as char);
+        }
+        None
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+        self
+    }
+}
+
+impl fmt::Write for S5lUart {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.chars() {
+            if c == '\n' {
+                self.put('\r')?;
+            }
+            self.put(c)?;
+        }
+        Ok(())
+    }
+}
+
+impl MemoryMappingOps for S5lUart {
+    fn get_mapping_info(
+        &self,
+        _offset: usize,
+        _length: usize,
+    ) -> Result<(usize, usize, bool), &'static str> {
+        Err("Memory mapping not supported for UART")
+    }
+
+    fn on_mapped(&self, _vaddr: usize, _paddr: usize, _length: usize, _offset: usize) {}
+    fn on_unmapped(&self, _vaddr: usize, _length: usize) {}
+
+    fn supports_mmap(&self) -> bool {
+        false
+    }
+}
+
+impl Device for S5lUart {
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Char
+    }
+
+    fn name(&self) -> &'static str {
+        "s5l-uart"
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+        self
+    }
+
+    fn as_char_device(&self) -> Option<&dyn CharDevice> {
+        Some(self)
+    }
+
+    fn capabilities(&self) -> &'static [DeviceCapability] {
+        &S5L_CAPS
+    }
+
+    fn as_event_capable(&self) -> Option<&dyn EventCapableDevice> {
+        Some(self)
+    }
+}
+
+impl CharDevice for S5lUart {
+    fn read_byte(&self) -> Option<u8> {
+        self.rx_buffer.lock().pop_front()
+    }
+
+    fn write_byte(&self, byte: u8) -> Result<(), &'static str> {
+        self.write_byte_internal(byte);
+        Ok(())
+    }
+
+    fn can_read(&self) -> bool {
+        self.can_read()
+    }
+
+    fn can_write(&self) -> bool {
+        self.can_write_hw()
+    }
+}
+
+impl ControlOps for S5lUart {
+    fn control(&self, _command: u32, _arg: usize) -> Result<i32, &'static str> {
+        Err("Control operations not supported")
+    }
+}
+
+impl EventCapableDevice for S5lUart {
+    fn register_event_listener(&self, listener: alloc::sync::Weak<dyn DeviceEventListener>) {
+        self.event_emitter.lock().register_listener(listener);
+    }
+
+    fn unregister_event_listener(&self, _listener_id: &str) {}
+
+    fn emit_event(&self, event: &dyn crate::device::events::DeviceEvent) {
+        self.event_emitter.lock().emit(event);
+    }
+}
+
+impl InterruptCapableDevice for S5lUart {
+    fn handle_interrupt(&self) -> InterruptResult<()> {
+        let utrstat = self.reg_read(UTRSTAT);
+
+        if utrstat & (UTRSTAT_RXTHRESH | UTRSTAT_RXTO) != 0 {
+            let mut count = 0;
+            while let Some(c) = self.read_byte_internal() {
+                self.emit_event(&InputEvent { data: c });
+                self.rx_buffer.lock().push_back(c);
+                count += 1;
+
+                if count > 128 {
+                    crate::early_println!("[S5L] Warning: read limit reached in interrupt handler");
+                    break;
+                }
+            }
+
+            self.reg_write(UTRSTAT, UTRSTAT_RXTHRESH | UTRSTAT_RXTO);
+        }
+
+        if utrstat & UTRSTAT_TXTHRESH != 0 {
+            self.reg_write(UTRSTAT, UTRSTAT_TXTHRESH);
+        }
+
+        Ok(())
+    }
+
+    fn interrupt_id(&self) -> Option<InterruptId> {
+        self.interrupt_id.read().clone()
+    }
+}
+
+impl Selectable for S5lUart {
+    fn wait_until_ready(
+        &self,
+        _interest: crate::object::capability::selectable::ReadyInterest,
+        _trapframe: &mut crate::arch::Trapframe,
+        _timeout_ticks: Option<u64>,
+    ) -> crate::object::capability::selectable::SelectWaitOutcome {
+        crate::object::capability::selectable::SelectWaitOutcome::Ready
+    }
+}
+
+unsafe impl Send for S5lUart {}
+unsafe impl Sync for S5lUart {}
+
+// =============================================================================
+// Platform Device Driver Registration
+// =============================================================================
+
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    crate::early_println!("[S5L] probe: probing device {}", device.name());
+
+    let mem_resources: alloc::vec::Vec<_> = device
+        .get_resources()
+        .iter()
+        .filter(|r| matches!(r.res_type, PlatformDeviceResourceType::MEM))
+        .collect();
+
+    let paddr = mem_resources
+        .get(0)
+        .map(|r| r.start)
+        .ok_or("No memory resource found for S5L UART")?;
+    let size = mem_resources
+        .get(0)
+        .map(|r| r.end - r.start + 1)
+        .unwrap_or(0x1000);
+
+    crate::early_println!("[S5L] probe: paddr={:#x}, size={:#x}", paddr, size);
+
+    let base_addr = crate::vm::ioremap(paddr, size).map_err(|e| {
+        crate::early_println!("[S5L] probe: ioremap failed: {}", e);
+        e
+    })?;
+
+    crate::early_println!("[S5L] probe: mapped to {:#x}", base_addr);
+
+    let uart = Arc::new(S5lUart::new(base_addr));
+    uart.init();
+
+    let irq_resources: alloc::vec::Vec<_> = device
+        .get_resources()
+        .iter()
+        .filter(|r| matches!(r.res_type, PlatformDeviceResourceType::IRQ))
+        .collect();
+
+    if let Some(irq_res) = irq_resources.get(0) {
+        let interrupt_id = irq_res.start as InterruptId;
+        crate::early_println!("[S5L] probe: interrupt ID={}", interrupt_id);
+
+        if let Err(e) = uart.enable_interrupts(interrupt_id) {
+            crate::early_println!("[S5L] probe: failed to enable interrupts: {}", e);
+        } else {
+            crate::early_println!("[S5L] probe: interrupts enabled");
+        }
+    } else {
+        crate::early_println!("[S5L] probe: no interrupt resource, polling mode");
+    }
+
+    let device_id = DeviceManager::get_manager().register_device(uart);
+    crate::early_println!("[S5L] probe: device registered with ID={}", device_id);
+
+    Ok(())
+}
+
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    Ok(())
+}
+
+fn register_s5l_uart() {
+    crate::early_println!("[S5L] register_driver: registering S5L UART driver");
+
+    let driver = Box::new(PlatformDeviceDriver::new(
+        "s5l-uart-driver",
+        probe_fn,
+        remove_fn,
+        vec!["apple,s5l-uart"],
+    ));
+
+    DeviceManager::get_manager().register_driver(driver, DriverPriority::Core);
+}
+
+driver_initcall!(register_s5l_uart);

--- a/kernel/src/drivers/watchdog/apple_wdt.rs
+++ b/kernel/src/drivers/watchdog/apple_wdt.rs
@@ -1,0 +1,94 @@
+use alloc::boxed::Box;
+
+use crate::{
+    arch::mmio,
+    device::{
+        DeviceInfo,
+        manager::{DeviceManager, DriverPriority},
+        platform::{
+            PlatformDeviceDriver, PlatformDeviceInfo, resource::PlatformDeviceResourceType,
+        },
+    },
+    driver_initcall, early_println,
+};
+
+const APPLE_WDT_WD1_CTRL: usize = 0x1c;
+
+struct AppleWdt {
+    base_addr: usize,
+}
+
+impl AppleWdt {
+    const fn new(base_addr: usize) -> Self {
+        Self { base_addr }
+    }
+
+    #[inline]
+    fn ctrl_addr(&self) -> usize {
+        self.base_addr + APPLE_WDT_WD1_CTRL
+    }
+
+    fn disable(&self) {
+        // SAFETY: `base_addr` comes from an MMIO mapping of the watchdog register block.
+        // Writing 0 to WD1 CTRL is the documented disable sequence for Apple Silicon.
+        unsafe {
+            mmio::write32(self.ctrl_addr(), 0);
+        }
+
+        // SAFETY: Same mapped register block as above. Readback confirms the posted write.
+        let ctrl = unsafe { mmio::read32(self.ctrl_addr()) };
+        early_println!("[apple-wdt] WD1 control after disable = {:#x}", ctrl);
+    }
+}
+
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    let mem_resource = device
+        .get_resources()
+        .iter()
+        .find(|resource| matches!(resource.res_type, PlatformDeviceResourceType::MEM))
+        .ok_or("Apple watchdog: no memory resource found")?;
+
+    let paddr = mem_resource.start;
+    let size = mem_resource.end - mem_resource.start + 1;
+    early_println!(
+        "[apple-wdt] probe {} at paddr={:#x}, size={:#x}",
+        device.name(),
+        paddr,
+        size
+    );
+
+    let base_addr = crate::vm::ioremap(paddr, size).map_err(|e| {
+        early_println!("[apple-wdt] ioremap failed: {}", e);
+        e
+    })?;
+
+    let watchdog = AppleWdt::new(base_addr);
+    watchdog.disable();
+    crate::vm::iounmap(base_addr);
+
+    early_println!("[apple-wdt] watchdog disabled");
+    Ok(())
+}
+
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    Ok(())
+}
+
+fn register_driver() {
+    let driver = PlatformDeviceDriver::new(
+        "apple-wdt",
+        probe_fn,
+        remove_fn,
+        alloc::vec![
+            "apple,wdt",
+            "apple,t8103-wdt",
+            "apple,t8112-wdt",
+            "apple,t6000-wdt",
+            "apple,t6020-wdt",
+        ],
+    );
+
+    DeviceManager::get_manager().register_driver(Box::new(driver), DriverPriority::Critical);
+}
+
+driver_initcall!(register_driver);

--- a/kernel/src/drivers/watchdog/mod.rs
+++ b/kernel/src/drivers/watchdog/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(target_arch = "aarch64")]
+pub mod apple_wdt;

--- a/kernel/src/earlyfb.rs
+++ b/kernel/src/earlyfb.rs
@@ -182,6 +182,10 @@ impl FramebufferConsole {
 
 static EARLY_CONSOLE: Mutex<FramebufferConsole> = Mutex::new(FramebufferConsole::new());
 
+pub fn console_lock_addr() -> usize {
+    &EARLY_CONSOLE as *const _ as usize
+}
+
 pub fn init(framebuffer: &Framebuffer<'_>) {
     let mut console = EARLY_CONSOLE.lock();
     if console.initialized {

--- a/kernel/src/earlyfb.rs
+++ b/kernel/src/earlyfb.rs
@@ -220,19 +220,18 @@ pub fn deactivate() {
 ///
 /// # Arguments
 ///
+/// * `old_hhdm_base` - The bootloader's HHDM base address (from BootInfo.hhdm_offset)
 /// * `new_hhdm_base` - The new HHDM base address (e.g., `SCARLET_HHDM_BASE`)
-pub fn fixup_hhdm_offset(new_hhdm_base: usize) {
+pub fn fixup_hhdm_offset(old_hhdm_base: usize, new_hhdm_base: usize) {
     let mut console = EARLY_CONSOLE.lock();
     if !console.initialized || console.addr == 0 {
         return;
     }
 
-    let limine_hhdm_base = 0xffff_8000_0000_0000usize;
-
     if console.addr >= new_hhdm_base {
         return;
     }
 
-    let paddr = console.addr.saturating_sub(limine_hhdm_base);
+    let paddr = console.addr.saturating_sub(old_hhdm_base);
     console.addr = new_hhdm_base.saturating_add(paddr);
 }

--- a/kernel/src/earlyfb.rs
+++ b/kernel/src/earlyfb.rs
@@ -207,3 +207,8 @@ pub fn write_str(s: &str) {
 pub fn is_initialized() -> bool {
     EARLY_CONSOLE.lock().initialized
 }
+
+pub fn deactivate() {
+    let mut console = EARLY_CONSOLE.lock();
+    console.initialized = false;
+}

--- a/kernel/src/earlyfb.rs
+++ b/kernel/src/earlyfb.rs
@@ -212,3 +212,27 @@ pub fn deactivate() {
     let mut console = EARLY_CONSOLE.lock();
     console.initialized = false;
 }
+
+/// Update framebuffer address for the new HHDM offset after page table transition.
+///
+/// This should be called after `transition_kernel_memory_layout()` to update
+/// the framebuffer virtual address to use Scarlet's HHDM instead of Limine's.
+///
+/// # Arguments
+///
+/// * `new_hhdm_base` - The new HHDM base address (e.g., `SCARLET_HHDM_BASE`)
+pub fn fixup_hhdm_offset(new_hhdm_base: usize) {
+    let mut console = EARLY_CONSOLE.lock();
+    if !console.initialized || console.addr == 0 {
+        return;
+    }
+
+    let limine_hhdm_base = 0xffff_8000_0000_0000usize;
+
+    if console.addr >= new_hhdm_base {
+        return;
+    }
+
+    let paddr = console.addr.saturating_sub(limine_hhdm_base);
+    console.addr = new_hhdm_base.saturating_add(paddr);
+}

--- a/kernel/src/environment/common.rs
+++ b/kernel/src/environment/common.rs
@@ -15,6 +15,29 @@ pub const TASK_KERNEL_STACK_SIZE: usize = 0x10000;
 // Number of slots available for concurrent tasks
 pub const KERNEL_KSTACK_SLOTS: usize = 256;
 
+// Scarlet-owned HHDM base address.
+//
+// After boot, Scarlet builds its own page tables and direct-maps all physical
+// memory starting at this fixed virtual address, fully decoupled from whatever
+// offset the bootloader (Limine) originally chose.
+//
+// Layout (upper canonical half):
+//   0xffff_8000_0000_0000  SCARLET_HHDM_BASE   (direct map)
+//   0xffff_c000_0000_0000  IOREMAP              (1 GiB)
+//   0xffff_d000_0000_0000  KERNEL_HEAP_BASE     (512 MiB)
+//   0xffff_ffff_8000_0000  Kernel image         (linker-placed)
+//   top of VA space        Trampoline / kstack slots
+pub const SCARLET_HHDM_BASE: usize = 0xffff_8000_0000_0000;
+
+// Kernel heap virtual address base.
+//
+// The heap is mapped at a fixed VA independent of the HHDM, so it survives
+// the HHDM offset change during the boot page-table switch.
+pub const KERNEL_HEAP_BASE: usize = 0xffff_d000_0000_0000;
+
+// Initial kernel heap size (512 MiB).
+pub const KERNEL_HEAP_SIZE: usize = 512 * 1024 * 1024;
+
 // IOREMAP virtual address region for dynamic device MMIO mapping.
 //
 // Located in the gap between HHDM end (0xFFFF_BFFF_FFFF_FFFF) and the kernel

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -365,6 +365,17 @@ impl InterruptManager {
         }
     }
 
+    pub fn is_local_interrupt_pending(
+        &self,
+        cpu_id: CpuId,
+        interrupt_type: controllers::LocalInterruptType,
+    ) -> bool {
+        self.controllers
+            .local_controller_for_cpu(cpu_id)
+            .map(|controller| controller.is_pending(cpu_id, interrupt_type))
+            .unwrap_or(false)
+    }
+
     /// Register a local interrupt controller (e.g., CLINT) for specific CPUs
     pub fn register_local_controller(
         &mut self,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -316,7 +316,7 @@ use vm::{
 fn panic(info: &core::panic::PanicInfo) -> ! {
     use arch::instruction::idle;
 
-    crate::early_println!("[Scarlet Kernel] panic: {}", info);
+    crate::println!("[Scarlet Kernel] panic: {}", info);
 
     // if let Some(task) = get_scheduler().get_current_task(get_cpu().get_cpuid()) {
     //     task.exit(1); // Exit the task with error code 1

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -368,7 +368,7 @@ pub enum DeviceSource {
 /// #[no_mangle]
 /// pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
 ///     // Use boot_info for system initialization
-///     let memory = boot_info.usable_memory;
+///     let memory = boot_info.usable_memory_paddr;
 ///     let cpu_id = boot_info.cpu_id;
 ///     // ...
 /// }
@@ -380,12 +380,14 @@ pub struct BootInfo {
     /// Number of CPUs detected at runtime (from FDT)
     /// Used to drive SMP initialization and per-CPU resource sizing
     pub cpu_count: usize,
-    pub usable_memory: MemoryArea,
-    pub direct_map_area: MemoryArea,
-    pub usable_memory_phys: MemoryArea,
-    pub direct_map_area_phys: MemoryArea,
-    pub initramfs: Option<MemoryArea>,
-    pub initramfs_phys: Option<MemoryArea>,
+    /// Physical memory area available for PMM allocation (usable RAM excluding reserved regions)
+    pub usable_memory_paddr: MemoryArea,
+    /// Physical memory area to be mapped into HHDM (direct map)
+    pub direct_map_paddr: MemoryArea,
+    /// Optional initramfs physical memory area
+    pub initramfs_paddr: Option<MemoryArea>,
+    /// HHDM offset: hhdm_va = paddr + hhdm_offset
+    pub hhdm_offset: usize,
     /// Optional kernel command line parameters
     /// Boot arguments passed by bootloader for kernel configuration
     pub cmdline: Option<&'static str>,
@@ -400,8 +402,10 @@ impl BootInfo {
     /// # Arguments
     ///
     /// * `cpu_id` - ID of the boot processor/hart
-    /// * `usable_memory` - Memory area available for kernel allocation
-    /// * `initramfs` - Optional initramfs memory area
+    /// * `usable_memory_paddr` - Physical memory area for PMM allocation
+    /// * `direct_map_paddr` - Physical memory area to map into HHDM
+    /// * `initramfs_paddr` - Optional initramfs physical memory area
+    /// * `hhdm_offset` - HHDM offset for VA = PA + offset
     /// * `cmdline` - Optional kernel command line parameters
     /// * `device_source` - Source of device information for hardware discovery
     ///
@@ -411,24 +415,20 @@ impl BootInfo {
     pub fn new(
         cpu_id: usize,
         cpu_count: usize,
-        usable_memory: MemoryArea,
-        direct_map_area: MemoryArea,
-        usable_memory_phys: MemoryArea,
-        direct_map_area_phys: MemoryArea,
-        initramfs: Option<MemoryArea>,
-        initramfs_phys: Option<MemoryArea>,
+        usable_memory_paddr: MemoryArea,
+        direct_map_paddr: MemoryArea,
+        initramfs_paddr: Option<MemoryArea>,
+        hhdm_offset: usize,
         cmdline: Option<&'static str>,
         device_source: DeviceSource,
     ) -> Self {
         Self {
             cpu_id,
             cpu_count,
-            usable_memory,
-            direct_map_area,
-            usable_memory_phys,
-            direct_map_area_phys,
-            initramfs,
-            initramfs_phys,
+            usable_memory_paddr,
+            direct_map_paddr,
+            initramfs_paddr,
+            hhdm_offset,
             cmdline,
             device_source,
         }
@@ -452,14 +452,13 @@ impl BootInfo {
 
     /// Returns the initramfs memory area if available
     ///
-    /// The initramfs contains an initial root filesystem that can be used
-    /// during early boot before mounting the real root filesystem.
-    ///
-    /// # Returns
-    ///
-    /// Optional memory area containing the initramfs data
-    pub fn get_initramfs(&self) -> Option<MemoryArea> {
-        self.initramfs
+    pub fn get_initramfs_vaddr(&self) -> Option<MemoryArea> {
+        self.initramfs_paddr.map(|area| {
+            MemoryArea::new(
+                crate::vm::addr::phys_to_virt(area.start),
+                crate::vm::addr::phys_to_virt(area.end),
+            )
+        })
     }
 }
 
@@ -531,38 +530,37 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     early_println!("[Scarlet Kernel] Hello, I'm Scarlet kernel!");
     early_println!("[Scarlet Kernel] Boot on CPU {}", cpu_id);
     early_println!("[Scarlet Kernel] Detected {} CPU(s)", cpu_count);
-    /* Use usable memory area from BootInfo */
-    let usable_area = boot_info.usable_memory;
-    let direct_map_area = boot_info.direct_map_area;
-    let usable_area_phys = boot_info.usable_memory_phys;
-    let direct_map_area_phys = boot_info.direct_map_area_phys;
+    let usable_memory_paddr = boot_info.usable_memory_paddr;
+    let direct_map_paddr = boot_info.direct_map_paddr;
+    let hhdm_offset = boot_info.hhdm_offset;
     early_println!(
-        "[Scarlet Kernel] Usable memory area : {:#x} - {:#x}",
-        usable_area.start,
-        usable_area.end
+        "[Scarlet Kernel] Usable memory (PA) : {:#x} - {:#x}",
+        usable_memory_paddr.start,
+        usable_memory_paddr.end
     );
     early_println!(
-        "[Scarlet Kernel] Direct-map area    : {:#x} - {:#x}",
-        direct_map_area.start,
-        direct_map_area.end
+        "[Scarlet Kernel] Direct-map (PA)    : {:#x} - {:#x}",
+        direct_map_paddr.start,
+        direct_map_paddr.end
     );
+    early_println!("[Scarlet Kernel] HHDM offset       : {:#x}", hhdm_offset);
 
     /* Handle initramfs if available in BootInfo */
-    if let Some(initramfs_area) = boot_info.initramfs {
+    if let Some(initramfs_paddr) = boot_info.initramfs_paddr {
         early_println!(
-            "[Scarlet Kernel] InitramFS available: {:#x} - {:#x}",
-            initramfs_area.start,
-            initramfs_area.end
+            "[Scarlet Kernel] InitramFS (PA)    : {:#x} - {:#x}",
+            initramfs_paddr.start,
+            initramfs_paddr.end
         );
     } else {
         early_println!("[Scarlet Kernel] No initramfs found");
     }
 
     early_println!("[Scarlet Kernel] Initializing PMM...");
-    let pmm_start_aligned = (usable_area_phys.start + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
-    if pmm_start_aligned < usable_area_phys.end {
+    let pmm_start_aligned = (usable_memory_paddr.start + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+    if pmm_start_aligned < usable_memory_paddr.end {
         unsafe {
-            mem::pmm::init(MemoryArea::new(pmm_start_aligned, usable_area_phys.end));
+            mem::pmm::init(MemoryArea::new(pmm_start_aligned, usable_memory_paddr.end));
         }
     }
 
@@ -600,9 +598,10 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
 
     early_println!("[Scarlet Kernel] Initializing Virtual Memory...");
     kernel_vm_init(
-        usable_area_phys,
-        direct_map_area_phys,
-        boot_info.initramfs_phys,
+        usable_memory_paddr,
+        direct_map_paddr,
+        boot_info.initramfs_paddr,
+        hhdm_offset,
     );
     /* After this point, we can use the heap and virtual memory */
     /* We will also be restricted to the kernel address space */
@@ -701,9 +700,13 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     let manager = init_global_vfs_manager();
 
     /* Initialize initramfs from BootInfo if available */
-    if let Some(initramfs_area) = boot_info.initramfs {
+    if let Some(initramfs_paddr) = boot_info.initramfs_paddr {
         println!("[Scarlet Kernel] Initializing initramfs from BootInfo...");
-        if let Err(e) = init_initramfs(&manager, initramfs_area) {
+        let initramfs_vaddr = MemoryArea::new(
+            phys_to_virt(initramfs_paddr.start),
+            phys_to_virt(initramfs_paddr.end),
+        );
+        if let Err(e) = init_initramfs(&manager, initramfs_vaddr) {
             println!(
                 "[Scarlet Kernel] Warning: Failed to initialize initramfs: {}",
                 e

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -306,7 +306,7 @@ use sched::scheduler::get_scheduler;
 use task::new_user_task;
 use timer::get_kernel_timer;
 use vm::{
-    boot::switch_to_boot_page_table, kernel_vm_init, phys_to_virt, set_hhdm_offset,
+    boot::switch_to_boot_page_table, kernel_vm_init, phys_to_virt, transition_kernel_memory_layout,
     vmem::MemoryArea,
 };
 
@@ -316,7 +316,7 @@ use vm::{
 fn panic(info: &core::panic::PanicInfo) -> ! {
     use arch::instruction::idle;
 
-    crate::println!("[Scarlet Kernel] panic: {}", info);
+    crate::early_println!("[Scarlet Kernel] panic: {}", info);
 
     // if let Some(task) = get_scheduler().get_current_task(get_cpu().get_cpuid()) {
     //     task.exit(1); // Exit the task with error code 1
@@ -580,7 +580,14 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     crate::earlyfb::deactivate();
     switch_to_boot_page_table(direct_map_paddr, boot_info.initramfs_paddr, heap_paddr);
 
-    set_hhdm_offset(SCARLET_HHDM_BASE);
+    transition_kernel_memory_layout(
+        SCARLET_HHDM_BASE,
+        direct_map_paddr.start,
+        direct_map_paddr.end,
+        heap_paddr.start,
+        KERNEL_HEAP_BASE,
+        heap_size,
+    );
     mem::pmm::fixup_hhdm_offset(hhdm_offset, SCARLET_HHDM_BASE);
 
     if let DeviceSource::Fdt(relocated_fdt_paddr) = boot_info.device_source {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -288,7 +288,7 @@ pub mod test;
 extern crate alloc;
 use alloc::string::ToString;
 use device::manager::{DeviceManager, DriverPriority};
-use environment::PAGE_SIZE;
+use environment::{KERNEL_HEAP_BASE, KERNEL_HEAP_SIZE, PAGE_SIZE, SCARLET_HHDM_BASE};
 use initcall::{call_initcalls, driver::driver_initcall_call, early::early_initcall_call};
 
 const MIN_HEAP_SIZE: usize = 32 * 1024;
@@ -301,11 +301,14 @@ use crate::{
 };
 use arch::get_cpu;
 use core::sync::atomic::{Ordering, fence};
-use mem::allocator::{add_heap_region, init_heap};
+use mem::allocator::init_heap;
 use sched::scheduler::get_scheduler;
 use task::new_user_task;
 use timer::get_kernel_timer;
-use vm::{kernel_vm_init, phys_to_virt, vmem::MemoryArea};
+use vm::{
+    boot::switch_to_boot_page_table, kernel_vm_init, phys_to_virt, set_hhdm_offset,
+    vmem::MemoryArea,
+};
 
 /// A panic handler is required in Rust, this is probably the most basic one possible
 #[cfg(not(test))]
@@ -331,7 +334,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 /// This enum captures the source and relevant parameters for device discovery.
 #[derive(Debug, Clone, Copy)]
 pub enum DeviceSource {
-    /// Flattened Device Tree (FDT) source with relocated FDT address
+    /// Flattened Device Tree (FDT) source
     /// Used by RISC-V, ARM, and other architectures that support device trees
     Fdt(usize),
     /// Unified Extensible Firmware Interface (UEFI) source
@@ -565,22 +568,33 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     }
 
     early_println!("[Scarlet Kernel] Allocating initial heap from PMM...");
-    let heap_size = 512 * 1024 * 1024;
+    let heap_size = KERNEL_HEAP_SIZE;
     let heap_pages = heap_size / PAGE_SIZE;
     let heap_start_phys =
         mem::pmm::alloc_contiguous_pages(heap_pages).expect("Failed to allocate heap from PMM");
     let heap_end_phys = heap_start_phys + heap_size - 1;
-    let heap_start = phys_to_virt(heap_start_phys);
-    let heap_end = phys_to_virt(heap_end_phys);
+    let heap_paddr = MemoryArea::new(heap_start_phys, heap_end_phys);
+
+    early_println!("[Scarlet Kernel] Building Scarlet boot page table...");
+    #[cfg(target_arch = "aarch64")]
+    crate::earlyfb::deactivate();
+    switch_to_boot_page_table(direct_map_paddr, boot_info.initramfs_paddr, heap_paddr);
+
+    set_hhdm_offset(SCARLET_HHDM_BASE);
+    mem::pmm::fixup_hhdm_offset(hhdm_offset, SCARLET_HHDM_BASE);
+
+    if let DeviceSource::Fdt(relocated_fdt_paddr) = boot_info.device_source {
+        crate::device::fdt::init_fdt(phys_to_virt(relocated_fdt_paddr));
+    }
 
     early_println!("[Scarlet Kernel] Initializing heap...");
-    unsafe { init_heap(heap_start, heap_size) };
+    unsafe { init_heap(KERNEL_HEAP_BASE, heap_size) };
 
     fence(Ordering::SeqCst);
     early_println!(
         "[Scarlet Kernel] Heap initialized at {:#x} - {:#x}",
-        heap_start,
-        heap_end
+        KERNEL_HEAP_BASE,
+        KERNEL_HEAP_BASE + heap_size - 1
     );
 
     {
@@ -597,12 +611,7 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     driver_initcall_call();
 
     early_println!("[Scarlet Kernel] Initializing Virtual Memory...");
-    kernel_vm_init(
-        usable_memory_paddr,
-        direct_map_paddr,
-        boot_info.initramfs_paddr,
-        hhdm_offset,
-    );
+    kernel_vm_init(direct_map_paddr, boot_info.initramfs_paddr, heap_paddr);
     /* After this point, we can use the heap and virtual memory */
     /* We will also be restricted to the kernel address space */
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -397,6 +397,9 @@ pub struct BootInfo {
     /// Source of device information for hardware discovery
     /// Determines how the kernel will enumerate and initialize devices
     pub device_source: DeviceSource,
+    /// Optional framebuffer physical memory area
+    /// Used for early console output before graphics subsystem initialization
+    pub framebuffer_paddr: Option<MemoryArea>,
 }
 
 impl BootInfo {
@@ -411,6 +414,7 @@ impl BootInfo {
     /// * `hhdm_offset` - HHDM offset for VA = PA + offset
     /// * `cmdline` - Optional kernel command line parameters
     /// * `device_source` - Source of device information for hardware discovery
+    /// * `framebuffer_paddr` - Optional framebuffer physical memory area
     ///
     /// # Returns
     ///
@@ -424,6 +428,7 @@ impl BootInfo {
         hhdm_offset: usize,
         cmdline: Option<&'static str>,
         device_source: DeviceSource,
+        framebuffer_paddr: Option<MemoryArea>,
     ) -> Self {
         Self {
             cpu_id,
@@ -434,6 +439,7 @@ impl BootInfo {
             hhdm_offset,
             cmdline,
             device_source,
+            framebuffer_paddr,
         }
     }
 
@@ -576,9 +582,12 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     let heap_paddr = MemoryArea::new(heap_start_phys, heap_end_phys);
 
     early_println!("[Scarlet Kernel] Building Scarlet boot page table...");
-    #[cfg(target_arch = "aarch64")]
-    crate::earlyfb::deactivate();
-    switch_to_boot_page_table(direct_map_paddr, boot_info.initramfs_paddr, heap_paddr);
+    switch_to_boot_page_table(
+        direct_map_paddr,
+        boot_info.initramfs_paddr,
+        heap_paddr,
+        boot_info.framebuffer_paddr,
+    );
 
     transition_kernel_memory_layout(
         SCARLET_HHDM_BASE,
@@ -589,6 +598,7 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
         heap_size,
     );
     mem::pmm::fixup_hhdm_offset(hhdm_offset, SCARLET_HHDM_BASE);
+    crate::earlyfb::fixup_hhdm_offset(SCARLET_HHDM_BASE);
 
     if let DeviceSource::Fdt(relocated_fdt_paddr) = boot_info.device_source {
         crate::device::fdt::init_fdt(phys_to_virt(relocated_fdt_paddr));

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -300,7 +300,7 @@ use crate::{
     interrupt::InterruptManager,
 };
 use arch::get_cpu;
-use core::sync::atomic::{Ordering, fence};
+use core::sync::atomic::{Ordering, compiler_fence, fence};
 use mem::allocator::init_heap;
 use sched::scheduler::get_scheduler;
 use task::new_user_task;
@@ -582,12 +582,22 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     let heap_paddr = MemoryArea::new(heap_start_phys, heap_end_phys);
 
     early_println!("[Scarlet Kernel] Building Scarlet boot page table...");
+    // crate::earlyfb::deactivate();
     switch_to_boot_page_table(
         direct_map_paddr,
         boot_info.initramfs_paddr,
         heap_paddr,
         boot_info.framebuffer_paddr,
     );
+
+    // Fix PMM metadata pointers immediately after page table switch
+    // Must be done before any operation that might touch PMM data structures
+    mem::pmm::fixup_hhdm_offset(hhdm_offset, SCARLET_HHDM_BASE);
+
+    fence(Ordering::SeqCst);
+    compiler_fence(Ordering::SeqCst); // Ensure PMM fixup is visible before proceeding
+
+    crate::earlyfb::fixup_hhdm_offset(hhdm_offset, SCARLET_HHDM_BASE);
 
     transition_kernel_memory_layout(
         SCARLET_HHDM_BASE,
@@ -597,8 +607,8 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
         KERNEL_HEAP_BASE,
         heap_size,
     );
-    mem::pmm::fixup_hhdm_offset(hhdm_offset, SCARLET_HHDM_BASE);
-    crate::earlyfb::fixup_hhdm_offset(SCARLET_HHDM_BASE);
+
+    fence(Ordering::SeqCst);
 
     if let DeviceSource::Fdt(relocated_fdt_paddr) = boot_info.device_source {
         crate::device::fdt::init_fdt(phys_to_virt(relocated_fdt_paddr));

--- a/kernel/src/mem/allocator.rs
+++ b/kernel/src/mem/allocator.rs
@@ -16,13 +16,14 @@ impl OomHandler for DynamicHeapHandler {
 
         let addr = crate::mem::pmm::alloc_contiguous_pages(pages_needed);
         match addr {
-            Some(start) => {
+            Some(start_paddr) => {
                 let size = pages_needed * PAGE_SIZE;
+                let start = crate::vm::phys_to_virt(start_paddr);
                 let span = Span::from_base_size(start as *mut u8, size);
                 match unsafe { talc.claim(span) } {
                     Ok(_) => Ok(()),
                     Err(_) => {
-                        crate::mem::pmm::free_contiguous_pages(start, pages_needed);
+                        crate::mem::pmm::free_contiguous_pages(start_paddr, pages_needed);
                         Err(())
                     }
                 }

--- a/kernel/src/mem/pmm.rs
+++ b/kernel/src/mem/pmm.rs
@@ -372,6 +372,77 @@ impl BuddyRegion {
     fn total_pages(&self) -> usize {
         self.page_count
     }
+
+    fn fixup_hhdm_offset(&mut self, old_offset: usize, new_offset: usize) {
+        if !self.active || old_offset == new_offset {
+            return;
+        }
+
+        let old_pages_start = self.pages as usize;
+        let new_pages_start = self.mem_start + new_offset;
+        let pages_bytes = self.page_count * core::mem::size_of::<Page>();
+        let old_pages_end = old_pages_start + pages_bytes;
+
+        self.pages = new_pages_start as *mut Page;
+
+        unsafe {
+            for order in 0..=MAX_ORDER {
+                let free_list = &mut self.free_area[order].free_list;
+                free_list.next = adjust_metadata_ptr(
+                    free_list.next,
+                    old_pages_start,
+                    old_pages_end,
+                    old_offset,
+                    new_offset,
+                );
+                free_list.prev = adjust_metadata_ptr(
+                    free_list.prev,
+                    old_pages_start,
+                    old_pages_end,
+                    old_offset,
+                    new_offset,
+                );
+            }
+
+            for i in 0..self.page_count {
+                let page = self.pages.add(i);
+                (*page).lru.next = adjust_metadata_ptr(
+                    (*page).lru.next,
+                    old_pages_start,
+                    old_pages_end,
+                    old_offset,
+                    new_offset,
+                );
+                (*page).lru.prev = adjust_metadata_ptr(
+                    (*page).lru.prev,
+                    old_pages_start,
+                    old_pages_end,
+                    old_offset,
+                    new_offset,
+                );
+            }
+        }
+    }
+}
+
+fn adjust_metadata_ptr(
+    ptr: *mut ListHead,
+    old_pages_start: usize,
+    old_pages_end: usize,
+    old_offset: usize,
+    new_offset: usize,
+) -> *mut ListHead {
+    if ptr.is_null() {
+        return ptr;
+    }
+
+    let addr = ptr as usize;
+    if !(old_pages_start..old_pages_end).contains(&addr) {
+        return ptr;
+    }
+
+    let paddr = addr - old_offset;
+    (paddr + new_offset) as *mut ListHead
 }
 
 struct PmmInner {
@@ -564,6 +635,13 @@ pub fn free_frame(paddr: usize) {
 
 pub fn stats() -> (usize, usize) {
     PMM.lock().stats()
+}
+
+pub fn fixup_hhdm_offset(old_offset: usize, new_offset: usize) {
+    let mut pmm = PMM.lock();
+    for region in &mut pmm.regions {
+        region.fixup_hhdm_offset(old_offset, new_offset);
+    }
 }
 
 fn align_up(addr: usize, align: usize) -> usize {

--- a/kernel/src/vm/addr.rs
+++ b/kernel/src/vm/addr.rs
@@ -2,6 +2,18 @@
 //!
 //! This module provides functions for converting between physical and virtual addresses.
 //!
+//! # Design
+//!
+//! The HHDM (Higher Half Direct Map) offset is stored in an `AtomicUsize` so it can be
+//! updated after the kernel switches from the bootloader's page tables to its own.
+//! During early boot (before the switch), `phys_to_virt` uses the Limine-provided offset.
+//! After switching to Scarlet's own page tables, `set_hhdm_offset()` is called to point
+//! translations at `SCARLET_HHDM_BASE`.
+//!
+//! For pre-switch page table construction code that must NOT go through the runtime
+//! `phys_to_virt` path, use `boot_phys_to_virt` which reads the boot-time offset
+//! directly from the immutable `BOOT_HHDM_OFFSET`.
+//!
 //! # Usage
 //!
 //! ```rust,ignore
@@ -17,17 +29,19 @@
 //! let vaddr_back = phys_to_virt(paddr);
 //! ```
 
+use core::sync::atomic::{AtomicUsize, Ordering};
+
 use spin::Once;
 
+/// Kernel image layout — immutable once set at boot.
 #[derive(Clone, Copy, Debug)]
-struct AddressLayout {
-    hhdm_offset: usize,
+struct KernelLayout {
     kernel_phys_base: usize,
     kernel_virt_base: usize,
     kernel_image_size: usize,
 }
 
-impl AddressLayout {
+impl KernelLayout {
     #[inline(always)]
     fn kernel_virt_end(&self) -> usize {
         self.kernel_virt_base + self.kernel_image_size
@@ -42,50 +56,115 @@ impl AddressLayout {
     fn contains_kernel_virt(&self, vaddr: usize) -> bool {
         vaddr >= self.kernel_virt_base && vaddr < self.kernel_virt_end()
     }
-
-    #[inline(always)]
-    fn contains_hhdm_virt(&self, vaddr: usize) -> bool {
-        vaddr >= self.hhdm_offset
-    }
 }
 
-static ADDRESS_LAYOUT: Once<AddressLayout> = Once::new();
+/// Kernel image layout (linker-placed addresses). Set once at boot, never changes.
+static KERNEL_LAYOUT: Once<KernelLayout> = Once::new();
+
+/// Runtime HHDM offset.  Initially set to the bootloader's value, then updated to
+/// `SCARLET_HHDM_BASE` after the kernel switches to its own page tables.
+///
+/// 0 = not yet initialized (pre-init_limine_addressing).
+static HHDM_OFFSET: AtomicUsize = AtomicUsize::new(0);
+
+/// Boot-time HHDM offset — the value Limine gave us.  Stored once and never modified.
+/// Used by `boot_phys_to_virt` during pre-switch page table construction so that code
+/// does not depend on the mutable `HHDM_OFFSET`.
+static BOOT_HHDM_OFFSET: Once<usize> = Once::new();
 
 #[inline(always)]
-fn layout() -> Option<&'static AddressLayout> {
-    ADDRESS_LAYOUT.get()
+fn kernel_layout() -> Option<&'static KernelLayout> {
+    KERNEL_LAYOUT.get()
 }
 
+/// Initialize address translation with the Limine-provided layout.
+///
+/// Must be called exactly once during early boot, before any `phys_to_virt` calls.
 pub fn init_limine_addressing(
     hhdm_offset: usize,
     kernel_phys_base: usize,
     kernel_virt_base: usize,
     kernel_image_size: usize,
 ) {
-    ADDRESS_LAYOUT.call_once(|| AddressLayout {
-        hhdm_offset,
+    KERNEL_LAYOUT.call_once(|| KernelLayout {
         kernel_phys_base,
         kernel_virt_base,
         kernel_image_size,
     });
+    BOOT_HHDM_OFFSET.call_once(|| hhdm_offset);
+    HHDM_OFFSET.store(hhdm_offset, Ordering::Release);
 }
 
+/// Returns `true` once `init_limine_addressing` has been called.
 #[inline(always)]
 pub fn address_translation_ready() -> bool {
-    layout().is_some()
+    HHDM_OFFSET.load(Ordering::Relaxed) != 0 && kernel_layout().is_some()
+}
+
+/// Update the runtime HHDM offset.
+///
+/// Called exactly once after switching to Scarlet's own page tables, so that subsequent
+/// `phys_to_virt` / `virt_to_phys` calls use the new direct-map base.
+///
+/// # Safety
+///
+/// The caller must ensure that the new page tables are active and the new offset is
+/// correct before calling this.  All existing HHDM-derived pointers (PMM metadata,
+/// etc.) must be fixed up before or after this call.
+pub fn set_hhdm_offset(new_offset: usize) {
+    HHDM_OFFSET.store(new_offset, Ordering::Release);
+}
+
+/// Returns the current runtime HHDM offset.
+#[inline(always)]
+pub fn get_hhdm_offset() -> usize {
+    HHDM_OFFSET.load(Ordering::Acquire)
+}
+
+/// Returns the boot-time (Limine) HHDM offset.
+///
+/// This is the immutable value from the bootloader.  Use this in pre-switch code
+/// (e.g., building Scarlet's own page tables) where you need the original mapping.
+#[inline(always)]
+pub fn get_boot_hhdm_offset() -> usize {
+    *BOOT_HHDM_OFFSET
+        .get()
+        .expect("boot HHDM offset not initialized")
+}
+
+/// Convert physical address to virtual address using the **boot-time** HHDM offset.
+///
+/// This function is for use during pre-switch page table construction ONLY.
+/// It always uses the Limine-provided offset regardless of whether `set_hhdm_offset`
+/// has been called.
+///
+/// After the PT switch, use `phys_to_virt` instead.
+#[inline(always)]
+pub fn boot_phys_to_virt(paddr: usize) -> usize {
+    let offset = get_boot_hhdm_offset();
+    paddr.checked_add(offset).unwrap_or_else(|| {
+        panic!(
+            "boot_phys_to_virt overflow: paddr={:#x} boot_hhdm_offset={:#x}",
+            paddr, offset
+        )
+    })
 }
 
 /// Converts a virtual address to a physical address.
 #[inline(always)]
 pub fn virt_to_phys(vaddr: usize) -> usize {
-    if let Some(layout) = layout() {
-        if layout.contains_kernel_virt(vaddr) {
-            return layout.kernel_phys_base + (vaddr - layout.kernel_virt_base);
-        }
-        if layout.contains_hhdm_virt(vaddr) {
-            return vaddr - layout.hhdm_offset;
+    // Kernel image region — fixed offset, never changes
+    if let Some(kl) = kernel_layout() {
+        if kl.contains_kernel_virt(vaddr) {
+            return kl.kernel_phys_base + (vaddr - kl.kernel_virt_base);
         }
     }
+    // HHDM region
+    let offset = HHDM_OFFSET.load(Ordering::Acquire);
+    if offset != 0 && vaddr >= offset {
+        return vaddr - offset;
+    }
+    // Fallback: identity
     vaddr
 }
 
@@ -94,9 +173,6 @@ pub fn virt_to_phys(vaddr: usize) -> usize {
 /// **Note:** This function is specifically intended for producing addresses in
 /// the HHDM (Higher Half Direct Map) / direct-map region. It is **not** valid
 /// for obtaining arbitrary kernel virtual addresses (e.g., kernel image VAs).
-///
-/// Currently assumes identity mapping (VA == PA).
-/// When Higher Half Kernel is enabled, this will add HHDM_OFFSET.
 ///
 /// # Arguments
 ///
@@ -107,14 +183,16 @@ pub fn virt_to_phys(vaddr: usize) -> usize {
 /// Direct-map virtual address corresponding to the given physical address
 #[inline(always)]
 pub fn phys_to_virt(paddr: usize) -> usize {
-    if let Some(layout) = layout() {
-        return paddr.checked_add(layout.hhdm_offset).unwrap_or_else(|| {
+    let offset = HHDM_OFFSET.load(Ordering::Acquire);
+    if offset != 0 {
+        return paddr.checked_add(offset).unwrap_or_else(|| {
             panic!(
                 "phys_to_virt overflow: paddr={:#x} hhdm_offset={:#x}",
-                paddr, layout.hhdm_offset
+                paddr, offset
             )
         });
     }
+    // Not yet initialized — identity
     paddr
 }
 
@@ -154,18 +232,15 @@ pub fn kernel_virt_to_phys(vaddr: usize) -> usize {
 
 #[inline(always)]
 pub fn phys_to_kernel_image_virt(paddr: usize) -> usize {
-    if let Some(layout) = layout() {
-        if paddr >= layout.kernel_phys_base && paddr < layout.kernel_phys_end() {
-            return layout.kernel_virt_base + (paddr - layout.kernel_phys_base);
+    if let Some(kl) = kernel_layout() {
+        if paddr >= kl.kernel_phys_base && paddr < kl.kernel_phys_end() {
+            return kl.kernel_virt_base + (paddr - kl.kernel_phys_base);
         }
     }
     paddr
 }
 
 /// Checks if the given virtual address is in the direct mapping region.
-///
-/// With identity mapping, all addresses are in the direct mapping region.
-/// When Higher Half is enabled, this will check if the address is in HHDM range.
 ///
 /// # Arguments
 ///
@@ -176,8 +251,9 @@ pub fn phys_to_kernel_image_virt(paddr: usize) -> usize {
 /// `true` if the address is in the direct mapping region
 #[inline(always)]
 pub fn is_direct_mapped(vaddr: usize) -> bool {
-    if let Some(layout) = layout() {
-        return layout.contains_hhdm_virt(vaddr);
+    let offset = HHDM_OFFSET.load(Ordering::Relaxed);
+    if offset != 0 {
+        return vaddr >= offset;
     }
     true
 }

--- a/kernel/src/vm/addr.rs
+++ b/kernel/src/vm/addr.rs
@@ -1,320 +1,643 @@
-//! Address translation utilities for virtual memory management.
-//!
-//! This module provides functions for converting between physical and virtual addresses.
-//!
-//! # Design
-//!
-//! The HHDM (Higher Half Direct Map) offset is stored in an `AtomicUsize` so it can be
-//! updated after the kernel switches from the bootloader's page tables to its own.
-//! During early boot (before the switch), `phys_to_virt` uses the Limine-provided offset.
-//! After switching to Scarlet's own page tables, `set_hhdm_offset()` is called to point
-//! translations at `SCARLET_HHDM_BASE`.
-//!
-//! For pre-switch page table construction code that must NOT go through the runtime
-//! `phys_to_virt` path, use `boot_phys_to_virt` which reads the boot-time offset
-//! directly from the immutable `BOOT_HHDM_OFFSET`.
-//!
-//! # Usage
-//!
-//! ```rust,ignore
-//! use crate::vm::addr::{virt_to_phys, phys_to_virt};
-//!
-//! // Example virtual address
-//! let vaddr: usize = 0x1000;
-//!
-//! // Convert virtual address to physical address
-//! let paddr = virt_to_phys(vaddr);
-//!
-//! // Convert physical address back to virtual address
-//! let vaddr_back = phys_to_virt(paddr);
-//! ```
+//! Address translation utilities backed by the kernel memory layout.
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 
 use spin::Once;
 
-/// Kernel image layout — immutable once set at boot.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KernelMemoryPhase {
+    Uninitialized = 0,
+    Bootloader = 1,
+    BootKernel = 2,
+    Runtime = 3,
+}
+
+impl KernelMemoryPhase {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Bootloader,
+            2 => Self::BootKernel,
+            3 => Self::Runtime,
+            _ => Self::Uninitialized,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
-struct KernelLayout {
-    kernel_phys_base: usize,
-    kernel_virt_base: usize,
-    kernel_image_size: usize,
+struct KernelImageLayout {
+    phys_base: usize,
+    virt_base: usize,
+    size: usize,
 }
 
-impl KernelLayout {
+impl KernelImageLayout {
     #[inline(always)]
-    fn kernel_virt_end(&self) -> usize {
-        self.kernel_virt_base + self.kernel_image_size
+    fn virt_end(&self) -> usize {
+        self.virt_base + self.size
     }
 
     #[inline(always)]
-    fn kernel_phys_end(&self) -> usize {
-        self.kernel_phys_base + self.kernel_image_size
+    fn phys_end(&self) -> usize {
+        self.phys_base + self.size
     }
 
     #[inline(always)]
-    fn contains_kernel_virt(&self, vaddr: usize) -> bool {
-        vaddr >= self.kernel_virt_base && vaddr < self.kernel_virt_end()
+    fn contains_virt(&self, vaddr: usize) -> bool {
+        vaddr >= self.virt_base && vaddr < self.virt_end()
+    }
+
+    #[inline(always)]
+    fn contains_phys(&self, paddr: usize) -> bool {
+        paddr >= self.phys_base && paddr < self.phys_end()
     }
 }
 
-/// Kernel image layout (linker-placed addresses). Set once at boot, never changes.
-static KERNEL_LAYOUT: Once<KernelLayout> = Once::new();
+#[derive(Clone, Copy, Debug)]
+struct DirectMapLayout {
+    offset: usize,
+    phys_start: usize,
+    phys_end: usize,
+}
 
-/// Runtime HHDM offset.  Initially set to the bootloader's value, then updated to
-/// `SCARLET_HHDM_BASE` after the kernel switches to its own page tables.
-///
-/// 0 = not yet initialized (pre-init_limine_addressing).
-static HHDM_OFFSET: AtomicUsize = AtomicUsize::new(0);
+impl DirectMapLayout {
+    #[inline(always)]
+    fn contains_phys(&self, paddr: usize) -> bool {
+        paddr >= self.phys_start && paddr <= self.phys_end
+    }
 
-/// Boot-time HHDM offset — the value Limine gave us.  Stored once and never modified.
-/// Used by `boot_phys_to_virt` during pre-switch page table construction so that code
-/// does not depend on the mutable `HHDM_OFFSET`.
-static BOOT_HHDM_OFFSET: Once<usize> = Once::new();
+    #[inline(always)]
+    fn virt_start(&self) -> usize {
+        self.offset + self.phys_start
+    }
+
+    #[inline(always)]
+    fn virt_end(&self) -> usize {
+        self.offset + self.phys_end
+    }
+
+    #[inline(always)]
+    fn contains_virt(&self, vaddr: usize) -> bool {
+        vaddr >= self.virt_start() && vaddr <= self.virt_end()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct HeapLayout {
+    phys_base: usize,
+    virt_base: usize,
+    size: usize,
+}
+
+impl HeapLayout {
+    #[inline(always)]
+    fn virt_end(&self) -> usize {
+        self.virt_base + self.size
+    }
+
+    #[inline(always)]
+    fn contains_virt(&self, vaddr: usize) -> bool {
+        vaddr >= self.virt_base && vaddr < self.virt_end()
+    }
+}
+
+struct KernelMemoryLayout {
+    phase: AtomicU8,
+    kernel_image: Once<KernelImageLayout>,
+    boot_direct_map_offset: AtomicUsize,
+    current_direct_map_offset: AtomicUsize,
+    boot_direct_map_phys_start: AtomicUsize,
+    boot_direct_map_phys_end: AtomicUsize,
+    current_direct_map_phys_start: AtomicUsize,
+    current_direct_map_phys_end: AtomicUsize,
+    heap_phys_base: AtomicUsize,
+    heap_virt_base: AtomicUsize,
+    heap_size: AtomicUsize,
+}
+
+impl KernelMemoryLayout {
+    const fn new() -> Self {
+        Self {
+            phase: AtomicU8::new(KernelMemoryPhase::Uninitialized as u8),
+            kernel_image: Once::new(),
+            boot_direct_map_offset: AtomicUsize::new(0),
+            current_direct_map_offset: AtomicUsize::new(0),
+            boot_direct_map_phys_start: AtomicUsize::new(0),
+            boot_direct_map_phys_end: AtomicUsize::new(0),
+            current_direct_map_phys_start: AtomicUsize::new(0),
+            current_direct_map_phys_end: AtomicUsize::new(0),
+            heap_phys_base: AtomicUsize::new(0),
+            heap_virt_base: AtomicUsize::new(0),
+            heap_size: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline(always)]
+    fn phase(&self) -> KernelMemoryPhase {
+        KernelMemoryPhase::from_u8(self.phase.load(Ordering::Acquire))
+    }
+
+    fn init_from_limine(
+        &self,
+        hhdm_offset: usize,
+        kernel_phys_base: usize,
+        kernel_virt_base: usize,
+        kernel_image_size: usize,
+    ) {
+        self.kernel_image.call_once(|| KernelImageLayout {
+            phys_base: kernel_phys_base,
+            virt_base: kernel_virt_base,
+            size: kernel_image_size,
+        });
+        self.boot_direct_map_offset
+            .store(hhdm_offset, Ordering::Release);
+        self.current_direct_map_offset
+            .store(hhdm_offset, Ordering::Release);
+        self.phase
+            .store(KernelMemoryPhase::Bootloader as u8, Ordering::Release);
+    }
+
+    fn set_boot_direct_map_range(&self, phys_start: usize, phys_end: usize) {
+        self.boot_direct_map_phys_start
+            .store(phys_start, Ordering::Release);
+        self.boot_direct_map_phys_end
+            .store(phys_end, Ordering::Release);
+
+        if self.phase() == KernelMemoryPhase::Bootloader {
+            self.current_direct_map_phys_start
+                .store(phys_start, Ordering::Release);
+            self.current_direct_map_phys_end
+                .store(phys_end, Ordering::Release);
+        }
+    }
+
+    fn transition_to_boot_kernel(
+        &self,
+        direct_map_offset: usize,
+        direct_map_phys_start: usize,
+        direct_map_phys_end: usize,
+        heap_phys_base: usize,
+        heap_virt_base: usize,
+        heap_size: usize,
+    ) {
+        self.current_direct_map_offset
+            .store(direct_map_offset, Ordering::Release);
+        self.current_direct_map_phys_start
+            .store(direct_map_phys_start, Ordering::Release);
+        self.current_direct_map_phys_end
+            .store(direct_map_phys_end, Ordering::Release);
+        self.heap_phys_base.store(heap_phys_base, Ordering::Release);
+        self.heap_virt_base.store(heap_virt_base, Ordering::Release);
+        self.heap_size.store(heap_size, Ordering::Release);
+        self.phase
+            .store(KernelMemoryPhase::BootKernel as u8, Ordering::Release);
+    }
+
+    fn finalize_runtime(&self) {
+        self.phase
+            .store(KernelMemoryPhase::Runtime as u8, Ordering::Release);
+    }
+
+    #[inline(always)]
+    fn kernel_image(&self) -> &KernelImageLayout {
+        self.kernel_image
+            .get()
+            .expect("kernel image layout not initialized")
+    }
+
+    #[inline(always)]
+    fn boot_direct_map(&self) -> DirectMapLayout {
+        let offset = self.boot_direct_map_offset.load(Ordering::Acquire);
+        let phys_start = self.boot_direct_map_phys_start.load(Ordering::Acquire);
+        let phys_end = self.boot_direct_map_phys_end.load(Ordering::Acquire);
+        assert!(offset != 0, "boot direct-map offset not initialized");
+        assert!(
+            phys_end >= phys_start,
+            "boot direct-map range not initialized"
+        );
+        DirectMapLayout {
+            offset,
+            phys_start,
+            phys_end,
+        }
+    }
+
+    #[inline(always)]
+    fn current_direct_map(&self) -> DirectMapLayout {
+        let offset = self.current_direct_map_offset.load(Ordering::Acquire);
+        let phys_start = self.current_direct_map_phys_start.load(Ordering::Acquire);
+        let phys_end = self.current_direct_map_phys_end.load(Ordering::Acquire);
+        assert!(offset != 0, "current direct-map offset not initialized");
+        assert!(
+            phys_end >= phys_start,
+            "current direct-map range not initialized"
+        );
+        DirectMapLayout {
+            offset,
+            phys_start,
+            phys_end,
+        }
+    }
+
+    #[inline(always)]
+    fn heap_layout(&self) -> Option<HeapLayout> {
+        let size = self.heap_size.load(Ordering::Acquire);
+        if size == 0 {
+            return None;
+        }
+        Some(HeapLayout {
+            phys_base: self.heap_phys_base.load(Ordering::Acquire),
+            virt_base: self.heap_virt_base.load(Ordering::Acquire),
+            size,
+        })
+    }
+
+    fn phys_to_current_virt(&self, paddr: usize) -> usize {
+        let direct_map = self.current_direct_map();
+        assert!(
+            direct_map.contains_phys(paddr),
+            "phys_to_virt: physical address {:#x} is outside current direct-map range {:#x}..={:#x}",
+            paddr,
+            direct_map.phys_start,
+            direct_map.phys_end
+        );
+        paddr
+            .checked_add(direct_map.offset)
+            .unwrap_or_else(|| panic!("phys_to_virt overflow: paddr={:#x}", paddr))
+    }
+
+    fn virt_to_current_phys(&self, vaddr: usize) -> Option<usize> {
+        let kernel_image = self.kernel_image();
+        if kernel_image.contains_virt(vaddr) {
+            return Some(kernel_image.phys_base + (vaddr - kernel_image.virt_base));
+        }
+
+        if let Some(heap) = self.heap_layout() {
+            if heap.contains_virt(vaddr) {
+                return Some(heap.phys_base + (vaddr - heap.virt_base));
+            }
+        }
+
+        let direct_map = self.current_direct_map();
+        if direct_map.contains_virt(vaddr) {
+            return Some(vaddr - direct_map.offset);
+        }
+
+        None
+    }
+
+    fn virt_to_boot_phys(&self, vaddr: usize) -> Option<usize> {
+        let kernel_image = self.kernel_image();
+        if kernel_image.contains_virt(vaddr) {
+            return Some(kernel_image.phys_base + (vaddr - kernel_image.virt_base));
+        }
+
+        let direct_map = self.boot_direct_map();
+        if direct_map.contains_virt(vaddr) {
+            return Some(vaddr - direct_map.offset);
+        }
+
+        None
+    }
+
+    fn phys_to_boot_virt(&self, paddr: usize) -> usize {
+        let direct_map = self.boot_direct_map();
+        assert!(
+            direct_map.contains_phys(paddr),
+            "boot_phys_to_virt: physical address {:#x} is outside boot direct-map range {:#x}..={:#x}",
+            paddr,
+            direct_map.phys_start,
+            direct_map.phys_end
+        );
+        paddr
+            .checked_add(direct_map.offset)
+            .unwrap_or_else(|| panic!("boot_phys_to_virt overflow: paddr={:#x}", paddr))
+    }
+}
+
+static KERNEL_MEMORY_LAYOUT: KernelMemoryLayout = KernelMemoryLayout::new();
 
 #[inline(always)]
-fn kernel_layout() -> Option<&'static KernelLayout> {
-    KERNEL_LAYOUT.get()
+fn layout() -> &'static KernelMemoryLayout {
+    &KERNEL_MEMORY_LAYOUT
 }
 
-/// Initialize address translation with the Limine-provided layout.
+/// Initialize address translation from Limine bootloader information.
 ///
-/// Must be called exactly once during early boot, before any `phys_to_virt` calls.
+/// This must be called early in the boot process (e.g., in `limine_entry`)
+/// before any address translation is performed. It records the HHDM offset
+/// and kernel image layout provided by the bootloader.
+///
+/// # Arguments
+///
+/// * `hhdm_offset` - The HHDM (Higher Half Direct Map) offset from physical addresses
+/// * `kernel_phys_base` - Physical base address of the kernel image
+/// * `kernel_virt_base` - Virtual base address of the kernel image
+/// * `kernel_image_size` - Size of the kernel image in bytes
 pub fn init_limine_addressing(
     hhdm_offset: usize,
     kernel_phys_base: usize,
     kernel_virt_base: usize,
     kernel_image_size: usize,
 ) {
-    KERNEL_LAYOUT.call_once(|| KernelLayout {
+    layout().init_from_limine(
+        hhdm_offset,
         kernel_phys_base,
         kernel_virt_base,
         kernel_image_size,
-    });
-    BOOT_HHDM_OFFSET.call_once(|| hhdm_offset);
-    HHDM_OFFSET.store(hhdm_offset, Ordering::Release);
+    );
 }
 
-/// Returns `true` once `init_limine_addressing` has been called.
+/// Check if address translation is initialized and ready to use.
+///
+/// Returns `true` after `init_limine_addressing()` has been called,
+/// indicating that address translation functions can be safely used.
 #[inline(always)]
 pub fn address_translation_ready() -> bool {
-    HHDM_OFFSET.load(Ordering::Relaxed) != 0 && kernel_layout().is_some()
+    layout().phase() != KernelMemoryPhase::Uninitialized
 }
 
-/// Update the runtime HHDM offset.
+/// Set the boot-time direct-map physical address range.
 ///
-/// Called exactly once after switching to Scarlet's own page tables, so that subsequent
-/// `phys_to_virt` / `virt_to_phys` calls use the new direct-map base.
+/// This defines the physical memory range that is directly mapped
+/// by the bootloader (via HHDM). Should be called during early boot
+/// after `init_limine_addressing()`.
 ///
-/// # Safety
+/// # Arguments
 ///
-/// The caller must ensure that the new page tables are active and the new offset is
-/// correct before calling this.  All existing HHDM-derived pointers (PMM metadata,
-/// etc.) must be fixed up before or after this call.
+/// * `start` - Start of the direct-mapped physical address range
+/// * `end` - End of the direct-mapped physical address range (inclusive)
+pub fn init_boot_direct_map_range(start: usize, end: usize) {
+    layout().set_boot_direct_map_range(start, end);
+}
+
+/// Transition to the kernel-owned memory layout.
+///
+/// This should be called after switching from the bootloader's page tables
+/// to Scarlet's own page tables. It updates the direct-map and heap
+/// layout information for runtime address translation.
+///
+/// # Arguments
+///
+/// * `direct_map_offset` - HHDM offset for the new page tables
+/// * `direct_map_phys_start` - Start of direct-mapped physical range
+/// * `direct_map_phys_end` - End of direct-mapped physical range (inclusive)
+/// * `heap_phys_base` - Physical base address of the kernel heap
+/// * `heap_virt_base` - Virtual base address of the kernel heap
+/// * `heap_size` - Size of the kernel heap in bytes
+pub fn transition_kernel_memory_layout(
+    direct_map_offset: usize,
+    direct_map_phys_start: usize,
+    direct_map_phys_end: usize,
+    heap_phys_base: usize,
+    heap_virt_base: usize,
+    heap_size: usize,
+) {
+    layout().transition_to_boot_kernel(
+        direct_map_offset,
+        direct_map_phys_start,
+        direct_map_phys_end,
+        heap_phys_base,
+        heap_virt_base,
+        heap_size,
+    );
+}
+
+/// Finalize the memory layout for full runtime operation.
+///
+/// Marks the memory layout as fully initialized. After this call,
+/// the system is in the Runtime phase and all address translation
+/// functions operate in their final configuration.
+pub fn finalize_runtime_memory_layout() {
+    layout().finalize_runtime();
+}
+
+/// Get the current direct-map physical address range.
+///
+/// Returns the physical memory range that is currently direct-mapped
+/// (accessible via HHDM offset).
+///
+/// # Returns
+///
+/// A tuple of `(start, end)` physical addresses (inclusive).
+pub fn get_current_direct_map_phys_range() -> (usize, usize) {
+    let current = layout().current_direct_map();
+    (current.phys_start, current.phys_end)
+}
+
+/// Get the kernel heap physical layout information.
+///
+/// Returns the heap layout if it has been initialized.
+///
+/// # Returns
+///
+/// `Some((phys_base, virt_base, size))` if heap is initialized,
+/// `None` otherwise.
+pub fn get_heap_phys_layout() -> Option<(usize, usize, usize)> {
+    layout()
+        .heap_layout()
+        .map(|heap| (heap.phys_base, heap.virt_base, heap.size))
+}
+
+/// Set the HHDM (Higher Half Direct Map) offset for address translation.
+///
+/// This updates the offset used for converting between physical and virtual
+/// addresses in the direct-mapped region.
+///
+/// # Arguments
+///
+/// * `new_offset` - The new HHDM offset value
 pub fn set_hhdm_offset(new_offset: usize) {
-    HHDM_OFFSET.store(new_offset, Ordering::Release);
+    let current = layout().current_direct_map();
+    transition_kernel_memory_layout(
+        new_offset,
+        current.phys_start,
+        current.phys_end,
+        layout()
+            .heap_layout()
+            .map(|heap| heap.phys_base)
+            .unwrap_or(0),
+        layout()
+            .heap_layout()
+            .map(|heap| heap.virt_base)
+            .unwrap_or(0),
+        layout().heap_layout().map(|heap| heap.size).unwrap_or(0),
+    );
 }
 
-/// Returns the current runtime HHDM offset.
+/// Get the current HHDM (Higher Half Direct Map) offset.
+///
+/// Returns the offset used for the current runtime address translation.
 #[inline(always)]
 pub fn get_hhdm_offset() -> usize {
-    HHDM_OFFSET.load(Ordering::Acquire)
+    layout().current_direct_map().offset
 }
 
-/// Returns the boot-time (Limine) HHDM offset.
+/// Get the boot-time HHDM (Higher Half Direct Map) offset.
 ///
-/// This is the immutable value from the bootloader.  Use this in pre-switch code
-/// (e.g., building Scarlet's own page tables) where you need the original mapping.
+/// Returns the offset provided by the bootloader during early boot.
+/// This is used for boot-phase address translation.
 #[inline(always)]
 pub fn get_boot_hhdm_offset() -> usize {
-    *BOOT_HHDM_OFFSET
-        .get()
-        .expect("boot HHDM offset not initialized")
+    layout().boot_direct_map().offset
 }
 
-/// Convert physical address to virtual address using the **boot-time** HHDM offset.
+/// Convert a boot-time physical address to virtual address.
 ///
-/// This function is for use during pre-switch page table construction ONLY.
-/// It always uses the Limine-provided offset regardless of whether `set_hhdm_offset`
-/// has been called.
+/// Uses the bootloader-provided HHDM offset. This should only be called
+/// during early boot before transitioning to kernel-owned page tables.
 ///
-/// After the PT switch, use `phys_to_virt` instead.
+/// # Panics
+///
+/// Panics if the physical address is outside the boot direct-map range.
 #[inline(always)]
 pub fn boot_phys_to_virt(paddr: usize) -> usize {
-    let offset = get_boot_hhdm_offset();
-    paddr.checked_add(offset).unwrap_or_else(|| {
+    layout().phys_to_boot_virt(paddr)
+}
+
+/// Convert a virtual address to physical address (runtime).
+///
+/// Uses the current runtime memory layout. This should be called after
+/// the kernel has transitioned to its own page tables.
+///
+/// # Panics
+///
+/// Panics with caller information if the virtual address cannot be mapped
+/// to a physical address in the current layout.
+#[inline(always)]
+#[track_caller]
+pub fn virt_to_phys(vaddr: usize) -> usize {
+    layout().virt_to_current_phys(vaddr).unwrap_or_else(|| {
+        let caller = core::panic::Location::caller();
         panic!(
-            "boot_phys_to_virt overflow: paddr={:#x} boot_hhdm_offset={:#x}",
-            paddr, offset
+            "virt_to_phys: unmapped kernel virtual address {:#x} (caller: {}:{})",
+            vaddr,
+            caller.file(),
+            caller.line()
         )
     })
 }
 
-/// Converts a virtual address to a physical address.
+/// Convert a boot-time virtual address to physical address.
+///
+/// Uses the bootloader-provided memory layout. This should be called
+/// during early boot for addresses provided by the bootloader.
+///
+/// # Panics
+///
+/// Panics with caller information if the virtual address cannot be mapped
+/// to a physical address in the boot layout.
 #[inline(always)]
-pub fn virt_to_phys(vaddr: usize) -> usize {
-    // Kernel image region — fixed offset, never changes
-    if let Some(kl) = kernel_layout() {
-        if kl.contains_kernel_virt(vaddr) {
-            return kl.kernel_phys_base + (vaddr - kl.kernel_virt_base);
-        }
-    }
-    // HHDM region
-    let offset = HHDM_OFFSET.load(Ordering::Acquire);
-    if offset != 0 && vaddr >= offset {
-        return vaddr - offset;
-    }
-    // Fallback: identity
-    vaddr
+#[track_caller]
+pub fn boot_virt_to_phys(vaddr: usize) -> usize {
+    layout().virt_to_boot_phys(vaddr).unwrap_or_else(|| {
+        let caller = core::panic::Location::caller();
+        panic!(
+            "boot_virt_to_phys: unmapped boot virtual address {:#x} (caller: {}:{})",
+            vaddr,
+            caller.file(),
+            caller.line()
+        )
+    })
 }
 
-/// Converts a physical address to a virtual address.
+/// Convert a physical address to virtual address (runtime).
 ///
-/// **Note:** This function is specifically intended for producing addresses in
-/// the HHDM (Higher Half Direct Map) / direct-map region. It is **not** valid
-/// for obtaining arbitrary kernel virtual addresses (e.g., kernel image VAs).
+/// Uses the current runtime memory layout (HHDM offset).
 ///
-/// # Arguments
+/// # Panics
 ///
-/// * `paddr` - Physical address to convert
-///
-/// # Returns
-///
-/// Direct-map virtual address corresponding to the given physical address
+/// Panics if the physical address is outside the current direct-map range.
 #[inline(always)]
 pub fn phys_to_virt(paddr: usize) -> usize {
-    let offset = HHDM_OFFSET.load(Ordering::Acquire);
-    if offset != 0 {
-        return paddr.checked_add(offset).unwrap_or_else(|| {
-            panic!(
-                "phys_to_virt overflow: paddr={:#x} hhdm_offset={:#x}",
-                paddr, offset
-            )
-        });
-    }
-    // Not yet initialized — identity
-    paddr
+    layout().phys_to_current_virt(paddr)
 }
 
-/// Converts a physical address to a virtual address for kernel use.
+/// Convert a physical address to kernel virtual address.
 ///
-/// This is an alias for `phys_to_virt` but makes the intent clearer
-/// when accessing kernel memory.
-///
-/// # Arguments
-///
-/// * `paddr` - Physical address to convert
-///
-/// # Returns
-///
-/// Virtual address that can be used to access the physical memory
+/// This is an alias for `phys_to_virt()`.
 #[inline(always)]
 pub fn phys_to_kernel_virt(paddr: usize) -> usize {
     phys_to_virt(paddr)
 }
 
-/// Converts a virtual address used by kernel to physical address.
+/// Convert a kernel virtual address to physical address.
 ///
-/// This is an alias for `virt_to_phys` but makes the intent clearer
-/// when dealing with kernel virtual addresses.
-///
-/// # Arguments
-///
-/// * `vaddr` - Kernel virtual address to convert
-///
-/// # Returns
-///
-/// Physical address corresponding to the given kernel virtual address
+/// This is an alias for `virt_to_phys()`.
 #[inline(always)]
 pub fn kernel_virt_to_phys(vaddr: usize) -> usize {
     virt_to_phys(vaddr)
 }
 
+/// Convert a physical address to kernel image virtual address.
+///
+/// Only works for addresses within the kernel image (code/data sections).
+/// For general direct-mapped addresses, use `phys_to_virt()` instead.
+///
+/// # Panics
+///
+/// Panics if the physical address is outside the kernel image range.
 #[inline(always)]
 pub fn phys_to_kernel_image_virt(paddr: usize) -> usize {
-    if let Some(kl) = kernel_layout() {
-        if paddr >= kl.kernel_phys_base && paddr < kl.kernel_phys_end() {
-            return kl.kernel_virt_base + (paddr - kl.kernel_phys_base);
-        }
+    let kernel_image = layout().kernel_image();
+    if kernel_image.contains_phys(paddr) {
+        return kernel_image.virt_base + (paddr - kernel_image.phys_base);
     }
-    paddr
+    panic!(
+        "phys_to_kernel_image_virt: physical address {:#x} is outside kernel image range",
+        paddr
+    )
 }
 
-/// Checks if the given virtual address is in the direct mapping region.
+/// Check if a virtual address is in the direct-mapped region.
 ///
-/// # Arguments
-///
-/// * `vaddr` - Virtual address to check
-///
-/// # Returns
-///
-/// `true` if the address is in the direct mapping region
+/// Returns `true` if the address can be translated to physical
+/// via simple HHDM offset subtraction.
 #[inline(always)]
 pub fn is_direct_mapped(vaddr: usize) -> bool {
-    let offset = HHDM_OFFSET.load(Ordering::Relaxed);
-    if offset != 0 {
-        return vaddr >= offset;
-    }
-    true
+    layout().current_direct_map().contains_virt(vaddr)
 }
 
-// ============================================================================
-// Type-safe address wrappers (for future use)
-// ============================================================================
-
-/// A physical memory address.
-///
-/// This type provides type safety when working with physical addresses,
-/// preventing accidental mixing with virtual addresses.
+/// A wrapper type representing a physical address.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PhysAddr(pub usize);
 
 impl PhysAddr {
-    /// Creates a new physical address.
+    /// Create a new `PhysAddr` from a raw address value.
     #[inline(always)]
     pub const fn new(addr: usize) -> Self {
         Self(addr)
     }
 
-    /// Returns the raw address value.
+    /// Return the raw address value.
     #[inline(always)]
     pub const fn as_usize(&self) -> usize {
         self.0
     }
 
-    /// Converts this physical address to a virtual address.
+    /// Convert this physical address to a virtual address.
+    ///
+    /// Uses `phys_to_virt()` for the translation.
     #[inline(always)]
     pub fn to_virt(&self) -> VirtAddr {
         VirtAddr::new(phys_to_virt(self.0))
     }
 
-    /// Returns true if the address is aligned to the given boundary.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `align` is 0 or not a power of two.
+    /// Check if the address is aligned to the given power-of-two alignment.
     #[inline(always)]
     pub const fn is_aligned(&self, align: usize) -> bool {
         assert!(align != 0 && align.is_power_of_two());
         self.0 & (align - 1) == 0
     }
 
-    /// Returns the address aligned down to the given boundary.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `align` is 0 or not a power of two.
+    /// Align the address down to the given power-of-two boundary.
     #[inline(always)]
     pub const fn align_down(&self, align: usize) -> Self {
         assert!(align != 0 && align.is_power_of_two());
         Self::new(self.0 & !(align - 1))
     }
 
-    /// Returns the address aligned up to the given boundary.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `align` is 0 or not a power of two.
+    /// Align the address up to the given power-of-two boundary.
     #[inline(always)]
     pub const fn align_up(&self, align: usize) -> Self {
         assert!(align != 0 && align.is_power_of_two());
@@ -322,161 +645,49 @@ impl PhysAddr {
     }
 }
 
-/// A virtual memory address.
-///
-/// This type provides type safety when working with virtual addresses,
-/// preventing accidental mixing with physical addresses.
+/// A wrapper type representing a virtual address.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VirtAddr(pub usize);
 
 impl VirtAddr {
-    /// Creates a new virtual address.
+    /// Create a new `VirtAddr` from a raw address value.
     #[inline(always)]
     pub const fn new(addr: usize) -> Self {
         Self(addr)
     }
 
-    /// Returns the raw address value.
+    /// Return the raw address value.
     #[inline(always)]
     pub const fn as_usize(&self) -> usize {
         self.0
     }
 
-    /// Converts this virtual address to a physical address.
+    /// Convert this virtual address to a physical address.
+    ///
+    /// Uses `virt_to_phys()` for the translation.
     #[inline(always)]
     pub fn to_phys(&self) -> PhysAddr {
         PhysAddr::new(virt_to_phys(self.0))
     }
 
-    /// Returns `true` if the address is aligned to the given boundary.
-    ///
-    /// # Parameters
-    ///
-    /// * `align` - Alignment in bytes. Must be non-zero and a power of two.
-    ///
-    /// If `align` is zero or not a power of two, this function:
-    ///
-    /// * Returns `false` in release builds.
-    /// * Triggers a debug assertion in debug builds and returns `false`.
+    /// Check if the address is aligned to the given power-of-two alignment.
     #[inline(always)]
     pub const fn is_aligned(&self, align: usize) -> bool {
-        if !Self::is_valid_align(align) {
-            debug_assert!(
-                false,
-                "VirtAddr::is_aligned called with invalid alignment (must be non-zero power of two)",
-            );
-            return false;
-        }
-        (self.0 & (align - 1)) == 0
+        assert!(align != 0 && align.is_power_of_two());
+        self.0 & (align - 1) == 0
     }
 
-    /// Returns the address aligned down to the given boundary.
-    ///
-    /// # Parameters
-    ///
-    /// * `align` - Alignment in bytes. Must be non-zero and a power of two.
-    ///
-    /// If `align` is zero or not a power of two, this function:
-    ///
-    /// * Returns the original address in release builds.
-    /// * Triggers a debug assertion in debug builds and returns the original address.
+    /// Align the address down to the given power-of-two boundary.
     #[inline(always)]
     pub const fn align_down(&self, align: usize) -> Self {
-        if !Self::is_valid_align(align) {
-            debug_assert!(
-                false,
-                "VirtAddr::align_down called with invalid alignment (must be non-zero power of two)",
-            );
-            return *self;
-        }
+        assert!(align != 0 && align.is_power_of_two());
         Self::new(self.0 & !(align - 1))
     }
 
-    /// Returns the address aligned up to the given boundary.
-    ///
-    /// # Parameters
-    ///
-    /// * `align` - Alignment in bytes. Must be non-zero and a power of two.
-    ///
-    /// If `align` is zero or not a power of two, this function:
-    ///
-    /// * Returns the original address in release builds.
-    /// * Triggers a debug assertion in debug builds and returns the original address.
+    /// Align the address up to the given power-of-two boundary.
     #[inline(always)]
     pub const fn align_up(&self, align: usize) -> Self {
-        if !Self::is_valid_align(align) {
-            debug_assert!(
-                false,
-                "VirtAddr::align_up called with invalid alignment (must be non-zero power of two)",
-            );
-            return *self;
-        }
+        assert!(align != 0 && align.is_power_of_two());
         Self::new((self.0 + align - 1) & !(align - 1))
-    }
-
-    /// Returns `true` if an alignment value is valid for use with
-    /// [`VirtAddr::is_aligned`], [`VirtAddr::align_down`], and [`VirtAddr::align_up`].
-    ///
-    /// A valid alignment is non-zero and a power of two.
-    #[inline(always)]
-    const fn is_valid_align(align: usize) -> bool {
-        align != 0 && align.is_power_of_two()
-    }
-}
-
-// ============================================================================
-// Unit tests
-// ============================================================================
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test_case]
-    fn test_identity_mapping_virt_to_phys() {
-        let vaddr = phys_to_virt(0x80000000usize);
-        let paddr = virt_to_phys(vaddr);
-        assert_eq!(paddr, 0x80000000usize);
-    }
-
-    #[test_case]
-    fn test_identity_mapping_phys_to_virt() {
-        let paddr = 0x80000000usize;
-        let vaddr = phys_to_virt(paddr);
-        assert_eq!(virt_to_phys(vaddr), paddr);
-    }
-
-    #[test_case]
-    fn test_roundtrip_conversion() {
-        let original_paddr = 0x80001234usize;
-        let vaddr = phys_to_virt(original_paddr);
-        let paddr = virt_to_phys(vaddr);
-        assert_eq!(paddr, original_paddr);
-    }
-
-    #[test_case]
-    fn test_phys_addr_type() {
-        let paddr = PhysAddr::new(0x80000000);
-        assert_eq!(paddr.as_usize(), 0x80000000);
-        assert_eq!(paddr.to_virt().to_phys().as_usize(), 0x80000000);
-    }
-
-    #[test_case]
-    fn test_virt_addr_type() {
-        let vaddr = VirtAddr::new(phys_to_virt(0x80000000));
-        assert_eq!(vaddr.to_phys().as_usize(), 0x80000000);
-    }
-
-    #[test_case]
-    fn test_addr_alignment() {
-        let addr = PhysAddr::new(0x80001234);
-        assert!(!addr.is_aligned(0x1000));
-        assert_eq!(addr.align_down(0x1000).as_usize(), 0x80001000);
-        assert_eq!(addr.align_up(0x1000).as_usize(), 0x80002000);
-
-        let aligned = PhysAddr::new(0x80002000);
-        assert!(aligned.is_aligned(0x1000));
-        assert_eq!(aligned.align_down(0x1000).as_usize(), 0x80002000);
-        assert_eq!(aligned.align_up(0x1000).as_usize(), 0x80002000);
     }
 }

--- a/kernel/src/vm/boot.rs
+++ b/kernel/src/vm/boot.rs
@@ -1,0 +1,306 @@
+use crate::arch::vm::mmu::{PageTable as ArchPageTable, PageTableEntry as ArchPageTableEntry};
+use crate::environment::{KERNEL_HEAP_BASE, PAGE_SIZE, SCARLET_HHDM_BASE};
+use crate::mem::pmm;
+use crate::vm::addr::{boot_phys_to_virt, kernel_virt_to_phys};
+use crate::vm::vmem::{MemoryArea, VirtualMemoryPermission};
+
+const BOOT_ASID: u16 = 0;
+
+fn align_down(addr: usize, align: usize) -> usize {
+    addr & !(align - 1)
+}
+
+fn align_up(addr: usize, align: usize) -> usize {
+    (addr + align - 1) & !(align - 1)
+}
+
+fn is_in_area(area: MemoryArea, paddr: usize) -> bool {
+    area.start <= paddr && paddr <= area.end
+}
+
+fn alloc_boot_pagetable() -> (usize, *mut ArchPageTable) {
+    let paddr = pmm::alloc_frame().expect("Failed to allocate boot page table frame");
+    let vaddr = boot_phys_to_virt(paddr);
+    unsafe {
+        core::ptr::write_bytes(vaddr as *mut u8, 0, PAGE_SIZE);
+        #[cfg(target_arch = "aarch64")]
+        crate::arch::aarch64::clean_dcache_to_poc_range(vaddr, PAGE_SIZE);
+    }
+    (paddr, vaddr as *mut ArchPageTable)
+}
+
+#[cfg(target_arch = "riscv64")]
+fn boot_walk(
+    root: *mut ArchPageTable,
+    vaddr: usize,
+    alloc: bool,
+) -> Option<&'static mut ArchPageTableEntry> {
+    let canonical_check = (vaddr >> 47) & 1;
+    let upper_bits = (vaddr >> 48) & 0xffff;
+    if canonical_check == 1 && upper_bits != 0xffff {
+        return None;
+    } else if canonical_check == 0 && upper_bits != 0 {
+        return None;
+    }
+
+    let mut pagetable = root;
+    unsafe {
+        for level in (1..=3).rev() {
+            let vpn = (vaddr >> (12 + 9 * level)) & 0x1ff;
+            let pte = &mut (*pagetable).entries[vpn];
+
+            if pte.is_valid() {
+                if pte.is_leaf() {
+                    return None;
+                }
+                pagetable = boot_phys_to_virt(pte.get_ppn() << 12) as *mut ArchPageTable;
+            } else {
+                if !alloc {
+                    return None;
+                }
+                let (new_table_paddr, new_table) = alloc_boot_pagetable();
+                pte.clear_all();
+                pte.set_ppn(new_table_paddr >> 12);
+                pte.validate();
+                pagetable = new_table;
+            }
+        }
+
+        let vpn = (vaddr >> 12) & 0x1ff;
+        Some(&mut (*pagetable).entries[vpn])
+    }
+}
+
+#[cfg(target_arch = "riscv64")]
+fn boot_map_page(root: *mut ArchPageTable, vaddr: usize, paddr: usize, permissions: usize) {
+    let vaddr = vaddr & !(PAGE_SIZE - 1);
+    let paddr = paddr & !(PAGE_SIZE - 1);
+    let pte = boot_walk(root, vaddr, true).expect("boot_map_page: failed to allocate walk path");
+
+    pte.clear_all();
+    if VirtualMemoryPermission::Read.contained_in(permissions) {
+        pte.readable();
+    }
+    if VirtualMemoryPermission::Write.contained_in(permissions) {
+        pte.writable();
+    }
+    if VirtualMemoryPermission::Execute.contained_in(permissions) {
+        pte.executable();
+    }
+    if VirtualMemoryPermission::User.contained_in(permissions) {
+        pte.accesible_from_user();
+    }
+    pte.accessed();
+    pte.dirty();
+    pte.set_ppn(paddr >> 12);
+    pte.validate();
+}
+
+#[cfg(target_arch = "aarch64")]
+fn boot_walk(
+    root: *mut ArchPageTable,
+    vaddr: usize,
+    alloc: bool,
+) -> Option<&'static mut ArchPageTableEntry> {
+    let upper = vaddr >> 48;
+    if upper != 0 && upper != 0xffff {
+        return None;
+    }
+
+    let mut pagetable = root;
+    unsafe {
+        for level in 0..3 {
+            let shift = 12 + 9 * (3 - level);
+            let index = (vaddr >> shift) & 0x1ff;
+            let pte = &mut (*pagetable).entries[index];
+
+            if pte.is_valid() {
+                if !pte.is_table() {
+                    return None;
+                }
+                pagetable = boot_phys_to_virt(pte.get_ppn() << 12) as *mut ArchPageTable;
+            } else {
+                if !alloc {
+                    return None;
+                }
+                let (new_table_paddr, new_table) = alloc_boot_pagetable();
+                pte.clear_all();
+                pte.set_ppn(new_table_paddr >> 12);
+                pte.set_table();
+                crate::arch::aarch64::clean_dcache_to_poc_range(
+                    (pte as *const ArchPageTableEntry) as usize,
+                    core::mem::size_of::<ArchPageTableEntry>(),
+                );
+                pagetable = new_table;
+            }
+        }
+
+        let index = (vaddr >> 12) & 0x1ff;
+        Some(&mut (*pagetable).entries[index])
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn boot_map_page(root: *mut ArchPageTable, vaddr: usize, paddr: usize, permissions: usize) {
+    let upper = vaddr >> 48;
+    if upper != 0 && upper != 0xffff {
+        panic!(
+            "boot_map_page: non-canonical AArch64 virtual address {:#x}",
+            vaddr
+        );
+    }
+
+    let vaddr = vaddr & !(PAGE_SIZE - 1);
+    let paddr = paddr & !(PAGE_SIZE - 1);
+    let pte = boot_walk(root, vaddr, true).expect("boot_map_page: failed to allocate walk path");
+
+    let is_write = VirtualMemoryPermission::Write.contained_in(permissions);
+    let ap = if is_write { 0b00 } else { 0b10 };
+
+    let mut entry = 0u64;
+    entry |= 0x3;
+    entry |= 1 << 10;
+    entry |= ((paddr >> 12) as u64 & 0xfffffffff) << 12;
+    entry |= 1 << 2;
+    entry |= (0b11_u64) << 8;
+    entry |= (ap as u64) << 6;
+    if !VirtualMemoryPermission::Execute.contained_in(permissions) {
+        entry |= (1 << 54) | (1 << 53);
+    }
+
+    pte.set_entry(entry);
+    crate::arch::aarch64::clean_dcache_to_poc_range(
+        (pte as *const ArchPageTableEntry) as usize,
+        core::mem::size_of::<ArchPageTableEntry>(),
+    );
+}
+
+fn boot_map_range(
+    root: *mut ArchPageTable,
+    varea: MemoryArea,
+    parea: MemoryArea,
+    permissions: usize,
+) {
+    if varea.start % PAGE_SIZE != 0
+        || parea.start % PAGE_SIZE != 0
+        || varea.size() % PAGE_SIZE != 0
+        || parea.size() % PAGE_SIZE != 0
+    {
+        panic!("boot_map_range: unaligned mapping request");
+    }
+    if varea.size() != parea.size() {
+        panic!("boot_map_range: size mismatch between virtual and physical areas");
+    }
+
+    let mut vaddr = varea.start;
+    let mut paddr = parea.start;
+    while vaddr <= varea.end.saturating_sub(PAGE_SIZE - 1) {
+        boot_map_page(root, vaddr, paddr, permissions);
+        vaddr = vaddr
+            .checked_add(PAGE_SIZE)
+            .expect("boot_map_range: vaddr overflow");
+        paddr = paddr
+            .checked_add(PAGE_SIZE)
+            .expect("boot_map_range: paddr overflow");
+    }
+}
+
+#[allow(static_mut_refs)]
+pub fn switch_to_boot_page_table(
+    direct_map_paddr: MemoryArea,
+    initramfs_paddr: Option<MemoryArea>,
+    heap_paddr: MemoryArea,
+) {
+    unsafe extern "C" {
+        static __KERNEL_SPACE_START: usize;
+        static __KERNEL_SPACE_END: usize;
+    }
+
+    let (_, root) = alloc_boot_pagetable();
+
+    let kernel_area = MemoryArea {
+        start: align_down(
+            unsafe { &__KERNEL_SPACE_START as *const usize as usize },
+            PAGE_SIZE,
+        ),
+        end: align_up(
+            unsafe { &__KERNEL_SPACE_END as *const usize as usize },
+            PAGE_SIZE,
+        ) - 1,
+    };
+    let kernel_phys_area = MemoryArea {
+        start: align_down(kernel_virt_to_phys(kernel_area.start), PAGE_SIZE),
+        end: align_up(kernel_virt_to_phys(kernel_area.end) + 1, PAGE_SIZE) - 1,
+    };
+
+    let direct_map_phys_area = MemoryArea {
+        start: align_down(direct_map_paddr.start, PAGE_SIZE),
+        end: align_up(direct_map_paddr.end + 1, PAGE_SIZE) - 1,
+    };
+    let direct_map_area = MemoryArea {
+        start: SCARLET_HHDM_BASE + direct_map_phys_area.start,
+        end: SCARLET_HHDM_BASE + direct_map_phys_area.end,
+    };
+
+    let heap_phys_area = MemoryArea {
+        start: align_down(heap_paddr.start, PAGE_SIZE),
+        end: align_up(heap_paddr.end + 1, PAGE_SIZE) - 1,
+    };
+    let heap_area = MemoryArea {
+        start: KERNEL_HEAP_BASE,
+        end: KERNEL_HEAP_BASE + heap_phys_area.size() - 1,
+    };
+
+    boot_map_range(
+        root,
+        kernel_area,
+        kernel_phys_area,
+        VirtualMemoryPermission::Read as usize
+            | VirtualMemoryPermission::Write as usize
+            | VirtualMemoryPermission::Execute as usize,
+    );
+    boot_map_range(
+        root,
+        direct_map_area,
+        direct_map_phys_area,
+        VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+    );
+    boot_map_range(
+        root,
+        heap_area,
+        heap_phys_area,
+        VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+    );
+
+    if let Some(initramfs) = initramfs_paddr {
+        let initramfs_phys_area = MemoryArea {
+            start: align_down(initramfs.start, PAGE_SIZE),
+            end: align_up(initramfs.end + 1, PAGE_SIZE) - 1,
+        };
+        if !is_in_area(direct_map_phys_area, initramfs_phys_area.start)
+            || !is_in_area(direct_map_phys_area, initramfs_phys_area.end)
+        {
+            let initramfs_area = MemoryArea {
+                start: SCARLET_HHDM_BASE + initramfs_phys_area.start,
+                end: SCARLET_HHDM_BASE + initramfs_phys_area.end,
+            };
+            boot_map_range(
+                root,
+                initramfs_area,
+                initramfs_phys_area,
+                VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+            );
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        (*root).switch_ttbr1(BOOT_ASID);
+        (*root).switch(BOOT_ASID);
+    }
+
+    #[cfg(target_arch = "riscv64")]
+    unsafe {
+        (*root).switch(BOOT_ASID);
+    }
+}

--- a/kernel/src/vm/boot.rs
+++ b/kernel/src/vm/boot.rs
@@ -210,6 +210,7 @@ pub fn switch_to_boot_page_table(
     direct_map_paddr: MemoryArea,
     initramfs_paddr: Option<MemoryArea>,
     heap_paddr: MemoryArea,
+    framebuffer_paddr: Option<MemoryArea>,
 ) {
     unsafe extern "C" {
         static __KERNEL_SPACE_START: usize;
@@ -288,6 +289,27 @@ pub fn switch_to_boot_page_table(
                 root,
                 initramfs_area,
                 initramfs_phys_area,
+                VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+            );
+        }
+    }
+
+    if let Some(fb) = framebuffer_paddr {
+        let fb_phys_area = MemoryArea {
+            start: align_down(fb.start, PAGE_SIZE),
+            end: align_up(fb.end + 1, PAGE_SIZE) - 1,
+        };
+        if !is_in_area(direct_map_phys_area, fb_phys_area.start)
+            || !is_in_area(direct_map_phys_area, fb_phys_area.end)
+        {
+            let fb_area = MemoryArea {
+                start: SCARLET_HHDM_BASE + fb_phys_area.start,
+                end: SCARLET_HHDM_BASE + fb_phys_area.end,
+            };
+            boot_map_range(
+                root,
+                fb_area,
+                fb_phys_area,
                 VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
             );
         }

--- a/kernel/src/vm/boot.rs
+++ b/kernel/src/vm/boot.rs
@@ -315,14 +315,7 @@ pub fn switch_to_boot_page_table(
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
     unsafe {
-        (*root).switch_ttbr1(BOOT_ASID);
-        (*root).switch(BOOT_ASID);
-    }
-
-    #[cfg(target_arch = "riscv64")]
-    unsafe {
-        (*root).switch(BOOT_ASID);
+        (*root).switch_for_boot(BOOT_ASID);
     }
 }

--- a/kernel/src/vm/manager.rs
+++ b/kernel/src/vm/manager.rs
@@ -1057,6 +1057,7 @@ mod tests {
     use crate::arch::vm::alloc_virtual_address_space;
     use crate::environment::PAGE_SIZE;
     use crate::vm::VirtualMemoryMap;
+    use crate::vm::get_current_direct_map_phys_range;
     use crate::vm::{manager::VirtualMemoryManager, vmem::MemoryArea};
 
     #[test_case]
@@ -1919,13 +1920,18 @@ mod tests {
     #[test_case]
     fn test_lazy_mapping_and_unmapping() {
         let manager = VirtualMemoryManager::new();
+        let (dm_phys_start, _) = get_current_direct_map_phys_range();
         let vma = MemoryArea {
             start: 0x1000,
             end: 0x1fff,
         };
+        let pma = MemoryArea {
+            start: dm_phys_start,
+            end: dm_phys_start + 0xfff,
+        };
         let map = VirtualMemoryMap {
             vmarea: vma,
-            pmarea: vma,
+            pmarea: pma,
             permissions: 0o644,
             is_shared: false,
             owner: None,

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -57,9 +57,10 @@ static KERNEL_AREA: Once<MemoryArea> = Once::new();
 /* Initialize MMU and enable paging */
 #[allow(static_mut_refs)]
 pub fn kernel_vm_init(
-    usable_area: MemoryArea,
-    direct_map_area: MemoryArea,
-    initramfs_area: Option<MemoryArea>,
+    usable_memory_paddr: MemoryArea,
+    direct_map_paddr: MemoryArea,
+    initramfs_paddr: Option<MemoryArea>,
+    hhdm_offset: usize,
 ) {
     let manager = get_kernel_vm_manager();
 
@@ -85,8 +86,8 @@ pub fn kernel_vm_init(
         end: addr::kernel_virt_to_phys(kernel_area.end),
     };
     let direct_map_phys_area = MemoryArea {
-        start: align_down(direct_map_area.start, PAGE_SIZE),
-        end: align_up(direct_map_area.end + 1, PAGE_SIZE) - 1,
+        start: align_down(direct_map_paddr.start, PAGE_SIZE),
+        end: align_up(direct_map_paddr.end + 1, PAGE_SIZE) - 1,
     };
     let hhdm_area = MemoryArea {
         start: phys_to_virt(direct_map_phys_area.start),
@@ -132,10 +133,10 @@ pub fn kernel_vm_init(
         .map_err(|e| panic!("Failed to map HHDM memory area: {}", e))
         .unwrap();
 
-    if let Some(initramfs_area) = initramfs_area {
+    if let Some(initramfs_paddr) = initramfs_paddr {
         let initramfs_phys_area = MemoryArea {
-            start: align_down(initramfs_area.start, PAGE_SIZE),
-            end: align_up(initramfs_area.end + 1, PAGE_SIZE) - 1,
+            start: align_down(initramfs_paddr.start, PAGE_SIZE),
+            end: align_up(initramfs_paddr.end + 1, PAGE_SIZE) - 1,
         };
         let initramfs_hhdm_area = MemoryArea {
             start: phys_to_virt(initramfs_phys_area.start),

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -10,8 +10,9 @@ pub mod manager;
 pub mod vmem;
 
 pub use addr::{
-    PhysAddr, VirtAddr, boot_phys_to_virt, get_boot_hhdm_offset, get_hhdm_offset, phys_to_virt,
-    set_hhdm_offset, virt_to_phys,
+    PhysAddr, VirtAddr, boot_phys_to_virt, boot_virt_to_phys, finalize_runtime_memory_layout,
+    get_boot_hhdm_offset, get_current_direct_map_phys_range, get_heap_phys_layout, get_hhdm_offset,
+    phys_to_virt, set_hhdm_offset, transition_kernel_memory_layout, virt_to_phys,
 };
 pub use ioremap::{ioremap, iounmap};
 
@@ -46,6 +47,8 @@ extern crate alloc;
 static KERNEL_VM_MANAGER: Once<VirtualMemoryManager> = Once::new();
 static HHDM_AREA: Once<MemoryArea> = Once::new();
 static KERNEL_HEAP_AREA: Once<MemoryArea> = Once::new();
+static HHDM_PHYS_AREA: Once<MemoryArea> = Once::new();
+static KERNEL_HEAP_PHYS_AREA: Once<MemoryArea> = Once::new();
 
 fn align_down(addr: usize, align: usize) -> usize {
     addr & !(align - 1)
@@ -110,6 +113,8 @@ pub fn kernel_vm_init(
     KERNEL_AREA.call_once(|| kernel_area);
     HHDM_AREA.call_once(|| hhdm_area);
     KERNEL_HEAP_AREA.call_once(|| kernel_heap_area);
+    HHDM_PHYS_AREA.call_once(|| direct_map_phys_area);
+    KERNEL_HEAP_PHYS_AREA.call_once(|| heap_phys_area);
 
     let kernel_map = VirtualMemoryMap {
         vmarea: kernel_area,
@@ -234,6 +239,8 @@ pub fn kernel_vm_init(
 
     #[cfg(any(debug_assertions, test))]
     early_println!("[vm] kernel_vm_init: done");
+
+    finalize_runtime_memory_layout();
 }
 
 pub fn user_vm_init(task: &Task) {
@@ -271,6 +278,12 @@ pub fn user_kernel_vm_init(task: &Task) {
     let kernel_heap_area = *KERNEL_HEAP_AREA
         .get()
         .expect("KERNEL_HEAP_AREA not initialized");
+    let hhdm_phys_area = *HHDM_PHYS_AREA
+        .get()
+        .expect("HHDM_PHYS_AREA not initialized");
+    let kernel_heap_phys_area = *KERNEL_HEAP_PHYS_AREA
+        .get()
+        .expect("KERNEL_HEAP_PHYS_AREA not initialized");
 
     let kernel_map = VirtualMemoryMap {
         vmarea: kernel_area,
@@ -300,10 +313,7 @@ pub fn user_kernel_vm_init(task: &Task) {
 
     let hhdm_map = VirtualMemoryMap {
         vmarea: hhdm_area,
-        pmarea: MemoryArea::new(
-            addr::virt_to_phys(hhdm_area.start),
-            addr::virt_to_phys(hhdm_area.end),
-        ),
+        pmarea: hhdm_phys_area,
         permissions: VirtualMemoryPermission::Read as usize
             | VirtualMemoryPermission::Write as usize,
         is_shared: true,
@@ -320,10 +330,7 @@ pub fn user_kernel_vm_init(task: &Task) {
 
     let heap_map = VirtualMemoryMap {
         vmarea: kernel_heap_area,
-        pmarea: MemoryArea::new(
-            addr::virt_to_phys(kernel_heap_area.start),
-            addr::virt_to_phys(kernel_heap_area.end),
-        ),
+        pmarea: kernel_heap_phys_area,
         permissions: VirtualMemoryPermission::Read as usize
             | VirtualMemoryPermission::Write as usize,
         is_shared: true,

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -4,11 +4,15 @@
 //! includes functions for managing virtual address spaces.
 
 pub mod addr;
+pub mod boot;
 pub mod ioremap;
 pub mod manager;
 pub mod vmem;
 
-pub use addr::{PhysAddr, VirtAddr, phys_to_virt, virt_to_phys};
+pub use addr::{
+    PhysAddr, VirtAddr, boot_phys_to_virt, get_boot_hhdm_offset, get_hhdm_offset, phys_to_virt,
+    set_hhdm_offset, virt_to_phys,
+};
 pub use ioremap::{ioremap, iounmap};
 
 use manager::VirtualMemoryManager;
@@ -27,9 +31,10 @@ use crate::environment::KERNEL_VM_STACK_START;
 use crate::environment::MAX_NUM_CPUS;
 use crate::environment::PAGE_SIZE;
 use crate::environment::USER_STACK_END;
+use crate::environment::{KERNEL_HEAP_BASE, SCARLET_HHDM_BASE};
 use crate::environment::{
-    KERNEL_KSTACK_REGION_END, KERNEL_KSTACK_REGION_START, KERNEL_KSTACK_SLOT_SIZE,
-    KERNEL_KSTACK_SLOTS, TASK_KERNEL_STACK_SIZE,
+    KERNEL_HEAP_SIZE, KERNEL_KSTACK_REGION_END, KERNEL_KSTACK_REGION_START,
+    KERNEL_KSTACK_SLOT_SIZE, KERNEL_KSTACK_SLOTS, TASK_KERNEL_STACK_SIZE,
 };
 use crate::sched::scheduler::get_scheduler;
 use crate::task::Task;
@@ -40,6 +45,7 @@ extern crate alloc;
 
 static KERNEL_VM_MANAGER: Once<VirtualMemoryManager> = Once::new();
 static HHDM_AREA: Once<MemoryArea> = Once::new();
+static KERNEL_HEAP_AREA: Once<MemoryArea> = Once::new();
 
 fn align_down(addr: usize, align: usize) -> usize {
     addr & !(align - 1)
@@ -57,10 +63,9 @@ static KERNEL_AREA: Once<MemoryArea> = Once::new();
 /* Initialize MMU and enable paging */
 #[allow(static_mut_refs)]
 pub fn kernel_vm_init(
-    usable_memory_paddr: MemoryArea,
     direct_map_paddr: MemoryArea,
     initramfs_paddr: Option<MemoryArea>,
-    hhdm_offset: usize,
+    heap_paddr: MemoryArea,
 ) {
     let manager = get_kernel_vm_manager();
 
@@ -90,12 +95,21 @@ pub fn kernel_vm_init(
         end: align_up(direct_map_paddr.end + 1, PAGE_SIZE) - 1,
     };
     let hhdm_area = MemoryArea {
-        start: phys_to_virt(direct_map_phys_area.start),
-        end: phys_to_virt(direct_map_phys_area.end),
+        start: SCARLET_HHDM_BASE + direct_map_phys_area.start,
+        end: SCARLET_HHDM_BASE + direct_map_phys_area.end,
+    };
+    let heap_phys_area = MemoryArea {
+        start: align_down(heap_paddr.start, PAGE_SIZE),
+        end: align_up(heap_paddr.end + 1, PAGE_SIZE) - 1,
+    };
+    let kernel_heap_area = MemoryArea {
+        start: KERNEL_HEAP_BASE,
+        end: KERNEL_HEAP_BASE + KERNEL_HEAP_SIZE - 1,
     };
 
     KERNEL_AREA.call_once(|| kernel_area);
     HHDM_AREA.call_once(|| hhdm_area);
+    KERNEL_HEAP_AREA.call_once(|| kernel_heap_area);
 
     let kernel_map = VirtualMemoryMap {
         vmarea: kernel_area,
@@ -131,6 +145,23 @@ pub fn kernel_vm_init(
     root_page_table
         .map_memory_area(asid, hhdm_map, true, true)
         .map_err(|e| panic!("Failed to map HHDM memory area: {}", e))
+        .unwrap();
+
+    let heap_map = VirtualMemoryMap {
+        vmarea: kernel_heap_area,
+        pmarea: heap_phys_area,
+        permissions: VirtualMemoryPermission::Read as usize
+            | VirtualMemoryPermission::Write as usize,
+        is_shared: true,
+        owner: None,
+    };
+    get_kernel_vm_manager()
+        .add_memory_map(heap_map.clone())
+        .map_err(|e| panic!("Failed to add heap memory map: {}", e))
+        .unwrap();
+    root_page_table
+        .map_memory_area(asid, heap_map, true, true)
+        .map_err(|e| panic!("Failed to map heap memory area: {}", e))
         .unwrap();
 
     if let Some(initramfs_paddr) = initramfs_paddr {
@@ -171,6 +202,11 @@ pub fn kernel_vm_init(
         "HHDM mapped               : {:#018x} - {:#018x}",
         hhdm_area.start,
         hhdm_area.end
+    );
+    early_println!(
+        "Kernel heap mapped        : {:#018x} - {:#018x}",
+        kernel_heap_area.start,
+        kernel_heap_area.end
     );
 
     #[cfg(any(debug_assertions, test))]
@@ -232,6 +268,9 @@ pub fn user_kernel_vm_init(task: &Task) {
 
     let kernel_area = *KERNEL_AREA.get().expect("KERNEL_AREA not initialized");
     let hhdm_area = *HHDM_AREA.get().expect("HHDM_AREA not initialized");
+    let kernel_heap_area = *KERNEL_HEAP_AREA
+        .get()
+        .expect("KERNEL_HEAP_AREA not initialized");
 
     let kernel_map = VirtualMemoryMap {
         vmarea: kernel_area,
@@ -277,6 +316,26 @@ pub fn user_kernel_vm_init(task: &Task) {
     root_page_table
         .map_memory_area(asid, hhdm_map, true, true)
         .map_err(|e| panic!("Failed to map HHDM memory area: {}", e))
+        .unwrap();
+
+    let heap_map = VirtualMemoryMap {
+        vmarea: kernel_heap_area,
+        pmarea: MemoryArea::new(
+            addr::virt_to_phys(kernel_heap_area.start),
+            addr::virt_to_phys(kernel_heap_area.end),
+        ),
+        permissions: VirtualMemoryPermission::Read as usize
+            | VirtualMemoryPermission::Write as usize,
+        is_shared: true,
+        owner: None,
+    };
+    task.vm_manager
+        .add_memory_map(heap_map.clone())
+        .map_err(|e| panic!("Failed to add heap memory map: {}", e))
+        .unwrap();
+    root_page_table
+        .map_memory_area(asid, heap_map, true, true)
+        .map_err(|e| panic!("Failed to map heap memory area: {}", e))
         .unwrap();
     task.data_size.store(kernel_area.end + 1, Ordering::SeqCst);
 

--- a/kernel/targets/aarch64-unknown-none-elf.json
+++ b/kernel/targets/aarch64-unknown-none-elf.json
@@ -1,20 +1,20 @@
 {
   "arch": "aarch64",
   "code-model": "large",
+  "abi": "softfloat",
   "cpu": "generic",
   "crt-objects-fallback": "false",
   "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+strict-align",
+  "features": "+v8a,+strict-align,-neon",
 
   "linker": "rust-lld",
   "linker-flavor": "gnu-lld",
-  "llvm-target": "aarch64-elf",
-  "llvm-abiname": "lp64",
-  "max-atomic-width": 64,
+  "llvm-target": "aarch64-unknown-none",
+  "max-atomic-width": 128,
   "metadata": {
-    "description": "Bare AArch64 (ARMv8-A ISA)",
+    "description": "Bare AArch64 (ARMv8-A ISA, softfloat)",
     "host_tools": false,
     "std": false,
     "tier": 2
@@ -24,8 +24,11 @@
       "ld.lld": ["-T", "lds/aarch64_limine.ld"]
     },
   "relocation-model": "static",
+  "stack-probes": {
+    "kind": "inline"
+  },
   "supported-sanitizers": [
-    "shadow-call-stack",
+    "kcfi",
     "kernel-address"
   ],
   "target-pointer-width": 64

--- a/user/bin/src/scarlet_desktop/taskbar/scarlet_ui.rs
+++ b/user/bin/src/scarlet_desktop/taskbar/scarlet_ui.rs
@@ -541,6 +541,11 @@ impl Application for TaskBarApp {
         self.update_menu_for_app(window_id, app_name, &resolved_menu_titles);
     }
 
+    fn on_resize(&mut self, width: u32, _height: u32) {
+        println!("[TaskBar] on_resize: width={}", width);
+        self.screen_width.set(width as f32);
+    }
+
     fn body(&self) -> impl View {
         let cpu = self.cpu_usage.get();
         let mem = self.memory_usage.get();

--- a/user/bin/src/sws/compositor.rs
+++ b/user/bin/src/sws/compositor.rs
@@ -2001,6 +2001,76 @@ impl Compositor {
                     self.broadcast_focus_change(window_id);
                 }
 
+                // Auto-configure DESKTOP and TASKBAR windows to match screen dimensions.
+                // The compositor is the authoritative source for screen size, so it enforces
+                // the correct dimensions even if the client requested a different size.
+                match wtype {
+                    super::window::WindowType::Desktop => {
+                        let needs_resize =
+                            width != self.screen_width || height != self.screen_height;
+                        if needs_resize {
+                            println!(
+                                "[Compositor] Auto-resizing DESKTOP window #{} from {}x{} to {}x{}",
+                                window_id, width, height, self.screen_width, self.screen_height
+                            );
+                            self.window_manager.resize_window_in_place(
+                                window_id,
+                                self.screen_width,
+                                self.screen_height,
+                            );
+                            let payload = sws_protocol::payload_window_configure(
+                                window_id,
+                                self.screen_width,
+                                self.screen_height,
+                            );
+                            super::ipc::send_message_to_window(
+                                window_id,
+                                sws_protocol::server_msg::WINDOW_CONFIGURE,
+                                payload.to_vec(),
+                            );
+                        }
+                    }
+                    super::window::WindowType::Taskbar => {
+                        if width != self.screen_width {
+                            println!(
+                                "[Compositor] Auto-resizing TASKBAR window #{} width from {} to {}",
+                                window_id, width, self.screen_width
+                            );
+                            self.window_manager.resize_window_in_place(
+                                window_id,
+                                self.screen_width,
+                                height,
+                            );
+                            let payload = sws_protocol::payload_window_configure(
+                                window_id,
+                                self.screen_width,
+                                height,
+                            );
+                            super::ipc::send_message_to_window(
+                                window_id,
+                                sws_protocol::server_msg::WINDOW_CONFIGURE,
+                                payload.to_vec(),
+                            );
+
+                            let workarea_y = height as i32;
+                            let workarea_height = self.screen_height.saturating_sub(height);
+                            self.workarea =
+                                Some((0, workarea_y, self.screen_width, workarea_height));
+                            self.window_manager.set_workarea(
+                                0,
+                                workarea_y,
+                                self.screen_width,
+                                workarea_height,
+                            );
+                            println!(
+                                "[Compositor] Updated workarea for resized taskbar: y={}, height={}",
+                                workarea_y, workarea_height
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+
                 // Don't trigger redraw yet - wait for client to draw and send UPDATE_BUFFER
                 // self.full_redraw_needed = true;
 
@@ -2737,22 +2807,17 @@ impl Compositor {
                     "[Compositor] GetScreenSize request from client {}",
                     client_id
                 );
-                let width = self.screen_width;
-                let height = self.screen_height;
-                // Send SCREEN_SIZE response to the client
-                // Use the first window (if any) to send the response
-                if let Some(first_window_id) = self.window_manager.get_first_window_id() {
-                    let payload = sws_protocol::payload_screen_size(width, height);
-                    let _ = send_message_to_window(
-                        first_window_id,
-                        sws_protocol::server_msg::SCREEN_SIZE,
-                        payload.to_vec(),
-                    );
-                    println!(
-                        "[Compositor] Sent SCREEN_SIZE: {}x{} to client {} (via window {})",
-                        width, height, client_id, first_window_id
-                    );
-                }
+                let payload =
+                    sws_protocol::payload_screen_size(self.screen_width, self.screen_height);
+                super::ipc::send_message_to_client(
+                    client_id,
+                    sws_protocol::server_msg::SCREEN_SIZE,
+                    payload.to_vec(),
+                );
+                println!(
+                    "[Compositor] Sent SCREEN_SIZE: {}x{} to client {}",
+                    self.screen_width, self.screen_height, client_id
+                );
             }
             IpcEvent::GetWindowList { client_id } => {
                 println!(

--- a/user/bin/src/sws/compositor.rs
+++ b/user/bin/src/sws/compositor.rs
@@ -1157,7 +1157,7 @@ impl Compositor {
         let src = &self.backbuffer[src_off..];
 
         self.framebuffer
-            .write_block_strided(x0 as u32, y0 as u32, w, h, src, stride as usize)
+            .write_block_bgra_strided(x0 as u32, y0 as u32, w, h, src, stride as usize)
             .map_err(|_| "Failed to write backbuffer")?;
 
         self.cursor.mark_drawn();

--- a/user/bin/src/sws/ipc.rs
+++ b/user/bin/src/sws/ipc.rs
@@ -1676,27 +1676,10 @@ fn client_thread_main(client_id: usize, mut socket: Socket) {
             }
             Ok(ClientMessageRef::GetScreenSize {}) => {
                 println!(
-                    "[ClientThread {}] GetScreenSize: requesting screen size",
+                    "[ClientThread {}] GetScreenSize: forwarding to compositor",
                     client_id
                 );
-                // Send response directly with default screen size
-                // TODO: Get actual screen size from compositor
-                let screen_width = 1024; // Default fallback
-                let screen_height = 768;
-                let payload = protocol::payload_screen_size(screen_width, screen_height);
-                if let Err(e) =
-                    write_frame(&mut socket, protocol::server_msg::SCREEN_SIZE, &payload)
-                {
-                    println!(
-                        "[ClientThread {}] Failed to send SCREEN_SIZE response: {:?}",
-                        client_id, e
-                    );
-                } else {
-                    println!(
-                        "[ClientThread {}] Sent SCREEN_SIZE: {}x{}",
-                        client_id, screen_width, screen_height
-                    );
-                }
+                push_ipc_event(IpcEvent::GetScreenSize { client_id });
             }
             Ok(ClientMessageRef::GetWindowList {}) => {
                 println!(

--- a/user/bin/src/sws/window.rs
+++ b/user/bin/src/sws/window.rs
@@ -930,6 +930,21 @@ impl WindowManager {
         }
     }
 
+    /// Resize a window in-place (compositor-side only).
+    ///
+    /// Updates the window's internal dimensions without replacing the buffer.
+    /// The client is expected to handle the corresponding WINDOW_CONFIGURE
+    /// message and provide a new buffer via ResizeWindow.
+    pub fn resize_window_in_place(&mut self, id: WindowId, width: u32, height: u32) -> bool {
+        if let Some(w) = self.get_window_mut(id) {
+            w.width = width.max(1);
+            w.height = height.max(1);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Minimize a window (hide from display but keep in window list)
     pub fn minimize_window(&mut self, id: WindowId) -> bool {
         if let Some(w) = self.get_window_mut(id) {

--- a/user/lib/framebuffer/src/lib.rs
+++ b/user/lib/framebuffer/src/lib.rs
@@ -206,6 +206,73 @@ pub struct Framebuffer {
 }
 
 impl Framebuffer {
+    fn bytes_per_pixel(var_info: &FbVarScreenInfo) -> usize {
+        (var_info.bits_per_pixel as usize).div_ceil(8)
+    }
+
+    fn scale_component_to_field(value: u8, field: FbBitfield) -> u32 {
+        if field.length == 0 {
+            return 0;
+        }
+
+        let max = (1u32 << field.length) - 1;
+        let scaled = ((value as u32) * max + 127) / 255;
+
+        if field.msb_right == 0 {
+            scaled
+        } else {
+            scaled.reverse_bits() >> (u32::BITS - field.length)
+        }
+    }
+
+    fn pack_bgra_pixel(color: [u8; 4], var_info: &FbVarScreenInfo) -> u32 {
+        (Self::scale_component_to_field(color[2], var_info.red) << var_info.red.offset)
+            | (Self::scale_component_to_field(color[1], var_info.green) << var_info.green.offset)
+            | (Self::scale_component_to_field(color[0], var_info.blue) << var_info.blue.offset)
+            | (Self::scale_component_to_field(color[3], var_info.transp) << var_info.transp.offset)
+    }
+
+    fn write_packed_pixel_bytes(dst: &mut [u8], color: [u8; 4], var_info: &FbVarScreenInfo) {
+        let bytes_per_pixel = Self::bytes_per_pixel(var_info);
+        let pixel = Self::pack_bgra_pixel(color, var_info).to_le_bytes();
+        dst[..bytes_per_pixel].copy_from_slice(&pixel[..bytes_per_pixel]);
+    }
+
+    fn is_native_bgra8888(var_info: &FbVarScreenInfo) -> bool {
+        var_info.bits_per_pixel == 32
+            && var_info.red.offset == 16
+            && var_info.red.length == 8
+            && var_info.red.msb_right == 0
+            && var_info.green.offset == 8
+            && var_info.green.length == 8
+            && var_info.green.msb_right == 0
+            && var_info.blue.offset == 0
+            && var_info.blue.length == 8
+            && var_info.blue.msb_right == 0
+            && var_info.transp.offset == 24
+            && var_info.transp.length == 8
+            && var_info.transp.msb_right == 0
+    }
+
+    fn populate_line_with_color(
+        line: &mut [u8],
+        width: usize,
+        color: [u8; 4],
+        var_info: &FbVarScreenInfo,
+    ) {
+        let bytes_per_pixel = Self::bytes_per_pixel(var_info);
+        for x in 0..width {
+            let pixel_offset = x * bytes_per_pixel;
+            if pixel_offset + bytes_per_pixel <= line.len() {
+                Self::write_packed_pixel_bytes(
+                    &mut line[pixel_offset..pixel_offset + bytes_per_pixel],
+                    color,
+                    var_info,
+                );
+            }
+        }
+    }
+
     /// Open a framebuffer device
     ///
     /// # Arguments
@@ -356,8 +423,10 @@ impl Framebuffer {
         let var_info = self.get_var_screen_info()?;
         let fix_info = self.get_fix_screen_info()?;
 
-        let bytes_per_pixel = (var_info.bits_per_pixel / 8) as usize;
+        let bytes_per_pixel = Self::bytes_per_pixel(&var_info);
         let line_length = fix_info.line_length as usize;
+        let mut packed_pixel = [0u8; 4];
+        Self::write_packed_pixel_bytes(&mut packed_pixel[..bytes_per_pixel], color, &var_info);
 
         // Calculate pixel offset
         let offset = y as usize * line_length + x as usize * bytes_per_pixel;
@@ -370,8 +439,7 @@ impl Framebuffer {
 
             unsafe {
                 let pixel_ptr = (mapped_addr + offset) as *mut u8;
-                let write_len = bytes_per_pixel.min(4);
-                core::ptr::copy_nonoverlapping(color.as_ptr(), pixel_ptr, write_len);
+                core::ptr::copy_nonoverlapping(packed_pixel.as_ptr(), pixel_ptr, bytes_per_pixel);
             }
         } else {
             // Fallback to file I/O if mmap is not available
@@ -379,9 +447,8 @@ impl Framebuffer {
                 .seek(SeekFrom::Start(offset as u64))
                 .map_err(|_| HandleError::SystemError(-1))?;
 
-            let write_len = bytes_per_pixel.min(4);
             self.file
-                .write(&color[..write_len])
+                .write(&packed_pixel[..bytes_per_pixel])
                 .map_err(|_| HandleError::SystemError(-1))?;
         }
 
@@ -451,7 +518,7 @@ impl Framebuffer {
         let var_info = self.get_var_screen_info()?;
         let fix_info = self.get_fix_screen_info()?;
 
-        let bytes_per_pixel = (var_info.bits_per_pixel / 8) as usize;
+        let bytes_per_pixel = Self::bytes_per_pixel(&var_info);
         let line_length = fix_info.line_length as usize;
         let block_line_bytes = width as usize * bytes_per_pixel;
 
@@ -535,7 +602,7 @@ impl Framebuffer {
         let var_info = self.get_var_screen_info()?;
         let fix_info = self.get_fix_screen_info()?;
 
-        let bytes_per_pixel = (var_info.bits_per_pixel / 8) as usize;
+        let bytes_per_pixel = Self::bytes_per_pixel(&var_info);
         let line_length = fix_info.line_length as usize;
         let block_line_bytes = width as usize * bytes_per_pixel;
 
@@ -593,6 +660,93 @@ impl Framebuffer {
         Ok(())
     }
 
+    pub fn write_block_bgra_strided(
+        &mut self,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+        data: &[u8],
+        src_stride_bytes: usize,
+    ) -> HandleResult<()> {
+        if width == 0 || height == 0 {
+            return Ok(());
+        }
+
+        let var_info = self.get_var_screen_info()?;
+        let fix_info = self.get_fix_screen_info()?;
+        let dst_bytes_per_pixel = Self::bytes_per_pixel(&var_info);
+        let line_length = fix_info.line_length as usize;
+        let src_line_bytes = width as usize * 4;
+
+        if Self::is_native_bgra8888(&var_info) {
+            return self.write_block_strided(x, y, width, height, data, src_stride_bytes);
+        }
+
+        if src_stride_bytes < src_line_bytes {
+            return Err(HandleError::InvalidParameter);
+        }
+
+        let required = (height as usize - 1)
+            .saturating_mul(src_stride_bytes)
+            .saturating_add(src_line_bytes);
+        if required > data.len() {
+            return Err(HandleError::InvalidParameter);
+        }
+
+        let mut converted_line = vec![0u8; width as usize * dst_bytes_per_pixel];
+
+        for row in 0..height {
+            let src_off = row as usize * src_stride_bytes;
+            let src_row = &data[src_off..src_off + src_line_bytes];
+
+            for pixel in 0..width as usize {
+                let src_pixel_offset = pixel * 4;
+                let dst_pixel_offset = pixel * dst_bytes_per_pixel;
+                let color = [
+                    src_row[src_pixel_offset],
+                    src_row[src_pixel_offset + 1],
+                    src_row[src_pixel_offset + 2],
+                    src_row[src_pixel_offset + 3],
+                ];
+                Self::write_packed_pixel_bytes(
+                    &mut converted_line[dst_pixel_offset..dst_pixel_offset + dst_bytes_per_pixel],
+                    color,
+                    &var_info,
+                );
+            }
+
+            let dst_y = y + row;
+            let dst_off = (dst_y as usize)
+                .saturating_mul(line_length)
+                .saturating_add((x as usize).saturating_mul(dst_bytes_per_pixel));
+
+            if let Some((mapped_addr, mapped_size)) = self.mapped_buffer {
+                if dst_off.saturating_add(converted_line.len()) > mapped_size {
+                    return Err(HandleError::InvalidParameter);
+                }
+
+                unsafe {
+                    let dst_ptr = (mapped_addr + dst_off) as *mut u8;
+                    core::ptr::copy_nonoverlapping(
+                        converted_line.as_ptr(),
+                        dst_ptr,
+                        converted_line.len(),
+                    );
+                }
+            } else {
+                self.file
+                    .seek(SeekFrom::Start(dst_off as u64))
+                    .map_err(|_| HandleError::SystemError(-1))?;
+                self.file
+                    .write(&converted_line)
+                    .map_err(|_| HandleError::SystemError(-1))?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Fill the entire screen with a solid color
     ///
     /// # Arguments
@@ -606,20 +760,11 @@ impl Framebuffer {
 
         let width = var_info.xres as usize;
         let height = var_info.yres as usize;
-        let bytes_per_pixel = (var_info.bits_per_pixel / 8) as usize;
         let line_length = fix_info.line_length as usize;
 
         // Create a line buffer filled with the color
         let mut line_buffer = vec![0u8; line_length];
-
-        // Fill line buffer with repeated color pattern
-        for x in 0..width {
-            let pixel_offset = x * bytes_per_pixel;
-            if pixel_offset + bytes_per_pixel <= line_buffer.len() {
-                line_buffer[pixel_offset..pixel_offset + bytes_per_pixel.min(4)]
-                    .copy_from_slice(&color[..bytes_per_pixel.min(4)]);
-            }
-        }
+        Self::populate_line_with_color(&mut line_buffer, width, color, &var_info);
 
         // Write the same line to all rows
         for y in 0..height {
@@ -655,21 +800,14 @@ impl Framebuffer {
         let var_info = self.get_var_screen_info()?;
         let fix_info = self.get_fix_screen_info()?;
 
-        let bytes_per_pixel = (var_info.bits_per_pixel / 8) as usize;
+        let bytes_per_pixel = Self::bytes_per_pixel(&var_info);
         let line_length = fix_info.line_length as usize;
 
         // Create a single-line buffer for the rectangle width.
         let line_bytes = width as usize * bytes_per_pixel;
         let mut line_buffer = vec![0u8; line_bytes];
 
-        // Fill line buffer with repeated color pattern
-        for pixel in 0..width as usize {
-            let pixel_offset = pixel * bytes_per_pixel;
-            if pixel_offset + bytes_per_pixel <= line_buffer.len() {
-                line_buffer[pixel_offset..pixel_offset + bytes_per_pixel.min(4)]
-                    .copy_from_slice(&color[..bytes_per_pixel.min(4)]);
-            }
-        }
+        Self::populate_line_with_color(&mut line_buffer, width as usize, color, &var_info);
 
         if let Some((mapped_addr, mapped_size)) = self.mapped_buffer {
             for row in 0..height {
@@ -719,7 +857,7 @@ impl Framebuffer {
         let var_info = self.get_var_screen_info()?;
         let width = var_info.xres as usize;
         let height = var_info.yres as usize;
-        let bytes_per_pixel = (var_info.bits_per_pixel / 8) as usize;
+        let bytes_per_pixel = Self::bytes_per_pixel(&var_info);
 
         // Create line buffer with horizontal gradient
         let line_bytes = width * bytes_per_pixel;
@@ -742,8 +880,11 @@ impl Framebuffer {
 
             let pixel_offset = x * bytes_per_pixel;
             if pixel_offset + bytes_per_pixel <= line_buffer.len() {
-                line_buffer[pixel_offset..pixel_offset + bytes_per_pixel.min(4)]
-                    .copy_from_slice(&color[..bytes_per_pixel.min(4)]);
+                Self::write_packed_pixel_bytes(
+                    &mut line_buffer[pixel_offset..pixel_offset + bytes_per_pixel],
+                    color,
+                    &var_info,
+                );
             }
         }
 
@@ -771,7 +912,7 @@ impl Framebuffer {
         let var_info = self.get_var_screen_info()?;
         let width = var_info.xres as usize;
         let height = var_info.yres as usize;
-        let bytes_per_pixel = (var_info.bits_per_pixel / 8) as usize;
+        let bytes_per_pixel = Self::bytes_per_pixel(&var_info);
 
         // Create line buffer filled with this color
         let line_bytes = width * bytes_per_pixel;
@@ -794,8 +935,11 @@ impl Framebuffer {
             for x in 0..width {
                 let pixel_offset = x * bytes_per_pixel;
                 if pixel_offset + bytes_per_pixel <= line_buffer.len() {
-                    line_buffer[pixel_offset..pixel_offset + bytes_per_pixel.min(4)]
-                        .copy_from_slice(&color[..bytes_per_pixel.min(4)]);
+                    Self::write_packed_pixel_bytes(
+                        &mut line_buffer[pixel_offset..pixel_offset + bytes_per_pixel],
+                        color,
+                        &var_info,
+                    );
                 }
             }
 
@@ -829,7 +973,7 @@ impl Framebuffer {
         horizontal: bool,
     ) -> HandleResult<()> {
         let var_info = self.get_var_screen_info()?;
-        let bytes_per_pixel = (var_info.bits_per_pixel / 8) as usize;
+        let bytes_per_pixel = Self::bytes_per_pixel(&var_info);
 
         if horizontal {
             // Horizontal gradient: create one line buffer and reuse it
@@ -847,8 +991,11 @@ impl Framebuffer {
 
                 let pixel_offset = px * bytes_per_pixel;
                 if pixel_offset + bytes_per_pixel <= line_buffer.len() {
-                    line_buffer[pixel_offset..pixel_offset + bytes_per_pixel.min(4)]
-                        .copy_from_slice(&color[..bytes_per_pixel.min(4)]);
+                    Self::write_packed_pixel_bytes(
+                        &mut line_buffer[pixel_offset..pixel_offset + bytes_per_pixel],
+                        color,
+                        &var_info,
+                    );
                 }
             }
 

--- a/user/lib/scarlet-ui/Cargo.lock
+++ b/user/lib/scarlet-ui/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "framebuffer"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "scarlet_std",
 ]
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "scarlet_std"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "hashbrown",
  "spin",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "sws_protocol"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "scarlet_std",
 ]

--- a/user/lib/scarlet-ui/src/application.rs
+++ b/user/lib/scarlet-ui/src/application.rs
@@ -3,20 +3,20 @@
 //! The Application trait provides the main loop and lifecycle management
 //! for ScarletUI applications.
 
-use crate::view::View;
-use crate::geometry::Size;
-use crate::event::Event;
-use crate::platform::{PlatformWindow, SWSPlatformWindow};
-use crate::pipeline::RenderingPipeline;
+use crate::element::{Element, ElementId, LayoutConstraints, UpdateResult, WindowSizeLimits};
 use crate::error::Result;
+use crate::event::Event;
+use crate::geometry::Size;
+use crate::geometry::{Point, Rect};
 use crate::menu_model;
+use crate::pipeline::RenderingPipeline;
+use crate::platform::{PlatformWindow, SWSPlatformWindow};
 use crate::state::StateId;
 use crate::state::SubscriptionId;
-use crate::element::{Element, ElementId, LayoutConstraints, UpdateResult, WindowSizeLimits};
-use crate::geometry::{Point, Rect};
+use crate::view::View;
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::any::Any;
 use std::println;
 
@@ -48,6 +48,15 @@ pub trait Application: View {
     /// This is used by TaskBar to update its menu bar.
     /// Default implementation does nothing.
     fn on_active_app_changed(&mut self, _window_id: u32, _app_name: &str, _menu_titles: &str) {
+        // Default: do nothing
+    }
+
+    /// Handle window resize event
+    ///
+    /// Called when the window is resized. Applications like TaskBar
+    /// can override this to update their internal state (e.g., screen_width).
+    /// Default implementation does nothing.
+    fn on_resize(&mut self, _width: u32, _height: u32) {
         // Default: do nothing
     }
 
@@ -131,7 +140,7 @@ pub trait Application: View {
                 focus_on_create,
                 active_on_focus,
             )
-                .map_err(|_| crate::error::Error::WindowCreationFailed)?
+            .map_err(|_| crate::error::Error::WindowCreationFailed)?
         } else {
             SWSPlatformWindow::create_with_type_and_menu_and_policies(
                 &app_id,
@@ -178,6 +187,7 @@ pub trait Application: View {
                         let new_size = Size::new(width as f32, height as f32);
                         if platform_window.resize(width, height).is_ok() {
                             pipeline.resize(new_size);
+                            self.on_resize(width, height);
                             if let Some(buffer) = pipeline.render() {
                                 platform_window.present(buffer);
                                 presented_this_cycle = true;
@@ -202,12 +212,15 @@ pub trait Application: View {
                                 if *offset + 4 > data.len() {
                                     return String::new();
                                 }
-                                let len = u32::from_le_bytes(data[*offset..*offset+4].try_into().unwrap()) as usize;
+                                let len = u32::from_le_bytes(
+                                    data[*offset..*offset + 4].try_into().unwrap(),
+                                ) as usize;
                                 *offset += 4;
                                 if *offset + len > data.len() {
                                     return String::new();
                                 }
-                                let s = core::str::from_utf8(&data[*offset..*offset+len]).unwrap_or("");
+                                let s = core::str::from_utf8(&data[*offset..*offset + len])
+                                    .unwrap_or("");
                                 *offset += len;
                                 String::from(s)
                             };
@@ -243,12 +256,15 @@ pub trait Application: View {
                                 if *offset + 4 > data.len() {
                                     return String::new();
                                 }
-                                let len = u32::from_le_bytes(data[*offset..*offset+4].try_into().unwrap()) as usize;
+                                let len = u32::from_le_bytes(
+                                    data[*offset..*offset + 4].try_into().unwrap(),
+                                ) as usize;
                                 *offset += 4;
                                 if *offset + len > data.len() {
                                     return String::new();
                                 }
-                                let s = core::str::from_utf8(&data[*offset..*offset+len]).unwrap_or("");
+                                let s = core::str::from_utf8(&data[*offset..*offset + len])
+                                    .unwrap_or("");
                                 *offset += len;
                                 String::from(s)
                             };

--- a/user/lib/std/src/arch/aarch64.rs
+++ b/user/lib/std/src/arch/aarch64.rs
@@ -55,6 +55,7 @@ pub fn arch_syscall0(syscall: Syscall) -> usize {
             "svc #0",
             in("x8") syscall as usize,
             out("x0") ret,
+            clobber_abi("C"),
             options(nostack)
         );
     }
@@ -67,7 +68,8 @@ pub fn arch_syscall1(syscall: Syscall, arg1: usize) -> usize {
         asm!(
             "svc #0",
             in("x8") syscall as usize,
-            inout("x0") arg1 => ret,
+            inlateout("x0") arg1 => ret,
+            clobber_abi("C"),
             options(nostack)
         );
     }
@@ -80,8 +82,9 @@ pub fn arch_syscall2(syscall: Syscall, arg1: usize, arg2: usize) -> usize {
         asm!(
             "svc #0",
             in("x8") syscall as usize,
-            inout("x0") arg1 => ret,
+            inlateout("x0") arg1 => ret,
             in("x1") arg2,
+            clobber_abi("C"),
             options(nostack)
         );
     }
@@ -94,9 +97,10 @@ pub fn arch_syscall3(syscall: Syscall, arg1: usize, arg2: usize, arg3: usize) ->
         asm!(
             "svc #0",
             in("x8") syscall as usize,
-            inout("x0") arg1 => ret,
+            inlateout("x0") arg1 => ret,
             in("x1") arg2,
             in("x2") arg3,
+            clobber_abi("C"),
             options(nostack)
         );
     }
@@ -115,10 +119,11 @@ pub fn arch_syscall4(
         asm!(
             "svc #0",
             in("x8") syscall as usize,
-            inout("x0") arg1 => ret,
+            inlateout("x0") arg1 => ret,
             in("x1") arg2,
             in("x2") arg3,
             in("x3") arg4,
+            clobber_abi("C"),
             options(nostack)
         );
     }
@@ -138,11 +143,12 @@ pub fn arch_syscall5(
         asm!(
             "svc #0",
             in("x8") syscall as usize,
-            inout("x0") arg1 => ret,
+            inlateout("x0") arg1 => ret,
             in("x1") arg2,
             in("x2") arg3,
             in("x3") arg4,
             in("x4") arg5,
+            clobber_abi("C"),
             options(nostack)
         );
     }
@@ -163,12 +169,13 @@ pub fn arch_syscall6(
         asm!(
             "svc #0",
             in("x8") syscall as usize,
-            inout("x0") arg1 => ret,
+            inlateout("x0") arg1 => ret,
             in("x1") arg2,
             in("x2") arg3,
             in("x3") arg4,
             in("x4") arg5,
             in("x5") arg6,
+            clobber_abi("C"),
             options(nostack)
         );
     }


### PR DESCRIPTION
This pull request introduces significant improvements to the AArch64 kernel's interrupt and timer handling, refactors CPU ID access, and updates boot information structures. The changes make timer interrupt routing more flexible and platform-agnostic, unify the handling of timer interrupts across different hardware, and modernize how CPU IDs are retrieved. Additionally, the boot process is updated to better handle memory regions and device information.

**Interrupt and Timer Handling Improvements:**

- Added a new `TimerInterruptRoute` enum and associated atomic state to track and configure how timer interrupts are routed (e.g., via external controller IRQ or FIQ), allowing for more flexible platform support. Includes helper functions for configuration and querying.
- Implemented platform-agnostic functions `enable_arch_timer_interrupt`, `disable_arch_timer_interrupt`, and `is_arch_timer_pending` to manage timer interrupts at both the local and external controller levels, handling differences between GIC and Apple AIC.
- Refactored the timer initialization and stop logic in `ArchTimer` to use the new platform-agnostic interrupt enable/disable functions, simplifying and unifying timer setup across platforms.

**CPU ID and Trap Handling Refactoring:**

- Refactored all uses of the CPU ID to use `get_cpu().get_cpuid()` instead of reading the MPIDR_EL1 register directly, removing the now-unnecessary `get_current_cpu_id()` function. This modernizes and centralizes CPU ID retrieval. [[1]](diffhunk://#diff-def212af33870a4eabfff42dd10c9f15e842e8fd0c0b87391637401d0443fb09R95-L103) [[2]](diffhunk://#diff-def212af33870a4eabfff42dd10c9f15e842e8fd0c0b87391637401d0443fb09L131-R130) [[3]](diffhunk://#diff-def212af33870a4eabfff42dd10c9f15e842e8fd0c0b87391637401d0443fb09L477-L489) [[4]](diffhunk://#diff-def212af33870a4eabfff42dd10c9f15e842e8fd0c0b87391637401d0443fb09L726-R717)
- Updated trap and interrupt handler signatures and logic to pass and use the `trap_kind` parameter, improving the distinction between IRQ and other trap types and ensuring timer ticks are handled appropriately. [[1]](diffhunk://#diff-6a8c9f889e4131a7157a9dfbb4c97c32dfeb8785e0d277209ac87410292a167dL11-R18) [[2]](diffhunk://#diff-6a8c9f889e4131a7157a9dfbb4c97c32dfeb8785e0d277209ac87410292a167dL24-R29) [[3]](diffhunk://#diff-c18054cf07c744e8437b4ae94f0362baec2d05f4698c67b1af84c7d4202a591fL189-R190)

**Boot Process and Memory Management Updates:**

- Enhanced the boot process to track and initialize the HHDM (Higher Half Direct Map) physical span, framebuffer area, and relocated FDT physical address, and to pass these to `BootInfo`, improving memory and device initialization. [[1]](diffhunk://#diff-285aeba21fbdcd3c6d5fbb3854cb9625123f4b93a0114ec7e46d52b10560360aL5-R14) [[2]](diffhunk://#diff-285aeba21fbdcd3c6d5fbb3854cb9625123f4b93a0114ec7e46d52b10560360aR65-R103)

**Other Notable Changes:**

- Updated the `Trapframe` struct to include a padding field, ensuring its size matches expectations for the trampoline code. [[1]](diffhunk://#diff-def212af33870a4eabfff42dd10c9f15e842e8fd0c0b87391637401d0443fb09R260) [[2]](diffhunk://#diff-def212af33870a4eabfff42dd10c9f15e842e8fd0c0b87391637401d0443fb09R273)
- Modified the logic for configuring user entry in trapframes to mask/unmask both IRQ and FIQ bits based on policy, improving interrupt control for user tasks.

**Build System Updates:**

- Updated the `Makefile.toml` to ensure the correct boot image tasks are dependencies for kernel run tasks, improving build reliability for both AArch64 and RISC-V.