### PR TITLE
Feature/apple display driver

### DIFF
--- a/kernel/src/device/graphics/manager.rs
+++ b/kernel/src/device/graphics/manager.rs
@@ -30,9 +30,9 @@ use spin::{Mutex, RwLock};
 
 use super::output::DisplayOutput;
 use crate::device::{
+    DeviceType,
     graphics::FramebufferConfig,
     manager::{DeviceManager, SharedDevice},
-    DeviceType,
 };
 use crate::vm::addr::phys_to_virt;
 
@@ -689,7 +689,7 @@ mod test_utils {
 mod tests {
     use super::*;
     use crate::device::graphics::{
-        manager::GraphicsManager, FramebufferConfig, GenericGraphicsDevice, PixelFormat,
+        FramebufferConfig, GenericGraphicsDevice, PixelFormat, manager::GraphicsManager,
     };
     use alloc::{string::ToString, sync::Arc};
 
@@ -788,20 +788,24 @@ mod tests {
         let shared_device2: SharedDevice = Arc::new(device2);
 
         // Register both devices
-        assert!(manager
-            .register_framebuffer_from_device_with_device_manager(
-                1,
-                shared_device1,
-                &device_manager,
-            )
-            .is_ok());
-        assert!(manager
-            .register_framebuffer_from_device_with_device_manager(
-                2,
-                shared_device2,
-                &device_manager,
-            )
-            .is_ok());
+        assert!(
+            manager
+                .register_framebuffer_from_device_with_device_manager(
+                    1,
+                    shared_device1,
+                    &device_manager,
+                )
+                .is_ok()
+        );
+        assert!(
+            manager
+                .register_framebuffer_from_device_with_device_manager(
+                    2,
+                    shared_device2,
+                    &device_manager,
+                )
+                .is_ok()
+        );
 
         // Check registration
         assert_eq!(manager.get_framebuffer_count(), 2);

--- a/kernel/src/device/graphics/manager.rs
+++ b/kernel/src/device/graphics/manager.rs
@@ -28,10 +28,11 @@ use alloc::{
 use hashbrown::HashMap;
 use spin::{Mutex, RwLock};
 
+use super::output::DisplayOutput;
 use crate::device::{
-    DeviceType,
     graphics::FramebufferConfig,
     manager::{DeviceManager, SharedDevice},
+    DeviceType,
 };
 use crate::vm::addr::phys_to_virt;
 
@@ -570,6 +571,88 @@ impl GraphicsManager {
         Ok(bytes_to_write)
     }
 
+    /// Present a framebuffer on all connected outputs across all graphics devices.
+    ///
+    /// This is the "mirror" operation — every connected display gets the same content.
+    pub fn mirror_all(&self, fb_name: &str) -> Result<(), &'static str> {
+        let fb = self
+            .get_framebuffer(fb_name)
+            .ok_or("mirror: framebuffer not found")?;
+
+        let device_manager = DeviceManager::get_manager();
+        let device_count = device_manager.get_devices_count();
+
+        let mut presented = 0u32;
+        let mut last_error: Option<&'static str> = None;
+
+        for device_id in 1..=device_count {
+            let device = match device_manager.get_device(device_id) {
+                Some(d) => d,
+                None => continue,
+            };
+
+            let graphics = match device.as_graphics_device() {
+                Some(g) => g,
+                None => continue,
+            };
+
+            let outputs: Vec<&dyn DisplayOutput> = graphics.get_outputs();
+            for output in outputs {
+                if !output.is_connected() {
+                    continue;
+                }
+                match output.present(&fb.config, fb.physical_addr) {
+                    Ok(()) => presented += 1,
+                    Err(e) => {
+                        crate::early_println!(
+                            "[GraphicsManager] mirror failed on '{}': {}",
+                            output.name(),
+                            e
+                        );
+                        last_error = Some(e);
+                    }
+                }
+            }
+        }
+
+        if presented == 0 {
+            return Err(last_error.unwrap_or("mirror: no connected outputs"));
+        }
+
+        Ok(())
+    }
+
+    /// Present a framebuffer on a specific output by name.
+    pub fn mirror_to(&self, fb_name: &str, output_name: &str) -> Result<(), &'static str> {
+        let fb = self
+            .get_framebuffer(fb_name)
+            .ok_or("mirror: framebuffer not found")?;
+
+        let device_manager = DeviceManager::get_manager();
+        let device_count = device_manager.get_devices_count();
+
+        for device_id in 1..=device_count {
+            let device = match device_manager.get_device(device_id) {
+                Some(d) => d,
+                None => continue,
+            };
+
+            let graphics = match device.as_graphics_device() {
+                Some(g) => g,
+                None => continue,
+            };
+
+            let outputs: Vec<&dyn DisplayOutput> = graphics.get_outputs();
+            for output in outputs {
+                if output.name() == output_name {
+                    return output.present(&fb.config, fb.physical_addr);
+                }
+            }
+        }
+
+        Err("mirror: output not found")
+    }
+
     /// Clear all framebuffers (for testing only)
     /// This allows tests to start with a clean GraphicsManager state
     #[cfg(test)]
@@ -606,7 +689,7 @@ mod test_utils {
 mod tests {
     use super::*;
     use crate::device::graphics::{
-        FramebufferConfig, GenericGraphicsDevice, PixelFormat, manager::GraphicsManager,
+        manager::GraphicsManager, FramebufferConfig, GenericGraphicsDevice, PixelFormat,
     };
     use alloc::{string::ToString, sync::Arc};
 
@@ -705,24 +788,20 @@ mod tests {
         let shared_device2: SharedDevice = Arc::new(device2);
 
         // Register both devices
-        assert!(
-            manager
-                .register_framebuffer_from_device_with_device_manager(
-                    1,
-                    shared_device1,
-                    &device_manager,
-                )
-                .is_ok()
-        );
-        assert!(
-            manager
-                .register_framebuffer_from_device_with_device_manager(
-                    2,
-                    shared_device2,
-                    &device_manager,
-                )
-                .is_ok()
-        );
+        assert!(manager
+            .register_framebuffer_from_device_with_device_manager(
+                1,
+                shared_device1,
+                &device_manager,
+            )
+            .is_ok());
+        assert!(manager
+            .register_framebuffer_from_device_with_device_manager(
+                2,
+                shared_device2,
+                &device_manager,
+            )
+            .is_ok());
 
         // Check registration
         assert_eq!(manager.get_framebuffer_count(), 2);

--- a/kernel/src/device/graphics/mod.rs
+++ b/kernel/src/device/graphics/mod.rs
@@ -7,6 +7,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::any::Any;
 use spin::Mutex;
 
+use self::output::DisplayOutput;
 use alloc::sync::Arc;
 
 use super::{Device, DeviceType, manager::DeviceManager};
@@ -15,6 +16,7 @@ use crate::object::capability::{ControlOps, MemoryMappingOps};
 
 pub mod framebuffer_device;
 pub mod manager;
+pub mod output;
 
 #[cfg(test)]
 mod tests;
@@ -154,6 +156,14 @@ pub trait GraphicsDevice: Device {
 
     /// Initialize the graphics device (idempotent)
     fn init_graphics(&self) -> Result<(), &'static str>;
+
+    /// Get display outputs provided by this device.
+    ///
+    /// Default returns empty — devices that don't support multi-output
+    /// don't need to override this.
+    fn get_outputs(&self) -> Vec<&dyn DisplayOutput> {
+        Vec::new()
+    }
 }
 
 /// A generic implementation of a graphics device

--- a/kernel/src/device/graphics/output.rs
+++ b/kernel/src/device/graphics/output.rs
@@ -28,3 +28,29 @@ pub struct DisplayMode {
     pub refresh_rate: u32,
     pub name: String,
 }
+
+pub struct SimpleFbOutput {
+    name: String,
+}
+
+impl SimpleFbOutput {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: String::from(name),
+        }
+    }
+}
+
+impl DisplayOutput for SimpleFbOutput {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    fn present(&self, _config: &FramebufferConfig, _fb_paddr: usize) -> Result<(), &'static str> {
+        Ok(())
+    }
+}

--- a/kernel/src/device/graphics/output.rs
+++ b/kernel/src/device/graphics/output.rs
@@ -1,0 +1,30 @@
+//! Display output abstraction
+
+use alloc::string::String;
+
+use super::FramebufferConfig;
+
+/// A single display connector / output (panel, DP port, HDMI, etc.)
+pub trait DisplayOutput: Send + Sync {
+    /// Human-readable name (e.g. "internal-panel", "dp0")
+    fn name(&self) -> &str;
+
+    /// Whether a display is connected (may require HPD detect)
+    fn is_connected(&self) -> bool;
+
+    /// Present a framebuffer on this output.
+    ///
+    /// `fb_paddr` is the physical address of the framebuffer memory.
+    /// For direct-mapped displays (e.g. simple-fb) this is a no-op.
+    /// For coprocessor-driven displays (e.g. DCPext) this triggers DMA/scanout.
+    fn present(&self, config: &FramebufferConfig, fb_paddr: usize) -> Result<(), &'static str>;
+}
+
+/// A display mode (resolution + refresh rate)
+#[derive(Debug, Clone)]
+pub struct DisplayMode {
+    pub width: u32,
+    pub height: u32,
+    pub refresh_rate: u32,
+    pub name: String,
+}

--- a/kernel/src/device/i2c/adapter.rs
+++ b/kernel/src/device/i2c/adapter.rs
@@ -1,0 +1,99 @@
+//! I2C adapter wrapper for shared bus access.
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use spin::Mutex;
+
+use crate::device::i2c::{I2cAddress, I2cBus, I2cError, I2cMessage, I2cMessageFlags};
+
+/// Shared adapter for a single I2C controller.
+pub struct I2cAdapter {
+    bus: Arc<dyn I2cBus>,
+    bus_lock: Mutex<()>,
+}
+
+impl I2cAdapter {
+    /// Create a new adapter from an I2C bus implementation.
+    pub fn new(bus: Arc<dyn I2cBus>) -> Self {
+        Self {
+            bus,
+            bus_lock: Mutex::new(()),
+        }
+    }
+
+    /// Returns adapter bus number.
+    pub fn bus_number(&self) -> u32 {
+        self.bus.bus_number()
+    }
+
+    /// Returns current bus speed in Hz.
+    pub fn bus_speed(&self) -> u32 {
+        self.bus.bus_speed()
+    }
+
+    /// Sets bus speed in Hz.
+    pub fn set_bus_speed(&self, hz: u32) -> Result<(), I2cError> {
+        let _guard = self.bus_lock.lock();
+        self.bus.set_bus_speed(hz)
+    }
+
+    /// Submit a low-level transfer.
+    pub fn transfer(&self, msgs: &mut [I2cMessage]) -> Result<(), I2cError> {
+        let _guard = self.bus_lock.lock();
+        self.bus.transfer(msgs)
+    }
+
+    /// Write bytes to a slave.
+    pub fn write(&self, addr: I2cAddress, data: &[u8]) -> Result<(), I2cError> {
+        let mut msgs = [I2cMessage::write(addr, data, true)];
+        self.transfer(&mut msgs)
+    }
+
+    /// Read bytes from a slave.
+    pub fn read(&self, addr: I2cAddress, buf: &mut [u8]) -> Result<(), I2cError> {
+        let mut msgs = [I2cMessage::read(addr, buf.len(), true)];
+        self.transfer(&mut msgs)?;
+        buf.copy_from_slice(&msgs[0].data);
+        Ok(())
+    }
+
+    /// Write then read in one transaction.
+    pub fn write_then_read(
+        &self,
+        addr: I2cAddress,
+        write: &[u8],
+        read: &mut [u8],
+    ) -> Result<(), I2cError> {
+        let mut msgs = [
+            I2cMessage::with_flags(addr, I2cMessageFlags::NONE, write.to_vec()),
+            I2cMessage::with_flags(
+                addr,
+                I2cMessageFlags::READ | I2cMessageFlags::NOSTART | I2cMessageFlags::STOP,
+                alloc::vec![0; read.len()],
+            ),
+        ];
+        self.transfer(&mut msgs)?;
+        read.copy_from_slice(&msgs[1].data);
+        Ok(())
+    }
+
+    /// Read consecutive bytes starting from an 8-bit register offset.
+    pub fn read_register(&self, addr: I2cAddress, reg: u8, buf: &mut [u8]) -> Result<(), I2cError> {
+        self.write_then_read(addr, &[reg], buf)
+    }
+
+    /// Write one register plus payload bytes.
+    pub fn write_register(&self, addr: I2cAddress, reg: u8, data: &[u8]) -> Result<(), I2cError> {
+        let mut payload = Vec::with_capacity(data.len() + 1);
+        payload.push(reg);
+        payload.extend_from_slice(data);
+        self.write(addr, &payload)
+    }
+
+    /// Probes if a slave responds on this address.
+    pub fn probe_device(&self, addr: I2cAddress) -> bool {
+        self.write(addr, &[]).is_ok()
+    }
+}

--- a/kernel/src/device/i2c/mod.rs
+++ b/kernel/src/device/i2c/mod.rs
@@ -1,0 +1,195 @@
+//! Generic I2C bus abstractions.
+//!
+//! This module defines protocol-level types used by I2C controller drivers and
+//! higher-level clients in the kernel.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+pub mod adapter;
+
+/// I2C slave address (7-bit or 10-bit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum I2cAddress {
+    /// 7-bit I2C address.
+    SevenBit(u8),
+    /// 10-bit I2C address.
+    TenBit(u16),
+}
+
+impl I2cAddress {
+    /// Returns true when this is a 10-bit address.
+    pub fn is_ten_bit(&self) -> bool {
+        matches!(self, Self::TenBit(_))
+    }
+
+    /// Returns address value as raw integer.
+    pub fn raw(&self) -> u16 {
+        match self {
+            Self::SevenBit(v) => *v as u16,
+            Self::TenBit(v) => *v,
+        }
+    }
+}
+
+/// I2C message flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct I2cMessageFlags(u16);
+
+impl I2cMessageFlags {
+    /// Empty/no flags.
+    pub const NONE: Self = Self(0);
+    /// Read transaction (controller reads from slave).
+    pub const READ: Self = Self(1 << 0);
+    /// Send STOP condition after this message.
+    pub const STOP: Self = Self(1 << 1);
+    /// Do not issue START/address phase before this message.
+    pub const NOSTART: Self = Self(1 << 2);
+    /// Message uses 10-bit address mode.
+    pub const TEN_BIT: Self = Self(1 << 3);
+
+    /// Returns true when all bits in `other` are present.
+    pub fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Raw flags value.
+    pub fn bits(self) -> u16 {
+        self.0
+    }
+}
+
+impl core::ops::BitOr for I2cMessageFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl core::ops::BitOrAssign for I2cMessageFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// A single I2C message segment.
+#[derive(Debug, Clone)]
+pub struct I2cMessage {
+    /// Target slave address.
+    pub addr: I2cAddress,
+    /// Segment flags.
+    pub flags: I2cMessageFlags,
+    /// Payload buffer.
+    ///
+    /// For write messages, this contains bytes to transmit.
+    /// For read messages, this is pre-sized and filled by the bus driver.
+    pub data: Vec<u8>,
+}
+
+impl I2cMessage {
+    /// Creates a write message.
+    pub fn write(addr: I2cAddress, data: &[u8], stop: bool) -> Self {
+        let mut flags = I2cMessageFlags::NONE;
+        if stop {
+            flags |= I2cMessageFlags::STOP;
+        }
+        if addr.is_ten_bit() {
+            flags |= I2cMessageFlags::TEN_BIT;
+        }
+
+        Self {
+            addr,
+            flags,
+            data: data.to_vec(),
+        }
+    }
+
+    /// Creates a read message with a fixed receive length.
+    pub fn read(addr: I2cAddress, len: usize, stop: bool) -> Self {
+        let mut flags = I2cMessageFlags::READ;
+        if stop {
+            flags |= I2cMessageFlags::STOP;
+        }
+        if addr.is_ten_bit() {
+            flags |= I2cMessageFlags::TEN_BIT;
+        }
+
+        Self {
+            addr,
+            flags,
+            data: alloc::vec![0; len],
+        }
+    }
+
+    /// Creates a message with explicit flags and payload.
+    pub fn with_flags(addr: I2cAddress, flags: I2cMessageFlags, data: Vec<u8>) -> Self {
+        Self { addr, flags, data }
+    }
+}
+
+/// A complete I2C transaction (one or more message segments).
+#[derive(Debug, Clone, Default)]
+pub struct I2cTransfer {
+    messages: Vec<I2cMessage>,
+}
+
+impl I2cTransfer {
+    /// Create an empty transfer.
+    pub fn new() -> Self {
+        Self {
+            messages: Vec::new(),
+        }
+    }
+
+    /// Create a transfer from pre-built messages.
+    pub fn from_messages(messages: Vec<I2cMessage>) -> Self {
+        Self { messages }
+    }
+
+    /// Append a message to this transfer.
+    pub fn push(&mut self, msg: I2cMessage) {
+        self.messages.push(msg);
+    }
+
+    /// Borrow all messages.
+    pub fn messages(&self) -> &[I2cMessage] {
+        &self.messages
+    }
+
+    /// Borrow all messages mutably.
+    pub fn messages_mut(&mut self) -> &mut [I2cMessage] {
+        &mut self.messages
+    }
+}
+
+/// I2C transfer errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum I2cError {
+    /// Slave NACKed address or data.
+    Nack,
+    /// Multi-master arbitration loss.
+    ArbitrationLost,
+    /// Polling or bus operation timeout.
+    Timeout,
+    /// Generic bus/controller failure.
+    BusError,
+    /// Invalid argument.
+    InvalidArg,
+}
+
+/// Generic I2C controller interface.
+pub trait I2cBus: Send + Sync {
+    /// Execute a full I2C transaction.
+    fn transfer(&self, msgs: &mut [I2cMessage]) -> Result<(), I2cError>;
+
+    /// Configure bus speed in Hz.
+    fn set_bus_speed(&self, hz: u32) -> Result<(), I2cError>;
+
+    /// Get current bus speed in Hz.
+    fn bus_speed(&self) -> u32;
+
+    /// Get logical bus number.
+    fn bus_number(&self) -> u32;
+}

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -9,6 +9,7 @@ pub mod char;
 pub mod events;
 pub mod fdt;
 pub mod graphics;
+pub mod i2c;
 pub mod input;
 pub mod manager;
 pub mod network;

--- a/kernel/src/drivers/display/dcpext.rs
+++ b/kernel/src/drivers/display/dcpext.rs
@@ -9,13 +9,13 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use spin::Mutex;
 
-use crate::device::graphics::FramebufferConfig;
 use crate::device::graphics::output::DisplayOutput;
+use crate::device::graphics::FramebufferConfig;
 use crate::device::manager::{DeviceManager, DriverPriority};
 use crate::device::platform::resource::PlatformDeviceResourceType;
 use crate::device::platform::{PlatformDeviceDriver, PlatformDeviceInfo};
 use crate::driver_initcall;
-use crate::drivers::iommu::apple_dart::{DartPageTable, get_dart_by_phandle};
+use crate::drivers::iommu::apple_dart::{get_dart_by_phandle, DartPageTable};
 use crate::drivers::soc::apple_afk::AfkEndpoint;
 use crate::drivers::soc::apple_asc::AppleAsc;
 use crate::drivers::soc::apple_epic::EpicEndpoint;
@@ -483,10 +483,38 @@ impl AppleDcpExt {
 }
 
 static DCP_EXT: Mutex<Option<AppleDcpExt>> = Mutex::new(None);
+static DCP_DART_PHANDLE: Mutex<Option<u32>> = Mutex::new(None);
 
 pub fn with_dcpext<R>(f: impl FnOnce(&mut AppleDcpExt) -> R) -> Option<R> {
     let mut guard = DCP_EXT.lock();
     guard.as_mut().map(f)
+}
+
+/// Mirror the bootloader-provided framebuffer (fb0) to external DisplayPort.
+///
+/// This is Phase 1 mirroring — takes the existing framebuffer from m1n1/limine,
+/// DART-maps it, and presents it via the DCPext coprocessor.
+pub fn mirror_boot_fb() -> Result<(), &'static str> {
+    use crate::device::graphics::manager::GraphicsManager;
+
+    let fb = GraphicsManager::get_manager()
+        .get_framebuffer("fb0")
+        .ok_or("apple-dcpext: fb0 not found")?;
+
+    let dart_phandle = DCP_DART_PHANDLE
+        .lock()
+        .ok_or("apple-dcpext: dart phandle not set (probe may not have run)")?;
+
+    let output = DcpextOutput::new(dart_phandle);
+    output.present(&fb.config, fb.physical_addr)?;
+
+    early_println!(
+        "[apple-dcpext] mirrored fb0 {}x{} to dp0",
+        fb.config.width,
+        fb.config.height
+    );
+
+    Ok(())
 }
 
 fn has_mboxes_property(device: &PlatformDeviceInfo) -> bool {
@@ -517,6 +545,17 @@ fn coproc_resource(device: &PlatformDeviceInfo) -> Result<(usize, usize), &'stat
     Ok((paddr, size))
 }
 
+fn parse_iommus_phandle(device: &PlatformDeviceInfo) -> Option<u32> {
+    let prop = device.property("iommus")?;
+    let bytes = prop.value();
+    // iommus = <phandle sid>; each entry is two big-endian u32s
+    if bytes.len() < 8 {
+        return None;
+    }
+    let phandle = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    Some(phandle)
+}
+
 fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
     let (coproc_paddr, coproc_size) = coproc_resource(device)?;
 
@@ -537,6 +576,11 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
     dcp.init()?;
 
     *DCP_EXT.lock() = Some(dcp);
+
+    if let Some(phandle) = parse_iommus_phandle(device) {
+        early_println!("[apple-dcpext] dart phandle: {:#x}", phandle);
+        *DCP_DART_PHANDLE.lock() = Some(phandle);
+    }
 
     Ok(())
 }

--- a/kernel/src/drivers/display/dcpext.rs
+++ b/kernel/src/drivers/display/dcpext.rs
@@ -5,13 +5,17 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use spin::Mutex;
 
+use crate::device::graphics::FramebufferConfig;
+use crate::device::graphics::output::DisplayOutput;
 use crate::device::manager::{DeviceManager, DriverPriority};
 use crate::device::platform::resource::PlatformDeviceResourceType;
 use crate::device::platform::{PlatformDeviceDriver, PlatformDeviceInfo};
 use crate::driver_initcall;
+use crate::drivers::iommu::apple_dart::{DartPageTable, get_dart_by_phandle};
 use crate::drivers::soc::apple_afk::AfkEndpoint;
 use crate::drivers::soc::apple_asc::AppleAsc;
 use crate::drivers::soc::apple_epic::EpicEndpoint;
@@ -25,6 +29,8 @@ const DCP_IBOOT_EP: u8 = 0x23;
 
 const DCP_ASC_OFFSET: usize = 0x8000;
 const DCP_SERVICE_WAIT_TIMEOUT_US: u64 = 5_000_000;
+const DCP_DVA_OFFSET: u64 = 0xf000_0000;
+const DCP_DART_FB_FLAGS: u64 = 1;
 
 const SYSTEM_SERVICE_PREFIX: &str = "system";
 const DPTX_SERVICE_PREFIX: &str = "AppleDCPDPTXRemotePort";
@@ -49,6 +55,70 @@ const IBOOT_CALL_SET_MODE: u32 = 3;
 const IBOOT_CALL_SWAP_BEGIN: u32 = 4;
 const IBOOT_CALL_SWAP_SET_LAYER: u32 = 5;
 const IBOOT_CALL_SWAP_END: u32 = 6;
+
+pub struct DcpextOutput {
+    dart_phandle: u32,
+    iova_base: usize,
+    page_table: Mutex<Option<DartPageTable>>,
+    connected: AtomicBool,
+}
+
+impl DcpextOutput {
+    pub fn new(dart_phandle: u32) -> Self {
+        Self {
+            dart_phandle,
+            iova_base: 0x1000_0000,
+            page_table: Mutex::new(None),
+            connected: AtomicBool::new(false),
+        }
+    }
+}
+
+impl DisplayOutput for DcpextOutput {
+    fn name(&self) -> &str {
+        "dp0"
+    }
+
+    fn is_connected(&self) -> bool {
+        if let Some(connected) = with_dcpext(|dcp| dcp.hotplug_detect().unwrap_or(false)) {
+            self.connected.store(connected, Ordering::Relaxed);
+            return connected;
+        }
+
+        self.connected.load(Ordering::Relaxed)
+    }
+
+    fn present(&self, config: &FramebufferConfig, fb_paddr: usize) -> Result<(), &'static str> {
+        {
+            let mut pt_guard = self.page_table.lock();
+            if pt_guard.is_none() {
+                let pt = DartPageTable::new()?;
+                let dart = get_dart_by_phandle(self.dart_phandle)
+                    .ok_or("apple-dcpext-output: DART not found")?;
+                dart.enable_translation(0, pt.root_paddr(), 2);
+                *pt_guard = Some(pt);
+            }
+
+            let pt = pt_guard
+                .as_mut()
+                .ok_or("apple-dcpext-output: DART page table unavailable")?;
+            pt.map_contiguous(self.iova_base, fb_paddr, config.size(), DCP_DART_FB_FLAGS)?;
+        }
+
+        let fb_iova = DCP_DVA_OFFSET | self.iova_base as u64;
+
+        with_dcpext(|dcp| {
+            dcp.mirror_framebuffer(
+                fb_paddr as u64,
+                config.width,
+                config.height,
+                config.stride,
+                fb_iova,
+            )
+        })
+        .ok_or("apple-dcpext-output: DCPext not initialized")?
+    }
+}
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]

--- a/kernel/src/drivers/display/dcpext.rs
+++ b/kernel/src/drivers/display/dcpext.rs
@@ -1,0 +1,287 @@
+#![cfg(target_arch = "aarch64")]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use spin::Mutex;
+
+use crate::device::manager::{DeviceManager, DriverPriority};
+use crate::device::platform::resource::PlatformDeviceResourceType;
+use crate::device::platform::{PlatformDeviceDriver, PlatformDeviceInfo};
+use crate::driver_initcall;
+use crate::drivers::soc::apple_afk::AfkEndpoint;
+use crate::drivers::soc::apple_asc::AppleAsc;
+use crate::drivers::soc::apple_epic::EpicEndpoint;
+use crate::drivers::soc::apple_rtkit::AppleRtkit;
+use crate::early_println;
+use crate::vm;
+
+const DCP_SYSTEM_EP: u8 = 0x20;
+const DCP_DPTX_PORT_EP: u8 = 0x2a;
+
+const DCP_ASC_OFFSET: usize = 0x8000;
+const DCP_SERVICE_WAIT_TIMEOUT_US: u64 = 5_000_000;
+
+const SYSTEM_SERVICE_PREFIX: &str = "system";
+const DPTX_SERVICE_PREFIX: &str = "AppleDCPDPTXRemotePort";
+
+const DPTX_GROUP: u16 = 0;
+const DPTX_APCALL_GET_LINK_RATE: u32 = 8;
+const DPTX_APCALL_SET_LINK_RATE: u32 = 9;
+const DPTX_APCALL_GET_ACTIVE_LANE_COUNT: u32 = 11;
+const DPTX_APCALL_SET_ACTIVE_LANE_COUNT: u32 = 12;
+const DPTX_APCALL_GET_HPD_STATUS: u32 = 13;
+const DPTX_APCALL_FORCE_HOTPLUG_DETECT: u32 = 19;
+
+pub struct AppleDcpExt {
+    coproc_base: usize,
+    _coproc_size: usize,
+    _asc: Option<Arc<AppleAsc>>,
+    _rtkit: Option<Arc<AppleRtkit>>,
+    system_ep: Option<EpicEndpoint>,
+    dptx_port_ep: Option<EpicEndpoint>,
+    initialized: bool,
+}
+
+impl AppleDcpExt {
+    fn new(coproc_base: usize, coproc_size: usize) -> Self {
+        Self {
+            coproc_base,
+            _coproc_size: coproc_size,
+            _asc: None,
+            _rtkit: None,
+            system_ep: None,
+            dptx_port_ep: None,
+            initialized: false,
+        }
+    }
+
+    fn asc_base(&self) -> usize {
+        self.coproc_base + DCP_ASC_OFFSET
+    }
+
+    fn create_rtkit(&self) -> (Arc<AppleAsc>, Arc<AppleRtkit>) {
+        let asc = Arc::new(AppleAsc::new(self.asc_base()));
+        let rtkit = Arc::new(AppleRtkit::new(Arc::clone(&asc)));
+        (asc, rtkit)
+    }
+
+    fn create_epic_endpoint(
+        rtkit: Arc<AppleRtkit>,
+        endpoint: u8,
+    ) -> Result<EpicEndpoint, &'static str> {
+        let afk = Arc::new(Mutex::new(AfkEndpoint::new(rtkit, endpoint)));
+        afk.lock().start()?;
+        EpicEndpoint::new(afk)
+    }
+
+    fn wait_for_named_service(
+        epic: &mut EpicEndpoint,
+        name_prefix: &str,
+    ) -> Result<(), &'static str> {
+        if epic.find_service(name_prefix).is_some() {
+            return Ok(());
+        }
+
+        epic.wait_for_services(1, DCP_SERVICE_WAIT_TIMEOUT_US)?;
+
+        if epic.find_service(name_prefix).is_some() {
+            return Ok(());
+        }
+
+        Err("apple-dcpext: expected service not announced")
+    }
+
+    fn ensure_ready(&self) -> Result<(), &'static str> {
+        if self.initialized {
+            Ok(())
+        } else {
+            Err("apple-dcpext: endpoint stack not initialized")
+        }
+    }
+
+    fn init(&mut self) -> Result<(), &'static str> {
+        early_println!(
+            "[apple-dcpext] init: coproc_base={:#x} asc_base={:#x}",
+            self.coproc_base,
+            self.asc_base()
+        );
+
+        let (asc, rtkit) = self.create_rtkit();
+
+        rtkit.boot()?;
+
+        let mut system_ep = Self::create_epic_endpoint(Arc::clone(&rtkit), DCP_SYSTEM_EP)?;
+        let mut dptx_port_ep = Self::create_epic_endpoint(Arc::clone(&rtkit), DCP_DPTX_PORT_EP)?;
+
+        Self::wait_for_named_service(&mut system_ep, SYSTEM_SERVICE_PREFIX)
+            .map_err(|_| "apple-dcpext: system service not announced")?;
+        Self::wait_for_named_service(&mut dptx_port_ep, DPTX_SERVICE_PREFIX)
+            .map_err(|_| "apple-dcpext: DPTX remote port service not announced")?;
+
+        early_println!("[apple-dcpext] init complete");
+
+        self._asc = Some(asc);
+        self._rtkit = Some(rtkit);
+        self.system_ep = Some(system_ep);
+        self.dptx_port_ep = Some(dptx_port_ep);
+        self.initialized = true;
+
+        Ok(())
+    }
+
+    fn dptx_service_channel(ep: &EpicEndpoint) -> Result<u32, &'static str> {
+        ep.find_service(DPTX_SERVICE_PREFIX)
+            .map(|service| service.channel)
+            .ok_or("apple-dcpext: DPTX service not found")
+    }
+
+    fn dptx_call(&mut self, command: u32, data: &[u8]) -> Result<Vec<u8>, &'static str> {
+        self.ensure_ready()?;
+
+        let ep = self
+            .dptx_port_ep
+            .as_mut()
+            .ok_or("apple-dcpext: DPTX EPIC endpoint not initialized")?;
+        let channel = Self::dptx_service_channel(ep)?;
+        ep.call_by_channel(channel, DPTX_GROUP, command, data)
+    }
+
+    fn read_u32_reply(reply: &[u8]) -> Result<u32, &'static str> {
+        if reply.len() < 4 {
+            return Err("apple-dcpext: short EPIC reply");
+        }
+
+        Ok(u32::from_le_bytes([reply[0], reply[1], reply[2], reply[3]]))
+    }
+
+    fn write_u32_payload(value: u32) -> [u8; 4] {
+        value.to_le_bytes()
+    }
+
+    fn call_get_u32(&mut self, command: u32) -> Result<u32, &'static str> {
+        let reply = self.dptx_call(command, &[])?;
+        Self::read_u32_reply(&reply)
+    }
+
+    fn call_set_u32(&mut self, command: u32, value: u32) -> Result<(), &'static str> {
+        let payload = Self::write_u32_payload(value);
+        let _ = self.dptx_call(command, &payload)?;
+        Ok(())
+    }
+
+    pub fn hotplug_detect(&mut self) -> Result<bool, &'static str> {
+        let _ = self.dptx_call(DPTX_APCALL_FORCE_HOTPLUG_DETECT, &[])?;
+        Ok(self.call_get_u32(DPTX_APCALL_GET_HPD_STATUS)? != 0)
+    }
+
+    pub fn get_link_rate(&mut self) -> Result<u32, &'static str> {
+        self.call_get_u32(DPTX_APCALL_GET_LINK_RATE)
+    }
+
+    pub fn set_link_rate(&mut self, rate: u32) -> Result<(), &'static str> {
+        self.call_set_u32(DPTX_APCALL_SET_LINK_RATE, rate)
+    }
+
+    pub fn get_lane_count(&mut self) -> Result<u32, &'static str> {
+        self.call_get_u32(DPTX_APCALL_GET_ACTIVE_LANE_COUNT)
+    }
+
+    pub fn set_lane_count(&mut self, lanes: u32) -> Result<(), &'static str> {
+        self.call_set_u32(DPTX_APCALL_SET_ACTIVE_LANE_COUNT, lanes)
+    }
+
+    pub fn poll(&mut self) {
+        if self.ensure_ready().is_err() {
+            return;
+        }
+
+        if let Some(system_ep) = self.system_ep.as_mut() {
+            system_ep.poll();
+        }
+
+        if let Some(dptx_port_ep) = self.dptx_port_ep.as_mut() {
+            dptx_port_ep.poll();
+        }
+    }
+}
+
+static DCP_EXT: Mutex<Option<AppleDcpExt>> = Mutex::new(None);
+
+pub fn with_dcpext<R>(f: impl FnOnce(&mut AppleDcpExt) -> R) -> Option<R> {
+    let mut guard = DCP_EXT.lock();
+    guard.as_mut().map(f)
+}
+
+fn has_mboxes_property(device: &PlatformDeviceInfo) -> bool {
+    device
+        .property("mboxes")
+        .map(|property| !property.value().is_empty())
+        .unwrap_or(false)
+}
+
+fn coproc_resource(device: &PlatformDeviceInfo) -> Result<(usize, usize), &'static str> {
+    let mem_resources: Vec<_> = device
+        .get_resources()
+        .iter()
+        .filter(|resource| matches!(resource.res_type, PlatformDeviceResourceType::MEM))
+        .collect();
+
+    let coproc = mem_resources
+        .first()
+        .ok_or("apple-dcpext: missing coproc memory resource")?;
+
+    let paddr = coproc.start;
+    let size = coproc
+        .end
+        .checked_sub(coproc.start)
+        .and_then(|value| value.checked_add(1))
+        .ok_or("apple-dcpext: invalid coproc memory resource")?;
+
+    Ok((paddr, size))
+}
+
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    let (coproc_paddr, coproc_size) = coproc_resource(device)?;
+
+    let coproc_base = vm::ioremap(coproc_paddr, coproc_size)
+        .map_err(|_| "apple-dcpext: failed to map coproc MMIO")?;
+
+    if !has_mboxes_property(device) {
+        early_println!("[apple-dcpext] warning: missing mboxes property");
+    }
+
+    early_println!(
+        "[apple-dcpext] probe: coproc paddr={:#x} size={:#x}",
+        coproc_paddr,
+        coproc_size
+    );
+
+    let mut dcp = AppleDcpExt::new(coproc_base, coproc_size);
+    dcp.init()?;
+
+    *DCP_EXT.lock() = Some(dcp);
+
+    Ok(())
+}
+
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    *DCP_EXT.lock() = None;
+    Ok(())
+}
+
+fn register_dcpext_driver() {
+    let driver = PlatformDeviceDriver::new(
+        "apple-dcpext",
+        probe_fn,
+        remove_fn,
+        alloc::vec!["apple,t8103-dcpext", "apple,dcpext"],
+    );
+
+    DeviceManager::get_manager().register_driver(Box::new(driver), DriverPriority::Standard);
+}
+
+driver_initcall!(register_dcpext_driver);

--- a/kernel/src/drivers/display/dcpext.rs
+++ b/kernel/src/drivers/display/dcpext.rs
@@ -9,13 +9,13 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use spin::Mutex;
 
-use crate::device::graphics::output::DisplayOutput;
 use crate::device::graphics::FramebufferConfig;
+use crate::device::graphics::output::DisplayOutput;
 use crate::device::manager::{DeviceManager, DriverPriority};
 use crate::device::platform::resource::PlatformDeviceResourceType;
 use crate::device::platform::{PlatformDeviceDriver, PlatformDeviceInfo};
 use crate::driver_initcall;
-use crate::drivers::iommu::apple_dart::{get_dart_by_phandle, DartPageTable};
+use crate::drivers::iommu::apple_dart::{DartPageTable, get_dart_by_phandle};
 use crate::drivers::soc::apple_afk::AfkEndpoint;
 use crate::drivers::soc::apple_asc::AppleAsc;
 use crate::drivers::soc::apple_epic::EpicEndpoint;

--- a/kernel/src/drivers/display/dcpext.rs
+++ b/kernel/src/drivers/display/dcpext.rs
@@ -21,6 +21,7 @@ use crate::vm;
 
 const DCP_SYSTEM_EP: u8 = 0x20;
 const DCP_DPTX_PORT_EP: u8 = 0x2a;
+const DCP_IBOOT_EP: u8 = 0x23;
 
 const DCP_ASC_OFFSET: usize = 0x8000;
 const DCP_SERVICE_WAIT_TIMEOUT_US: u64 = 5_000_000;
@@ -36,6 +37,49 @@ const DPTX_APCALL_SET_ACTIVE_LANE_COUNT: u32 = 12;
 const DPTX_APCALL_GET_HPD_STATUS: u32 = 13;
 const DPTX_APCALL_FORCE_HOTPLUG_DETECT: u32 = 19;
 
+const IBOOT_GROUP: u16 = 0;
+#[allow(dead_code)]
+const IBOOT_CALL_GET_MODE_COUNT: u32 = 0;
+#[allow(dead_code)]
+const IBOOT_CALL_GET_TIMING_MODES: u32 = 1;
+#[allow(dead_code)]
+const IBOOT_CALL_GET_COLOR_MODES: u32 = 2;
+#[allow(dead_code)]
+const IBOOT_CALL_SET_MODE: u32 = 3;
+const IBOOT_CALL_SWAP_BEGIN: u32 = 4;
+const IBOOT_CALL_SWAP_SET_LAYER: u32 = 5;
+const IBOOT_CALL_SWAP_END: u32 = 6;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct IBootPlaneInfo {
+    unk1: u32,
+    addr: u64,
+    tile_size: u32,
+    stride: u32,
+    unk5: u32,
+    unk6: u32,
+    unk7: u32,
+    unk8: u32,
+    addr_format: u32,
+    unk9: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct IBootLayerInfo {
+    planes: [IBootPlaneInfo; 3],
+    unk: u32,
+    plane_cnt: u32,
+    width: u32,
+    height: u32,
+    surface_fmt: u32,
+    colorspace: u32,
+    eotf: u32,
+    transform: u32,
+    _pad: [u8; 3],
+}
+
 pub struct AppleDcpExt {
     coproc_base: usize,
     _coproc_size: usize,
@@ -43,6 +87,7 @@ pub struct AppleDcpExt {
     _rtkit: Option<Arc<AppleRtkit>>,
     system_ep: Option<EpicEndpoint>,
     dptx_port_ep: Option<EpicEndpoint>,
+    iboot_ep: Option<EpicEndpoint>,
     initialized: bool,
 }
 
@@ -55,6 +100,7 @@ impl AppleDcpExt {
             _rtkit: None,
             system_ep: None,
             dptx_port_ep: None,
+            iboot_ep: None,
             initialized: false,
         }
     }
@@ -116,11 +162,14 @@ impl AppleDcpExt {
 
         let mut system_ep = Self::create_epic_endpoint(Arc::clone(&rtkit), DCP_SYSTEM_EP)?;
         let mut dptx_port_ep = Self::create_epic_endpoint(Arc::clone(&rtkit), DCP_DPTX_PORT_EP)?;
+        let mut iboot_ep = Self::create_epic_endpoint(Arc::clone(&rtkit), DCP_IBOOT_EP)?;
 
         Self::wait_for_named_service(&mut system_ep, SYSTEM_SERVICE_PREFIX)
             .map_err(|_| "apple-dcpext: system service not announced")?;
         Self::wait_for_named_service(&mut dptx_port_ep, DPTX_SERVICE_PREFIX)
             .map_err(|_| "apple-dcpext: DPTX remote port service not announced")?;
+        Self::wait_for_named_service(&mut iboot_ep, "disp0")
+            .map_err(|_| "apple-dcpext: disp0-service not announced")?;
 
         early_println!("[apple-dcpext] init complete");
 
@@ -128,6 +177,7 @@ impl AppleDcpExt {
         self._rtkit = Some(rtkit);
         self.system_ep = Some(system_ep);
         self.dptx_port_ep = Some(dptx_port_ep);
+        self.iboot_ep = Some(iboot_ep);
         self.initialized = true;
 
         Ok(())
@@ -148,6 +198,20 @@ impl AppleDcpExt {
             .ok_or("apple-dcpext: DPTX EPIC endpoint not initialized")?;
         let channel = Self::dptx_service_channel(ep)?;
         ep.call_by_channel(channel, DPTX_GROUP, command, data)
+    }
+
+    fn iboot_call(&mut self, command: u32, data: &[u8]) -> Result<Vec<u8>, &'static str> {
+        self.ensure_ready()?;
+
+        let ep = self
+            .iboot_ep
+            .as_mut()
+            .ok_or("apple-dcpext: IBoot EPIC endpoint not initialized")?;
+        let channel = ep
+            .find_service("disp0")
+            .map(|service| service.channel)
+            .ok_or("apple-dcpext: disp0 service not found")?;
+        ep.call_by_channel(channel, IBOOT_GROUP, command, data)
     }
 
     fn read_u32_reply(reply: &[u8]) -> Result<u32, &'static str> {
@@ -194,17 +258,156 @@ impl AppleDcpExt {
         self.call_set_u32(DPTX_APCALL_SET_ACTIVE_LANE_COUNT, lanes)
     }
 
+    pub(crate) fn create_layer_info(
+        fb_iova: u64,
+        width: u32,
+        height: u32,
+        stride: u32,
+        surface_fmt: u32,
+    ) -> IBootLayerInfo {
+        IBootLayerInfo {
+            planes: [
+                IBootPlaneInfo {
+                    unk1: 0,
+                    addr: fb_iova,
+                    tile_size: 0,
+                    stride,
+                    unk5: 0,
+                    unk6: 0,
+                    unk7: 0,
+                    unk8: 0,
+                    addr_format: 1,
+                    unk9: 0,
+                },
+                IBootPlaneInfo {
+                    unk1: 0,
+                    addr: 0,
+                    tile_size: 0,
+                    stride: 0,
+                    unk5: 0,
+                    unk6: 0,
+                    unk7: 0,
+                    unk8: 0,
+                    addr_format: 0,
+                    unk9: 0,
+                },
+                IBootPlaneInfo {
+                    unk1: 0,
+                    addr: 0,
+                    tile_size: 0,
+                    stride: 0,
+                    unk5: 0,
+                    unk6: 0,
+                    unk7: 0,
+                    unk8: 0,
+                    addr_format: 0,
+                    unk9: 0,
+                },
+            ],
+            unk: 0,
+            plane_cnt: 1,
+            width,
+            height,
+            surface_fmt,
+            colorspace: 1,
+            eotf: 1,
+            transform: 0,
+            _pad: [0; 3],
+        }
+    }
+
+    pub fn swap_begin(&mut self) -> Result<(), &'static str> {
+        self.iboot_call(IBOOT_CALL_SWAP_BEGIN, &[])?;
+        Ok(())
+    }
+
+    pub fn swap_set_layer(
+        &mut self,
+        layer_index: u32,
+        layer: &IBootLayerInfo,
+        src_rect: (u32, u32, u32, u32),
+        dst_rect: (u32, u32, u32, u32),
+    ) -> Result<(), &'static str> {
+        let layer_size = core::mem::size_of::<IBootLayerInfo>();
+        let mut payload = alloc::vec![0u8; 8 + layer_size + 32];
+
+        payload[0..4].copy_from_slice(&layer_index.to_le_bytes());
+
+        // SAFETY: `layer` is a valid reference to a plain `#[repr(C)]` POD wire struct,
+        // and we only read exactly `size_of::<IBootLayerInfo>()` bytes from it.
+        let layer_bytes =
+            unsafe { core::slice::from_raw_parts(layer as *const _ as *const u8, layer_size) };
+
+        payload[8..8 + layer_bytes.len()].copy_from_slice(layer_bytes);
+
+        let src_offset = 8 + layer_bytes.len();
+        payload[src_offset..src_offset + 4].copy_from_slice(&src_rect.0.to_le_bytes());
+        payload[src_offset + 4..src_offset + 8].copy_from_slice(&src_rect.1.to_le_bytes());
+        payload[src_offset + 8..src_offset + 12].copy_from_slice(&src_rect.2.to_le_bytes());
+        payload[src_offset + 12..src_offset + 16].copy_from_slice(&src_rect.3.to_le_bytes());
+
+        let dst_offset = src_offset + 16;
+        payload[dst_offset..dst_offset + 4].copy_from_slice(&dst_rect.0.to_le_bytes());
+        payload[dst_offset + 4..dst_offset + 8].copy_from_slice(&dst_rect.1.to_le_bytes());
+        payload[dst_offset + 8..dst_offset + 12].copy_from_slice(&dst_rect.2.to_le_bytes());
+        payload[dst_offset + 12..dst_offset + 16].copy_from_slice(&dst_rect.3.to_le_bytes());
+
+        self.iboot_call(IBOOT_CALL_SWAP_SET_LAYER, &payload)?;
+        Ok(())
+    }
+
+    pub fn swap_end(&mut self) -> Result<(), &'static str> {
+        self.iboot_call(IBOOT_CALL_SWAP_END, &[])?;
+        Ok(())
+    }
+
+    pub fn mirror_framebuffer(
+        &mut self,
+        fb_paddr: u64,
+        fb_width: u32,
+        fb_height: u32,
+        fb_stride: u32,
+        fb_iova: u64,
+    ) -> Result<(), &'static str> {
+        let layer = Self::create_layer_info(fb_iova, fb_width, fb_height, fb_stride, 1);
+
+        early_println!(
+            "[apple-dcpext] mirror: {}x{} stride={} paddr={:#x} iova={:#x}",
+            fb_width,
+            fb_height,
+            fb_stride,
+            fb_paddr,
+            fb_iova
+        );
+
+        self.swap_begin()?;
+        self.swap_set_layer(
+            0,
+            &layer,
+            (0, 0, fb_width, fb_height),
+            (0, 0, fb_width, fb_height),
+        )?;
+        self.swap_end()?;
+
+        early_println!("[apple-dcpext] mirror complete");
+        Ok(())
+    }
+
     pub fn poll(&mut self) {
         if self.ensure_ready().is_err() {
             return;
         }
 
-        if let Some(system_ep) = self.system_ep.as_mut() {
-            system_ep.poll();
+        if let Some(ep) = self.system_ep.as_mut() {
+            ep.poll();
         }
 
-        if let Some(dptx_port_ep) = self.dptx_port_ep.as_mut() {
-            dptx_port_ep.poll();
+        if let Some(ep) = self.dptx_port_ep.as_mut() {
+            ep.poll();
+        }
+
+        if let Some(ep) = self.iboot_ep.as_mut() {
+            ep.poll();
         }
     }
 }

--- a/kernel/src/drivers/display/dpxbar.rs
+++ b/kernel/src/drivers/display/dpxbar.rs
@@ -1,0 +1,330 @@
+//! Apple DPXBAR (DisplayPort Crossbar) driver.
+//!
+//! Routes DCP extension (dcpext) display pipes to ATC PHY DisplayPort lanes.
+
+#![cfg(target_arch = "aarch64")]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use spin::Mutex;
+
+use crate::device::DeviceInfo;
+use crate::device::manager::{DeviceManager, DriverPriority};
+use crate::device::platform::resource::PlatformDeviceResourceType;
+use crate::device::platform::{PlatformDeviceDriver, PlatformDeviceInfo};
+use crate::driver_initcall;
+use crate::early_println;
+use crate::time;
+use crate::vm;
+
+const FIFO_WR_DPTX_CLK_EN: usize = 0x000;
+const FIFO_WR_N_CLK_EN: usize = 0x004;
+const FIFO_WR_UNK_EN: usize = 0x008;
+const FIFO_RD_PCLK1_EN: usize = 0x020;
+const FIFO_RD_N_CLK_EN: usize = 0x028;
+const FIFO_RD_UNK_EN: usize = 0x02c;
+
+const OUT_PCLK1_EN: usize = 0x040;
+const OUT_N_CLK_EN: usize = 0x048;
+const OUT_UNK_EN: usize = 0x04c;
+
+const CROSSBAR_DISPEXT_EN: usize = 0x050;
+const CROSSBAR_MUX_CTRL: usize = 0x060;
+const CROSSBAR_ATC_EN: usize = 0x070;
+
+const FIFO_WR_DPTX_CLK_EN_STAT: usize = 0x800;
+const FIFO_WR_N_CLK_EN_STAT: usize = 0x804;
+const FIFO_RD_PCLK1_EN_STAT: usize = 0x820;
+const FIFO_RD_PCLK2_EN_STAT: usize = 0x824;
+const FIFO_RD_N_CLK_EN_STAT: usize = 0x828;
+const OUT_PCLK1_EN_STAT: usize = 0x840;
+const OUT_PCLK2_EN_STAT: usize = 0x844;
+const OUT_N_CLK_EN_STAT: usize = 0x848;
+
+const UNK_TUNABLE: usize = 0xc00;
+
+const ATC_DPIN0: u32 = 1 << 0;
+const ATC_DPIN1: u32 = 1 << 4;
+const ATC_DPPHY: u32 = 1 << 8;
+
+const MUX_DPPHY: usize = 0;
+const MUX_DPIN0: usize = 1;
+const MUX_DPIN1: usize = 2;
+const MUX_MAX: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DpxbarPort {
+    DpPhy,
+    Dpin0,
+    Dpin1,
+}
+
+pub struct AppleDpxbar {
+    base: usize,
+    selected_dispext: [i32; MUX_MAX],
+    n_ufp: u32,
+}
+
+impl AppleDpxbar {
+    fn new(base: usize, n_ufp: u32) -> Self {
+        Self {
+            base,
+            selected_dispext: [-1; MUX_MAX],
+            n_ufp,
+        }
+    }
+
+    fn port_index(port: DpxbarPort) -> usize {
+        match port {
+            DpxbarPort::DpPhy => MUX_DPPHY,
+            DpxbarPort::Dpin0 => MUX_DPIN0,
+            DpxbarPort::Dpin1 => MUX_DPIN1,
+        }
+    }
+
+    pub fn set_port(
+        &mut self,
+        port: DpxbarPort,
+        dispext_state: Option<u32>,
+    ) -> Result<(), &'static str> {
+        let state = match dispext_state {
+            Some(value) => {
+                if value >= self.n_ufp {
+                    return Err("apple-dpxbar: invalid dispext state");
+                }
+                value as i32
+            }
+            None => -1,
+        };
+
+        self.set(Self::port_index(port), state)
+    }
+
+    pub fn disconnect_all(&mut self) {
+        for port in [MUX_DPPHY, MUX_DPIN0, MUX_DPIN1] {
+            if let Err(error) = self.set(port, -1) {
+                early_println!(
+                    "[apple-dpxbar] disconnect_all failed on port {}: {}",
+                    port,
+                    error
+                );
+            }
+        }
+
+        self.log_status();
+    }
+
+    fn log_status(&self) {
+        early_println!(
+            "[apple-dpxbar] stat wr_dptx={:#x} wr_n={:#x} rd_pclk1={:#x} rd_pclk2={:#x} rd_n={:#x} out_pclk1={:#x} out_pclk2={:#x} out_n={:#x}",
+            read32(self.base, FIFO_WR_DPTX_CLK_EN_STAT),
+            read32(self.base, FIFO_WR_N_CLK_EN_STAT),
+            read32(self.base, FIFO_RD_PCLK1_EN_STAT),
+            read32(self.base, FIFO_RD_PCLK2_EN_STAT),
+            read32(self.base, FIFO_RD_N_CLK_EN_STAT),
+            read32(self.base, OUT_PCLK1_EN_STAT),
+            read32(self.base, OUT_PCLK2_EN_STAT),
+            read32(self.base, OUT_N_CLK_EN_STAT)
+        );
+    }
+
+    fn set(&mut self, port_index: usize, dispext_state: i32) -> Result<(), &'static str> {
+        if port_index >= MUX_MAX {
+            return Err("apple-dpxbar: invalid port index");
+        }
+        if dispext_state >= 0 && (dispext_state as u32) >= self.n_ufp {
+            return Err("apple-dpxbar: dispext state out of range");
+        }
+
+        let (atc_bit, mux_mask, mux_set) = match port_index {
+            MUX_DPPHY => (
+                ATC_DPPHY,
+                ((0xfu32) << 20) | ((0xfu32) << 8),
+                field_prep(20, dispext_state as u32) | field_prep(8, dispext_state as u32),
+            ),
+            MUX_DPIN0 => (
+                ATC_DPIN0,
+                ((0xfu32) << 16) | ((0xfu32) << 0),
+                field_prep(16, dispext_state as u32) | field_prep(0, dispext_state as u32),
+            ),
+            MUX_DPIN1 => (
+                ATC_DPIN1,
+                ((0xfu32) << 12) | ((0xfu32) << 4),
+                field_prep(12, dispext_state as u32) | field_prep(4, dispext_state as u32),
+            ),
+            _ => return Err("apple-dpxbar: unknown port mapping"),
+        };
+
+        set32(self.base, OUT_N_CLK_EN, atc_bit);
+        clear32(self.base, OUT_UNK_EN, atc_bit);
+        clear32(self.base, OUT_PCLK1_EN, atc_bit);
+        clear32(self.base, CROSSBAR_ATC_EN, atc_bit);
+
+        let prev_state = self.selected_dispext[port_index];
+        if prev_state >= 0 {
+            let prev_dispext_bit = 1u32 << (prev_state as u32);
+            let prev_dispext_bit_en = 1u32 << (2 * (prev_state as u32));
+
+            set32(self.base, FIFO_WR_N_CLK_EN, prev_dispext_bit);
+            set32(self.base, FIFO_RD_N_CLK_EN, prev_dispext_bit);
+
+            clear32(self.base, FIFO_WR_UNK_EN, prev_dispext_bit);
+            clear32(self.base, FIFO_RD_UNK_EN, prev_dispext_bit_en);
+            clear32(self.base, FIFO_WR_DPTX_CLK_EN, prev_dispext_bit);
+
+            clear32(self.base, FIFO_RD_PCLK1_EN, prev_dispext_bit);
+            clear32(self.base, CROSSBAR_DISPEXT_EN, prev_dispext_bit);
+
+            self.selected_dispext[port_index] = -1;
+        }
+
+        mask32(self.base, CROSSBAR_MUX_CTRL, mux_mask, mux_set);
+
+        if dispext_state >= 0 {
+            let dispext_bit = 1u32 << (dispext_state as u32);
+            let dispext_bit_en = 1u32 << (2 * (dispext_state as u32));
+
+            clear32(self.base, FIFO_WR_N_CLK_EN, dispext_bit);
+            clear32(self.base, FIFO_RD_N_CLK_EN, dispext_bit);
+            clear32(self.base, OUT_N_CLK_EN, atc_bit);
+
+            set32(self.base, FIFO_WR_UNK_EN, dispext_bit);
+            set32(self.base, FIFO_RD_UNK_EN, dispext_bit_en);
+            set32(self.base, OUT_UNK_EN, atc_bit);
+
+            set32(self.base, FIFO_WR_DPTX_CLK_EN, dispext_bit);
+            set32(self.base, FIFO_RD_PCLK1_EN, dispext_bit);
+            set32(self.base, OUT_PCLK1_EN, atc_bit);
+
+            set32(self.base, CROSSBAR_ATC_EN, atc_bit);
+            set32(self.base, CROSSBAR_DISPEXT_EN, dispext_bit);
+
+            clear32(self.base, FIFO_RD_PCLK1_EN, dispext_bit);
+            time::udelay(10);
+            set32(self.base, FIFO_RD_PCLK1_EN, dispext_bit);
+
+            self.selected_dispext[port_index] = dispext_state;
+        }
+
+        Ok(())
+    }
+}
+
+fn field_prep(shift: u32, value: u32) -> u32 {
+    (value & 0xf) << shift
+}
+
+fn read32(base: usize, offset: usize) -> u32 {
+    // SAFETY: `base` is obtained from `vm::ioremap` and `offset` is a fixed
+    // register offset for this MMIO region. Access must be volatile.
+    unsafe { core::ptr::read_volatile((base + offset) as *const u32) }
+}
+
+fn write32(base: usize, offset: usize, value: u32) {
+    // SAFETY: `base` is obtained from `vm::ioremap` and `offset` is a fixed
+    // register offset for this MMIO region. Access must be volatile.
+    unsafe { core::ptr::write_volatile((base + offset) as *mut u32, value) }
+}
+
+fn mask32(base: usize, offset: usize, mask: u32, set: u32) {
+    let value = read32(base, offset);
+    write32(base, offset, (value & !mask) | set);
+}
+
+fn set32(base: usize, offset: usize, bits: u32) {
+    mask32(base, offset, 0, bits);
+}
+
+fn clear32(base: usize, offset: usize, bits: u32) {
+    mask32(base, offset, bits, 0);
+}
+
+fn dpxbar_resource(device: &PlatformDeviceInfo) -> Result<(usize, usize), &'static str> {
+    let mem_resources: Vec<_> = device
+        .get_resources()
+        .iter()
+        .filter(|resource| matches!(resource.res_type, PlatformDeviceResourceType::MEM))
+        .collect();
+
+    let region = mem_resources
+        .first()
+        .ok_or("apple-dpxbar: missing memory resource")?;
+
+    let paddr = region.start;
+    let size = region
+        .end
+        .checked_sub(region.start)
+        .and_then(|value| value.checked_add(1))
+        .ok_or("apple-dpxbar: invalid memory resource")?;
+
+    Ok((paddr, size))
+}
+
+fn is_t8103(device: &PlatformDeviceInfo) -> bool {
+    device
+        .compatible()
+        .iter()
+        .any(|entry| *entry == "apple,t8103-display-crossbar")
+}
+
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    let (paddr, size) = dpxbar_resource(device)?;
+    let base = vm::ioremap(paddr, size).map_err(|_| "apple-dpxbar: failed to map MMIO")?;
+
+    let mut dpxbar = AppleDpxbar::new(base, 2);
+
+    if is_t8103(device) {
+        let tunable = read32(base, UNK_TUNABLE);
+        write32(base, UNK_TUNABLE, 0);
+        let tunable_after = read32(base, UNK_TUNABLE);
+        early_println!(
+            "[apple-dpxbar] t8103 tunable: before={:#x} after={:#x}",
+            tunable,
+            tunable_after
+        );
+    }
+
+    dpxbar.disconnect_all();
+
+    early_println!(
+        "[apple-dpxbar] probe: paddr={:#x} size={:#x} n_ufp={}",
+        paddr,
+        size,
+        dpxbar.n_ufp
+    );
+
+    *DPXBAR.lock() = Some(dpxbar);
+    Ok(())
+}
+
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    *DPXBAR.lock() = None;
+    Ok(())
+}
+
+static DPXBAR: Mutex<Option<AppleDpxbar>> = Mutex::new(None);
+
+pub fn with_dpxbar<R>(f: impl FnOnce(&mut AppleDpxbar) -> R) -> Option<R> {
+    let mut guard = DPXBAR.lock();
+    guard.as_mut().map(f)
+}
+
+fn register_dpxbar_driver() {
+    let driver = PlatformDeviceDriver::new(
+        "apple-dpxbar",
+        probe_fn,
+        remove_fn,
+        alloc::vec![
+            "apple,t8103-display-crossbar",
+            "apple,t8112-display-crossbar",
+            "apple,t6000-display-crossbar",
+        ],
+    );
+
+    DeviceManager::get_manager().register_driver(Box::new(driver), DriverPriority::Standard);
+}
+
+driver_initcall!(register_dpxbar_driver);

--- a/kernel/src/drivers/display/mod.rs
+++ b/kernel/src/drivers/display/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(target_arch = "aarch64")]
+pub mod dcpext;

--- a/kernel/src/drivers/display/mod.rs
+++ b/kernel/src/drivers/display/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(target_arch = "aarch64")]
 pub mod dcpext;
+
+#[cfg(target_arch = "aarch64")]
+pub mod dpxbar;

--- a/kernel/src/drivers/display/mod.rs
+++ b/kernel/src/drivers/display/mod.rs
@@ -1,5 +1,26 @@
-#[cfg(target_arch = "aarch64")]
-pub mod dcpext;
+//! External display drivers for Apple Silicon (DCPext, DPXBAR).
+//!
+//! Disabled until the kernel architecture supports the required prerequisites:
+//! - Late/delayed driver probing (after interrupt subsystem and scheduler init)
+//! - Driver dependency graph (DART → PMGR → CLK → DCPext ordering)
+//! - Interrupt-driven EPIC message handling (AFK ring buffer, service announces)
+//! - DART IOMMU setup that coexists with m1n1's pre-initialized page tables
+//!
+//! The driver code itself is complete (I2C → EFUSE → ASC → RTKit → AFK → EPIC
+//! → DCPext → DPXBAR → ATC PHY DP → DisplayOutput). What's missing is the kernel
+//! infrastructure to initialize coprocessors safely after the boot interrupt
+//! and scheduler are ready.
+//!
+//! TODO: Implement late_probe mechanism so coprocessor drivers can init after
+//!       interrupt/scheduler are available.
+//! TODO: Resolve DART page table ownership — m1n1 locks dart-disp0 and pre-sets
+//!       page tables before handing off to the OS. Scarlet must either inherit
+//!       or rebuild these tables.
+//! TODO: Add deferred probe support (equivalent to Linux's deferred_probe)
+//!       so DART can probe before DCPext without ordering hacks.
 
-#[cfg(target_arch = "aarch64")]
-pub mod dpxbar;
+// #[cfg(target_arch = "aarch64")]
+// pub mod dcpext;
+//
+// #[cfg(target_arch = "aarch64")]
+// pub mod dpxbar;

--- a/kernel/src/drivers/i2c/apple_i2c.rs
+++ b/kernel/src/drivers/i2c/apple_i2c.rs
@@ -1,0 +1,407 @@
+//! Apple PA Semi I2C controller driver.
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use spin::Mutex;
+
+use crate::arch::mmio;
+use crate::device::i2c::adapter::I2cAdapter;
+use crate::device::i2c::{I2cAddress, I2cBus, I2cError, I2cMessage, I2cMessageFlags};
+use crate::device::{
+    DeviceInfo,
+    manager::{DeviceManager, DriverPriority},
+    platform::{PlatformDeviceDriver, PlatformDeviceInfo, resource::PlatformDeviceResourceType},
+};
+use crate::driver_initcall;
+use crate::time;
+use crate::vm;
+
+const REG_MTXFIFO: usize = 0x00;
+const REG_MRXFIFO: usize = 0x04;
+const REG_MCNT: usize = 0x08;
+const REG_XFSTA: usize = 0x0c;
+const REG_SADDR: usize = 0x10;
+const REG_SMSTA: usize = 0x14;
+const REG_IMASK: usize = 0x18;
+const REG_CTL: usize = 0x1c;
+const REG_REV: usize = 0x28;
+const REG_FIFOCTL: usize = 0x44;
+
+const MTXFIFO_DATA_MASK: u32 = 0xff;
+const MTXFIFO_START: u32 = 1 << 8;
+const MTXFIFO_STOP: u32 = 1 << 9;
+const MTXFIFO_READ: u32 = 1 << 10;
+
+const MRXFIFO_DATA_MASK: u32 = 0xff;
+const MRXFIFO_EMPTY: u32 = 1 << 8;
+
+const SMSTA_XIP: u32 = 1 << 28;
+const SMSTA_XEN: u32 = 1 << 27;
+const SMSTA_JAM: u32 = 1 << 24;
+const SMSTA_MTO: u32 = 1 << 23;
+const SMSTA_MTA: u32 = 1 << 22;
+const SMSTA_MTN: u32 = 1 << 21;
+const SMSTA_ERR_MASK: u32 = SMSTA_JAM | SMSTA_MTO | SMSTA_MTA | SMSTA_MTN;
+
+const CTL_EN: u32 = 1 << 11;
+const CTL_MRR: u32 = 1 << 10;
+const CTL_MTR: u32 = 1 << 9;
+const CTL_UJM: u32 = 1 << 8;
+const CTL_CLK_MASK: u32 = 0xff;
+
+const DEFAULT_BUS_HZ: u32 = 100_000;
+const REF_CLOCK_HZ: u32 = 24_000_000;
+const TXN_TIMEOUT_US: u64 = 100_000;
+const POLL_INTERVAL_US: u64 = 10;
+
+struct AppleI2cInner {
+    bus_hz: u32,
+    hw_rev: u32,
+}
+
+/// Apple PA Semi I2C master controller.
+pub struct AppleI2cController {
+    base: usize,
+    bus_number: u32,
+    inner: Mutex<AppleI2cInner>,
+}
+
+impl AppleI2cController {
+    /// Create a controller instance and initialize hardware.
+    pub fn new(base: usize, bus_number: u32) -> Result<Self, I2cError> {
+        let controller = Self {
+            base,
+            bus_number,
+            inner: Mutex::new(AppleI2cInner {
+                bus_hz: DEFAULT_BUS_HZ,
+                hw_rev: 0,
+            }),
+        };
+        controller.init_hardware()?;
+        Ok(controller)
+    }
+
+    fn init_hardware(&self) -> Result<(), I2cError> {
+        let hw_rev = self.read_reg(REG_REV);
+        {
+            let mut inner = self.inner.lock();
+            inner.hw_rev = hw_rev;
+        }
+
+        self.write_reg(REG_IMASK, 0);
+        self.write_reg(REG_SADDR, 0);
+        self.write_reg(REG_FIFOCTL, 0);
+        self.clear_status();
+        self.clear_fifos();
+        self.program_bus_speed(DEFAULT_BUS_HZ)?;
+        Ok(())
+    }
+
+    fn read_reg(&self, offset: usize) -> u32 {
+        // SAFETY: `self.base` is an ioremap'd MMIO region and `offset` values
+        // are fixed controller register offsets.
+        unsafe { mmio::read32(self.base + offset) }
+    }
+
+    fn write_reg(&self, offset: usize, value: u32) {
+        // SAFETY: `self.base` is an ioremap'd MMIO region and `offset` values
+        // are fixed controller register offsets.
+        unsafe { mmio::write32(self.base + offset, value) }
+    }
+
+    fn clear_status(&self) {
+        self.write_reg(REG_SMSTA, !0u32);
+        self.write_reg(REG_XFSTA, !0u32);
+    }
+
+    fn clear_fifos(&self) {
+        let inner = self.inner.lock();
+        let mut ctl = CTL_MRR | CTL_MTR | CTL_UJM;
+        ctl |= self.divider_to_ctl_clock(Self::divider_for_speed(inner.bus_hz));
+        if inner.hw_rev >= 6 {
+            ctl |= CTL_EN;
+        }
+        drop(inner);
+        self.write_reg(REG_CTL, ctl);
+    }
+
+    fn divider_to_ctl_clock(&self, divider: u8) -> u32 {
+        (divider as u32) & CTL_CLK_MASK
+    }
+
+    fn divider_for_speed(hz: u32) -> u8 {
+        let clamped_hz = hz.max(1);
+        let mut divider = REF_CLOCK_HZ / (16 * clamped_hz);
+        if divider == 0 {
+            divider = 1;
+        }
+        if divider > u8::MAX as u32 {
+            divider = u8::MAX as u32;
+        }
+        divider as u8
+    }
+
+    fn program_bus_speed(&self, hz: u32) -> Result<(), I2cError> {
+        if hz == 0 {
+            return Err(I2cError::InvalidArg);
+        }
+
+        let divider = Self::divider_for_speed(hz);
+        let mut inner = self.inner.lock();
+        inner.bus_hz = hz;
+
+        let mut ctl = CTL_UJM | self.divider_to_ctl_clock(divider);
+        if inner.hw_rev >= 6 {
+            ctl |= CTL_EN;
+        }
+        drop(inner);
+
+        self.write_reg(REG_CTL, ctl);
+        Ok(())
+    }
+
+    fn map_smsta_error(smsta: u32) -> I2cError {
+        if smsta & SMSTA_MTN != 0 {
+            I2cError::Nack
+        } else if smsta & SMSTA_MTA != 0 {
+            I2cError::ArbitrationLost
+        } else if smsta & SMSTA_MTO != 0 {
+            I2cError::Timeout
+        } else {
+            I2cError::BusError
+        }
+    }
+
+    fn poll_transfer_done(&self) -> Result<(), I2cError> {
+        let start = time::current_time();
+        loop {
+            let smsta = self.read_reg(REG_SMSTA);
+            if smsta & SMSTA_ERR_MASK != 0 {
+                return Err(Self::map_smsta_error(smsta));
+            }
+
+            if smsta & SMSTA_XIP == 0 {
+                return Ok(());
+            }
+
+            let now = time::current_time();
+            if now.saturating_sub(start) > TXN_TIMEOUT_US {
+                return Err(I2cError::Timeout);
+            }
+
+            time::udelay(POLL_INTERVAL_US);
+        }
+    }
+
+    fn wait_rx_available(&self) -> Result<u8, I2cError> {
+        let start = time::current_time();
+        loop {
+            let r = self.read_reg(REG_MRXFIFO);
+            if r & MRXFIFO_EMPTY == 0 {
+                return Ok((r & MRXFIFO_DATA_MASK) as u8);
+            }
+
+            let smsta = self.read_reg(REG_SMSTA);
+            if smsta & SMSTA_ERR_MASK != 0 {
+                return Err(Self::map_smsta_error(smsta));
+            }
+
+            let now = time::current_time();
+            if now.saturating_sub(start) > TXN_TIMEOUT_US {
+                return Err(I2cError::Timeout);
+            }
+
+            time::udelay(POLL_INTERVAL_US);
+        }
+    }
+
+    fn validate_message(msg: &I2cMessage) -> Result<(), I2cError> {
+        if msg.addr.is_ten_bit() {
+            return Err(I2cError::InvalidArg);
+        }
+        if msg.flags.contains(I2cMessageFlags::READ) && msg.data.len() > u8::MAX as usize {
+            return Err(I2cError::InvalidArg);
+        }
+        Ok(())
+    }
+
+    fn start_address_byte(addr: I2cAddress, read: bool) -> Result<u8, I2cError> {
+        match addr {
+            I2cAddress::SevenBit(a) => {
+                if a > 0x7f {
+                    return Err(I2cError::InvalidArg);
+                }
+                Ok((a << 1) | u8::from(read))
+            }
+            I2cAddress::TenBit(_) => Err(I2cError::InvalidArg),
+        }
+    }
+
+    fn transfer_write(&self, msg: &I2cMessage, start: bool, stop: bool) -> Result<(), I2cError> {
+        let addr = Self::start_address_byte(msg.addr, false)?;
+
+        if start {
+            self.write_reg(REG_MTXFIFO, MTXFIFO_START | (addr as u32));
+        }
+
+        if msg.data.is_empty() {
+            if stop {
+                self.write_reg(REG_MTXFIFO, MTXFIFO_STOP);
+            }
+            self.poll_transfer_done()?;
+            return Ok(());
+        }
+
+        for (index, byte) in msg.data.iter().enumerate() {
+            let is_last = index == msg.data.len() - 1;
+            let mut value = (*byte as u32) & MTXFIFO_DATA_MASK;
+            if !start && index == 0 {
+                value |= MTXFIFO_START;
+                value = (value & !MTXFIFO_DATA_MASK) | (addr as u32);
+            }
+            if stop && is_last {
+                value |= MTXFIFO_STOP;
+            }
+            self.write_reg(REG_MTXFIFO, value);
+        }
+
+        self.poll_transfer_done()
+    }
+
+    fn transfer_read(&self, msg: &mut I2cMessage, start: bool, stop: bool) -> Result<(), I2cError> {
+        let addr = Self::start_address_byte(msg.addr, true)?;
+        if start {
+            self.write_reg(REG_MTXFIFO, MTXFIFO_START | (addr as u32));
+        }
+
+        let mut cmd = MTXFIFO_READ | ((msg.data.len() as u32) & MTXFIFO_DATA_MASK);
+        if stop {
+            cmd |= MTXFIFO_STOP;
+        }
+        self.write_reg(REG_MTXFIFO, cmd);
+
+        self.poll_transfer_done()?;
+
+        for byte in msg.data.iter_mut() {
+            *byte = self.wait_rx_available()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl I2cBus for AppleI2cController {
+    fn transfer(&self, msgs: &mut [I2cMessage]) -> Result<(), I2cError> {
+        if msgs.is_empty() {
+            return Err(I2cError::InvalidArg);
+        }
+
+        self.clear_fifos();
+        self.clear_status();
+
+        let total = msgs.len();
+        for (index, msg) in msgs.iter_mut().enumerate() {
+            Self::validate_message(msg)?;
+            let is_last = index == total - 1;
+            let start = if index == 0 {
+                true
+            } else {
+                !msg.flags.contains(I2cMessageFlags::NOSTART)
+            };
+            let stop = msg.flags.contains(I2cMessageFlags::STOP) || is_last;
+
+            if msg.flags.contains(I2cMessageFlags::READ) {
+                self.transfer_read(msg, start, stop)?;
+            } else {
+                self.transfer_write(msg, start, stop)?;
+            }
+        }
+
+        let smsta = self.read_reg(REG_SMSTA);
+        if smsta & SMSTA_ERR_MASK != 0 {
+            return Err(Self::map_smsta_error(smsta));
+        }
+
+        let _ = self.read_reg(REG_MCNT);
+        self.clear_status();
+        Ok(())
+    }
+
+    fn set_bus_speed(&self, hz: u32) -> Result<(), I2cError> {
+        self.program_bus_speed(hz)
+    }
+
+    fn bus_speed(&self) -> u32 {
+        self.inner.lock().bus_hz
+    }
+
+    fn bus_number(&self) -> u32 {
+        self.bus_number
+    }
+}
+
+static I2C_ADAPTER_REGISTRY: Mutex<Vec<Arc<I2cAdapter>>> = Mutex::new(Vec::new());
+
+/// Lookup a registered I2C adapter by bus number.
+pub fn get_i2c_adapter(bus: u32) -> Option<Arc<I2cAdapter>> {
+    let guard = I2C_ADAPTER_REGISTRY.lock();
+    guard
+        .iter()
+        .find(|adapter| adapter.bus_number() == bus)
+        .map(Arc::clone)
+}
+
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    let mem_resources: Vec<_> = device
+        .get_resources()
+        .iter()
+        .filter(|r| matches!(r.res_type, PlatformDeviceResourceType::MEM))
+        .collect();
+
+    let resource = mem_resources
+        .first()
+        .ok_or("apple-i2c: no memory resource")?;
+
+    let paddr = resource.start;
+    let size = resource
+        .end
+        .checked_sub(resource.start)
+        .and_then(|v| v.checked_add(1))
+        .ok_or("apple-i2c: invalid memory resource")?;
+
+    let base = vm::ioremap(paddr, size).map_err(|_| "apple-i2c: ioremap failed")?;
+
+    let bus_number = device
+        .property("reg")
+        .and_then(|p| p.as_usize())
+        .map(|v| v as u32)
+        .unwrap_or(device.id() as u32);
+
+    let controller = AppleI2cController::new(base, bus_number)
+        .map_err(|_| "apple-i2c: controller initialization failed")?;
+    let bus: Arc<dyn I2cBus> = Arc::new(controller);
+    let adapter = Arc::new(I2cAdapter::new(bus));
+
+    I2C_ADAPTER_REGISTRY.lock().push(adapter);
+    Ok(())
+}
+
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    Ok(())
+}
+
+fn register_apple_i2c_driver() {
+    let driver = PlatformDeviceDriver::new(
+        "apple-i2c",
+        probe_fn,
+        remove_fn,
+        alloc::vec!["apple,t8103-i2c", "apple,t8112-i2c", "apple,i2c"],
+    );
+
+    DeviceManager::get_manager().register_driver(Box::new(driver), DriverPriority::Core);
+}
+
+driver_initcall!(register_apple_i2c_driver);

--- a/kernel/src/drivers/i2c/mod.rs
+++ b/kernel/src/drivers/i2c/mod.rs
@@ -1,0 +1,4 @@
+//! I2C controller drivers.
+
+#[cfg(target_arch = "aarch64")]
+pub mod apple_i2c;

--- a/kernel/src/drivers/iommu/apple_dart.rs
+++ b/kernel/src/drivers/iommu/apple_dart.rs
@@ -323,6 +323,26 @@ impl DartPageTable {
     pub fn root_paddr(&self) -> usize {
         self.root_paddr
     }
+
+    /// Map a physically contiguous region into the DART page table.
+    ///
+    /// Maps `size` bytes starting at `paddr` to the IOVA range starting at `iova`.
+    pub fn map_contiguous(
+        &mut self,
+        iova: usize,
+        paddr: usize,
+        size: usize,
+        flags: u64,
+    ) -> Result<(), &'static str> {
+        let page_size = 1usize << DART_PAGE_SHIFT;
+        let pages = (size + page_size - 1) / page_size;
+
+        for i in 0..pages {
+            self.map_page(iova + i * page_size, paddr + i * page_size, flags)?;
+        }
+
+        Ok(())
+    }
 }
 
 // =============================================================================

--- a/kernel/src/drivers/mod.rs
+++ b/kernel/src/drivers/mod.rs
@@ -5,6 +5,8 @@
 pub mod block;
 pub mod graphics;
 #[cfg(target_arch = "aarch64")]
+pub mod i2c;
+#[cfg(target_arch = "aarch64")]
 pub mod iommu;
 pub mod network;
 #[cfg(target_arch = "aarch64")]

--- a/kernel/src/drivers/mod.rs
+++ b/kernel/src/drivers/mod.rs
@@ -3,6 +3,8 @@
 //! This module encapsulates various device drivers for the Scarlet kernel.
 
 pub mod block;
+#[cfg(target_arch = "aarch64")]
+pub mod display;
 pub mod graphics;
 #[cfg(target_arch = "aarch64")]
 pub mod i2c;

--- a/kernel/src/drivers/mod.rs
+++ b/kernel/src/drivers/mod.rs
@@ -10,6 +10,8 @@ pub mod i2c;
 pub mod iommu;
 pub mod network;
 #[cfg(target_arch = "aarch64")]
+pub mod nvmem;
+#[cfg(target_arch = "aarch64")]
 pub mod pcie;
 #[cfg(target_arch = "aarch64")]
 pub mod phy;

--- a/kernel/src/drivers/nvmem/apple_efuse.rs
+++ b/kernel/src/drivers/nvmem/apple_efuse.rs
@@ -1,0 +1,109 @@
+//! Apple EFUSE read-only memory driver.
+//!
+//! Provides access to factory calibration data stored in on-chip eFUSE memory.
+//! Used primarily to read ATC PHY tunables for USB-C/DisplayPort calibration
+//! on Apple Silicon (t8103/M1, t6000/M1 Pro/Max).
+//!
+//! EFUSE is a simple MMIO region with 32-bit read-only words.
+//! Calibration values are bitfields within these words, defined as
+//! nvmem-cells in the device tree with `reg` (byte offset) and `bits`
+//! (bit offset, bit count) properties.
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use spin::Mutex;
+
+use crate::arch::mmio;
+use crate::device::manager::{DeviceManager, DriverPriority};
+use crate::device::platform::resource::PlatformDeviceResourceType;
+use crate::device::platform::{PlatformDeviceDriver, PlatformDeviceInfo};
+use crate::driver_initcall;
+use crate::early_println;
+use crate::vm;
+
+/// An EFUSE nvmem cell — a bitfield extracted from the EFUSE MMIO region.
+#[derive(Debug, Clone)]
+pub struct EfuseCell {
+    pub name: String,
+    pub offset: usize,
+    pub bit_offset: u32,
+    pub bit_count: u32,
+}
+
+impl EfuseCell {
+    pub fn extract(&self, word: u32) -> u32 {
+        let mask = (1u32 << self.bit_count) - 1;
+        (word >> self.bit_offset) & mask
+    }
+}
+
+/// Apple EFUSE driver instance.
+pub struct AppleEfuse {
+    base: usize,
+}
+
+impl AppleEfuse {
+    fn new(base: usize) -> Self {
+        Self { base }
+    }
+
+    /// Read a raw 32-bit word from the EFUSE region.
+    pub fn read32(&self, offset: usize) -> u32 {
+        // SAFETY: `self.base + offset` points to a mapped EFUSE MMIO region.
+        unsafe { mmio::read32(self.base + offset) }
+    }
+
+    /// Read and extract a cell value.
+    pub fn read_cell(&self, cell: &EfuseCell) -> u32 {
+        cell.extract(self.read32(cell.offset))
+    }
+}
+
+static EFUSE_REGISTRY: Mutex<Vec<Arc<AppleEfuse>>> = Mutex::new(Vec::new());
+
+/// Get a probed EFUSE instance by index.
+pub fn get_apple_efuse(id: u32) -> Option<Arc<AppleEfuse>> {
+    EFUSE_REGISTRY.lock().get(id as usize).map(Arc::clone)
+}
+
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    let resource = device
+        .get_resources()
+        .iter()
+        .find(|r| matches!(r.res_type, PlatformDeviceResourceType::MEM))
+        .ok_or("apple-efuse: no memory resource")?;
+
+    let paddr = resource.start;
+    let size = resource
+        .end
+        .checked_sub(resource.start)
+        .and_then(|v| v.checked_add(1))
+        .ok_or("apple-efuse: invalid memory resource")?;
+
+    let base = vm::ioremap(paddr, size).map_err(|_| "apple-efuse: ioremap failed")?;
+
+    early_println!("[apple-efuse] probed at {:#x} ({} bytes)", paddr, size);
+
+    EFUSE_REGISTRY.lock().push(Arc::new(AppleEfuse::new(base)));
+
+    Ok(())
+}
+
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    Ok(())
+}
+
+fn register_apple_efuse_driver() {
+    let driver = PlatformDeviceDriver::new(
+        "apple-efuse",
+        probe_fn,
+        remove_fn,
+        alloc::vec!["apple,t8103-efuses", "apple,t6000-efuses", "apple,efuses"],
+    );
+
+    DeviceManager::get_manager().register_driver(Box::new(driver), DriverPriority::Core);
+}
+
+driver_initcall!(register_apple_efuse_driver);

--- a/kernel/src/drivers/nvmem/mod.rs
+++ b/kernel/src/drivers/nvmem/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(target_arch = "aarch64")]
+pub mod apple_efuse;

--- a/kernel/src/drivers/phy/apple_atcphy.rs
+++ b/kernel/src/drivers/phy/apple_atcphy.rs
@@ -1,6 +1,7 @@
 //! Apple ATC PHY driver
 //!
 //! Apple Type-C PHY found on Apple Silicon SoCs (t8103/M1).
+//! Supports USB3, DisplayPort, and combined USB3+DP modes.
 
 #![allow(dead_code)]
 
@@ -96,22 +97,120 @@ const PIPEHANDLER_NATIVE_RESET: u32 = 1 << 12;
 const PIPEHANDLER_DUMMY_PHY_EN: u32 = 1 << 15;
 const PIPEHANDLER_NATIVE_POWER_DOWN_MASK: u32 = 0xf;
 
+const PIPEHANDLER_MUX_CTRL_DATA_DP: u32 = 4;
+const PIPEHANDLER_MUX_CTRL_CLK_DP: u32 = 4;
+
+// =============================================================================
+// Hardware Tunable
+// =============================================================================
+
+/// One hardware tunable entry: `[offset, mask, value]` applied to an MMIO region.
+///
+/// The bootloader (m1n1) pre-processes EFUSE calibration data into these
+/// register-level tunables and injects them into the device tree.
+#[derive(Debug, Clone)]
+pub struct HardwareTunable {
+    pub offset: u32,
+    pub mask: u32,
+    pub value: u32,
+}
+
+impl HardwareTunable {
+    /// Parse a tunable array from device tree property bytes.
+    ///
+    /// Property contains big-endian u32 triplets: `[offset, mask, value, ...]`.
+    pub fn parse_from_property(prop_bytes: &[u8]) -> Vec<Self> {
+        let mut tunables = Vec::new();
+        let chunks = prop_bytes.chunks_exact(12);
+        for chunk in chunks {
+            let offset = u32::from_be_bytes(chunk[0..4].try_into().unwrap_or([0; 4]));
+            let mask = u32::from_be_bytes(chunk[4..8].try_into().unwrap_or([0; 4]));
+            let value = u32::from_be_bytes(chunk[8..12].try_into().unwrap_or([0; 4]));
+            tunables.push(Self {
+                offset,
+                mask,
+                value,
+            });
+        }
+        tunables
+    }
+
+    /// Apply this tunable to a 32-bit register read from `base + offset`.
+    pub fn apply(&self, base: usize) {
+        let old = unsafe { mmio::read32(base + self.offset as usize) };
+        let new = (old & !self.mask) | self.value;
+        if new != old {
+            unsafe { mmio::write32(base + self.offset as usize, new) };
+        }
+    }
+}
+
+/// Apply a slice of tunables to an MMIO base.
+pub fn apply_tunables(tunables: &[HardwareTunable], base: usize) {
+    for t in tunables {
+        t.apply(base);
+    }
+}
+
+/// Parse an `apple,tunable-*` property from the device info.
+fn parse_tunable_prop(device: &PlatformDeviceInfo, name: &str) -> Vec<HardwareTunable> {
+    device
+        .property(name)
+        .map(|p| HardwareTunable::parse_from_property(p.value()))
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// ATC PHY Mode
+// =============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AtcPhyMode {
+    Usb3,
+    DisplayPort,
+    Usb3Dp,
+}
+
 // =============================================================================
 // ATC PHY Instance
 // =============================================================================
 
 pub struct AppleAtcPhy {
     core_base: usize,
+    lpdptx_base: Option<usize>,
+    axi2af_base: Option<usize>,
     usb2phy_base: usize,
     pipehandler_base: usize,
+    common_a: Vec<HardwareTunable>,
+    common_b: Vec<HardwareTunable>,
+    axi2af_tunables: Vec<HardwareTunable>,
+    lane0_usb: Vec<HardwareTunable>,
+    lane1_usb: Vec<HardwareTunable>,
+    lane0_dp: Vec<HardwareTunable>,
+    lane1_dp: Vec<HardwareTunable>,
 }
 
 impl AppleAtcPhy {
-    pub fn new(core_base: usize, usb2phy_base: usize, pipehandler_base: usize) -> Self {
+    pub fn new(
+        core_base: usize,
+        lpdptx_base: Option<usize>,
+        axi2af_base: Option<usize>,
+        usb2phy_base: usize,
+        pipehandler_base: usize,
+    ) -> Self {
         Self {
             core_base,
+            lpdptx_base,
+            axi2af_base,
             usb2phy_base,
             pipehandler_base,
+            common_a: Vec::new(),
+            common_b: Vec::new(),
+            axi2af_tunables: Vec::new(),
+            lane0_usb: Vec::new(),
+            lane1_usb: Vec::new(),
+            lane0_dp: Vec::new(),
+            lane1_dp: Vec::new(),
         }
     }
 
@@ -167,6 +266,22 @@ impl AppleAtcPhy {
 
     fn ph_clear32(&self, offset: usize, bits: u32) {
         self.ph_write32(offset, self.ph_read32(offset) & !bits);
+    }
+
+    fn lpdptx_read32(&self, offset: usize) -> u32 {
+        unsafe { mmio::read32(self.lpdptx_base.unwrap() + offset) }
+    }
+
+    fn lpdptx_write32(&self, offset: usize, val: u32) {
+        unsafe { mmio::write32(self.lpdptx_base.unwrap() + offset, val) }
+    }
+
+    fn axi2af_read32(&self, offset: usize) -> u32 {
+        unsafe { mmio::read32(self.axi2af_base.unwrap() + offset) }
+    }
+
+    fn axi2af_write32(&self, offset: usize, val: u32) {
+        unsafe { mmio::write32(self.axi2af_base.unwrap() + offset, val) }
     }
 
     fn poll_core(
@@ -276,6 +391,88 @@ impl AppleAtcPhy {
         self.ph_clear32(PIPEHANDLER_LOCK_REQ, PIPEHANDLER_LOCK_EN);
     }
 
+    fn configure_pipehandler_dp(&self, swap_lanes: bool) {
+        let (lane0, lane1) = if swap_lanes { (1, 0) } else { (0, 1) };
+
+        let nonselected = self.ph_read32(PIPEHANDLER_NONSELECTED_OVERRIDE);
+        self.ph_write32(
+            PIPEHANDLER_NONSELECTED_OVERRIDE,
+            (nonselected & !PIPEHANDLER_NATIVE_POWER_DOWN_MASK) | 3,
+        );
+        self.ph_clear32(PIPEHANDLER_NONSELECTED_OVERRIDE, PIPEHANDLER_NATIVE_RESET);
+
+        // Configure the DP lane
+        let dp_lane = if lane0 == 0 { 0 } else { 1 };
+        let mut mux = self.ph_read32(PIPEHANDLER_MUX_CTRL);
+
+        mux = (mux & !PIPEHANDLER_MUX_CTRL_CLK_MASK) | (PIPEHANDLER_MUX_CTRL_CLK_OFF << 3);
+        self.ph_write32(PIPEHANDLER_MUX_CTRL, mux);
+        self.small_delay();
+
+        mux = (mux & !PIPEHANDLER_MUX_CTRL_DATA_MASK) | PIPEHANDLER_MUX_CTRL_DATA_DP;
+        self.ph_write32(PIPEHANDLER_MUX_CTRL, mux);
+        self.small_delay();
+
+        mux = (mux & !PIPEHANDLER_MUX_CTRL_CLK_MASK) | (PIPEHANDLER_MUX_CTRL_CLK_DP << 3);
+        self.ph_write32(PIPEHANDLER_MUX_CTRL, mux);
+        self.small_delay();
+    }
+
+    fn apply_mode_tunables(&self, mode: AtcPhyMode, swap_lanes: bool) {
+        let (lane0_idx, lane1_idx) = if swap_lanes { (1, 0) } else { (0, 1) };
+
+        apply_tunables(&self.common_a, self.core_base);
+
+        if let Some(axi2af_base) = self.axi2af_base {
+            apply_tunables(&self.axi2af_tunables, axi2af_base);
+        }
+
+        apply_tunables(&self.common_b, self.core_base);
+
+        match mode {
+            AtcPhyMode::Usb3 => {
+                apply_tunables(&self.lane0_usb, self.core_base);
+                apply_tunables(&self.lane1_usb, self.core_base);
+            }
+            AtcPhyMode::DisplayPort => {
+                apply_tunables(
+                    if lane0_idx == 0 {
+                        &self.lane0_dp
+                    } else {
+                        &self.lane1_dp
+                    },
+                    self.core_base,
+                );
+                apply_tunables(
+                    if lane1_idx == 0 {
+                        &self.lane0_dp
+                    } else {
+                        &self.lane1_dp
+                    },
+                    self.core_base,
+                );
+            }
+            AtcPhyMode::Usb3Dp => {
+                apply_tunables(
+                    if lane0_idx == 0 {
+                        &self.lane0_usb
+                    } else {
+                        &self.lane1_usb
+                    },
+                    self.core_base,
+                );
+                apply_tunables(
+                    if lane1_idx == 0 {
+                        &self.lane0_dp
+                    } else {
+                        &self.lane1_dp
+                    },
+                    self.core_base,
+                );
+            }
+        }
+    }
+
     pub fn init(&mut self) -> Result<(), &'static str> {
         early_println!("[apple-atcphy] initializing...");
 
@@ -284,7 +481,36 @@ impl AppleAtcPhy {
         self.configure_crossbar();
         self.configure_pipehandler_usb3();
 
-        early_println!("[apple-atcphy] initialized");
+        early_println!("[apple-atcphy] initialized (USB3 mode)");
+        Ok(())
+    }
+
+    pub fn init_dp(&mut self, mode: AtcPhyMode) -> Result<(), &'static str> {
+        if self.lpdptx_base.is_none() || self.axi2af_base.is_none() {
+            return Err("apple-atcphy: lpdptx/axi2af regions not mapped, cannot init DP");
+        }
+
+        early_println!("[apple-atcphy] initializing in DP mode ({:?})...", mode);
+
+        self.usb2_power_on();
+        self.core_power_on()?;
+        self.configure_crossbar();
+        self.apply_mode_tunables(mode, false);
+
+        match mode {
+            AtcPhyMode::Usb3Dp => {
+                self.configure_pipehandler_usb3();
+                self.configure_pipehandler_dp(false);
+            }
+            AtcPhyMode::DisplayPort => {
+                self.configure_pipehandler_dp(false);
+            }
+            _ => {
+                self.configure_pipehandler_usb3();
+            }
+        }
+
+        early_println!("[apple-atcphy] initialized ({:?} mode)", mode);
         Ok(())
     }
 }
@@ -341,6 +567,12 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
     let core_paddr = mem_resources[0].start;
     let core_size = mem_resources[0].end - mem_resources[0].start + 1;
 
+    let lpdptx_paddr = mem_resources[1].start;
+    let lpdptx_size = mem_resources[1].end - mem_resources[1].start + 1;
+
+    let axi2af_paddr = mem_resources[2].start;
+    let axi2af_size = mem_resources[2].end - mem_resources[2].start + 1;
+
     let usb2phy_paddr = mem_resources[3].start;
     let usb2phy_size = mem_resources[3].end - mem_resources[3].start + 1;
 
@@ -348,21 +580,61 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
     let pipehandler_size = mem_resources[4].end - mem_resources[4].start + 1;
 
     early_println!(
-        "[apple-atcphy] probing {} core={:#x} usb2phy={:#x} pipehandler={:#x}",
+        "[apple-atcphy] probing {} core={:#x} lpdptx={:#x} axi2af={:#x} usb2phy={:#x} ph={:#x}",
         device.name(),
         core_paddr,
+        lpdptx_paddr,
+        axi2af_paddr,
         usb2phy_paddr,
         pipehandler_paddr
     );
 
     let core_base = crate::vm::ioremap(core_paddr, core_size)
         .map_err(|_| "apple-atcphy: ioremap core failed")?;
+    let lpdptx_base = crate::vm::ioremap(lpdptx_paddr, lpdptx_size).ok();
+    let axi2af_base = crate::vm::ioremap(axi2af_paddr, axi2af_size).ok();
     let usb2phy_base = crate::vm::ioremap(usb2phy_paddr, usb2phy_size)
         .map_err(|_| "apple-atcphy: ioremap usb2phy failed")?;
     let pipehandler_base = crate::vm::ioremap(pipehandler_paddr, pipehandler_size)
         .map_err(|_| "apple-atcphy: ioremap pipehandler failed")?;
 
-    let mut phy = AppleAtcPhy::new(core_base, usb2phy_base, pipehandler_base);
+    let mut phy = AppleAtcPhy::new(
+        core_base,
+        lpdptx_base,
+        axi2af_base,
+        usb2phy_base,
+        pipehandler_base,
+    );
+
+    phy.common_a = parse_tunable_prop(device, "apple,tunable-common-a");
+    phy.common_b = parse_tunable_prop(device, "apple,tunable-common-b");
+    phy.axi2af_tunables = parse_tunable_prop(device, "apple,tunable-axi2af");
+    phy.lane0_usb = parse_tunable_prop(device, "apple,tunable-lane0-usb");
+    phy.lane1_usb = parse_tunable_prop(device, "apple,tunable-lane1-usb");
+    phy.lane0_dp = parse_tunable_prop(device, "apple,tunable-lane0-dp");
+    phy.lane1_dp = parse_tunable_prop(device, "apple,tunable-lane1-dp");
+
+    let tunable_count = phy.common_a.len()
+        + phy.common_b.len()
+        + phy.axi2af_tunables.len()
+        + phy.lane0_usb.len()
+        + phy.lane1_usb.len()
+        + phy.lane0_dp.len()
+        + phy.lane1_dp.len();
+    if tunable_count > 0 {
+        early_println!(
+            "[apple-atcphy] loaded {} tunables (common={}/{}, axi2af={}, usb={}/{}, dp={}/{})",
+            tunable_count,
+            phy.common_a.len(),
+            phy.common_b.len(),
+            phy.axi2af_tunables.len(),
+            phy.lane0_usb.len(),
+            phy.lane1_usb.len(),
+            phy.lane0_dp.len(),
+            phy.lane1_dp.len()
+        );
+    }
+
     phy.init()?;
 
     let phandle = device

--- a/kernel/src/drivers/soc/apple_afk.rs
+++ b/kernel/src/drivers/soc/apple_afk.rs
@@ -1,0 +1,703 @@
+//! Apple AFK (Apple Firmware Kit) ring buffer protocol driver.
+//!
+//! AFK provides ring-buffer-based bidirectional communication with Apple
+//! coprocessors, sitting on top of the RTKit endpoint messaging layer.
+//! It is used by the display coprocessor (DCP/DCPext) and other firmware.
+//!
+//! # Protocol Overview
+//!
+//! Each AFK endpoint manages two ring buffers (TX and RX) within a single
+//! shared DMA buffer. Messages are enqueued as queue entries (`AfkQueueEntry`)
+//! with 64-byte alignment. The coprocessor is notified of new data via RBEP
+//! control messages sent through RTKit.
+//!
+//! # Initialization Sequence
+//!
+//! ```text
+//! START_EP → INIT/INIT_ACK → GETBUF/GETBUF_ACK →
+//! INIT_TX → INIT_RX → START/START_ACK
+//! ```
+//!
+//! Reference: m1n1 `src/afk.c`, AsahiLinux `drivers/gpu/drm/apple/afk.c`
+
+use alloc::sync::Arc;
+use core::arch::asm;
+use core::mem;
+
+use crate::drivers::soc::apple_rtkit::{AppleRtkit, RtkitMessage};
+use crate::early_println;
+use crate::mem::pmm;
+use crate::time;
+use crate::vm;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Block shift: all ring buffer operations use 64-byte blocks.
+const BLOCK_SHIFT: u32 = 6;
+/// Block size in bytes.
+const BLOCK_SIZE: usize = 1 << BLOCK_SHIFT;
+/// Block alignment mask.
+const BLOCK_MASK: usize = BLOCK_SIZE - 1;
+
+/// Queue entry magic value: `' POI'` (0x20504f49).
+const QE_MAGIC: u32 = 0x2050_4F49;
+
+/// Default AFK shared buffer size (256 KB).
+const AFK_BUFFER_SIZE: usize = 256 * 1024;
+
+// RBEP message type field: bits [63:48].
+const RBEP_TYPE_SHIFT: u64 = 48;
+const RBEP_TYPE_MASK: u64 = 0xFFFF << RBEP_TYPE_SHIFT;
+
+/// GETBUF fields within the payload.
+const GETBUF_SIZE_SHIFT: u64 = 16;
+const GETBUF_SIZE_MASK: u64 = 0xFFFF << GETBUF_SIZE_SHIFT;
+const GETBUF_TAG_MASK: u64 = 0xFFFF;
+
+/// GETBUF_ACK DVA field: bits [47:0].
+const GETBUF_ACK_DVA_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+
+/// INIT_TX / INIT_RX fields within the payload.
+const INITRB_OFFSET_SHIFT: u64 = 32;
+const INITRB_OFFSET_MASK: u64 = 0xFFFF << INITRB_OFFSET_SHIFT;
+const INITRB_SIZE_MASK: u64 = GETBUF_SIZE_MASK;
+const INITRB_TAG_MASK: u64 = GETBUF_TAG_MASK;
+
+/// RBEP message type constants.
+const RBEP_INIT: u64 = 0x80;
+const RBEP_INIT_ACK: u64 = 0xa0;
+const RBEP_GETBUF: u64 = 0x89;
+const RBEP_GETBUF_ACK: u64 = 0xa1;
+const RBEP_INIT_TX: u64 = 0x8a;
+const RBEP_INIT_RX: u64 = 0x8b;
+const RBEP_START: u64 = 0xa3;
+const RBEP_START_ACK: u64 = 0x86;
+const RBEP_SEND: u64 = 0xa2;
+const RBEP_RECV: u64 = 0x85;
+const RBEP_SHUTDOWN: u64 = 0xc0;
+const RBEP_SHUTDOWN_ACK: u64 = 0xc1;
+
+/// AFK handshake timeout in microseconds.
+const AFK_TIMEOUT_US: u64 = 5_000_000;
+/// Poll delay in microseconds.
+const AFK_POLL_DELAY_US: u64 = 1;
+
+// =============================================================================
+// Data Structures
+// =============================================================================
+
+/// Ring buffer header — shared between AP and coprocessor.
+///
+/// Each field sits at a 64-byte-aligned offset to match Apple's DMA
+/// cache line expectations. The data area follows immediately after.
+///
+/// ```text
+/// Offset 0x00: bufsz (u32) — size of data area in bytes
+/// Offset 0x40: rptr  (u32) — read pointer
+/// Offset 0x80: wptr  (u32) — write pointer
+/// Total: 0xC0 (192) bytes
+/// ```
+#[repr(C)]
+struct AfkRingBufferHeader {
+    bufsz: u32,
+    _pad0: [u32; 15],
+    rptr: u32,
+    _pad1: [u32; 15],
+    wptr: u32,
+    _pad2: [u32; 15],
+}
+
+// SAFETY: accessed only via volatile reads/writes for cross-device sync.
+unsafe impl Send for AfkRingBufferHeader {}
+unsafe impl Sync for AfkRingBufferHeader {}
+
+/// Queue entry header in the ring buffer.
+///
+/// Each entry is 16 bytes of header followed by `size` bytes of payload,
+/// padded to 64-byte block alignment.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct AfkQueueEntry {
+    /// Magic value, must be `QE_MAGIC`.
+    pub magic: u32,
+    /// Payload size in bytes.
+    pub size: u32,
+    /// Channel number.
+    pub channel: u32,
+    /// Message type.
+    pub msg_type: u32,
+}
+
+impl AfkQueueEntry {
+    /// Header size in bytes (4 × u32).
+    pub const HEADER_SIZE: usize = mem::size_of::<Self>();
+}
+
+/// One ring buffer direction (TX or RX).
+struct AfkRingBuffer {
+    /// Pointer to the shared ring buffer header.
+    hdr: *mut AfkRingBufferHeader,
+    /// Pointer to the data area following the header.
+    buf: *mut u8,
+    /// Data area size in bytes.
+    bufsz: u32,
+    /// Whether this ring buffer has been initialized.
+    ready: bool,
+}
+
+// SAFETY: accessed only under the endpoint lock.
+unsafe impl Send for AfkRingBuffer {}
+unsafe impl Sync for AfkRingBuffer {}
+
+/// Shared DMA buffer backing the TX and RX ring buffers.
+struct AfkSharedBuffer {
+    /// Kernel virtual address.
+    virt: *mut u8,
+    /// Physical address (used as DVA/IOVA for now).
+    paddr: usize,
+    /// Total buffer size in bytes.
+    size: usize,
+    /// Tag from GETBUF, used to validate INIT_TX/INIT_RX messages.
+    tag: u32,
+}
+
+// SAFETY: accessed only under the endpoint lock.
+unsafe impl Send for AfkSharedBuffer {}
+unsafe impl Sync for AfkSharedBuffer {}
+
+/// AFK endpoint state.
+///
+/// Manages a pair of ring buffers (TX and RX) within a single shared DMA
+/// buffer, communicating with one coprocessor endpoint via RBEP.
+pub struct AfkEndpoint {
+    rtkit: Arc<AppleRtkit>,
+    ep: u8,
+    shared: Option<AfkSharedBuffer>,
+    tx: AfkRingBuffer,
+    rx: AfkRingBuffer,
+    started: bool,
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+#[inline(always)]
+const fn block_align_up(val: usize) -> usize {
+    (val + BLOCK_SIZE - 1) & !BLOCK_MASK
+}
+
+#[inline(always)]
+fn field_get(val: u64, mask: u64) -> u64 {
+    (val & mask) >> mask.trailing_zeros()
+}
+
+#[inline(always)]
+fn field_prep(mask: u64, val: u64) -> u64 {
+    val << mask.trailing_zeros()
+}
+
+fn rbep_msg(msg_type: u64, payload: u64) -> u64 {
+    field_prep(RBEP_TYPE_MASK, msg_type) | payload
+}
+
+fn rbep_type(msg: u64) -> u64 {
+    field_get(msg, RBEP_TYPE_MASK)
+}
+
+/// DMA write barrier — ensures preceding writes are visible to the coprocessor.
+#[inline(always)]
+unsafe fn dma_wmb() {
+    // SAFETY: AArch64 inner-shareable write barrier for DMA ordering.
+    unsafe {
+        asm!("dsb ishst", options(nostack, nomem, preserves_flags));
+    }
+}
+
+/// DMA full memory barrier — ensures ordering of all reads and writes.
+#[inline(always)]
+unsafe fn dma_mb() {
+    // SAFETY: AArch64 inner-shareable full barrier for DMA ordering.
+    unsafe {
+        asm!("dsb ish", options(nostack, nomem, preserves_flags));
+    }
+}
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+impl AfkEndpoint {
+    /// Create a new AFK endpoint (not started).
+    ///
+    /// Call [`start`](Self::start) to perform the full RBEP handshake.
+    pub fn new(rtkit: Arc<AppleRtkit>, ep: u8) -> Self {
+        Self {
+            rtkit,
+            ep,
+            shared: None,
+            tx: AfkRingBuffer {
+                hdr: core::ptr::null_mut(),
+                buf: core::ptr::null_mut(),
+                bufsz: 0,
+                ready: false,
+            },
+            rx: AfkRingBuffer {
+                hdr: core::ptr::null_mut(),
+                buf: core::ptr::null_mut(),
+                bufsz: 0,
+                ready: false,
+            },
+            started: false,
+        }
+    }
+
+    /// Perform the full RBEP initialization handshake.
+    ///
+    /// Sequence: START_EP → INIT/INIT_ACK → GETBUF/GETBUF_ACK →
+    ///           INIT_TX → INIT_RX → START/START_ACK
+    pub fn start(&mut self) -> Result<(), &'static str> {
+        self.rtkit.start_ep(self.ep)?;
+
+        self.send_rbep(RBEP_INIT, 0)?;
+        self.wait_rbep_type(RBEP_INIT_ACK)?;
+
+        self.handle_getbuf()?;
+
+        self.wait_init_ringbuffers()?;
+
+        self.send_rbep(RBEP_START, 0)?;
+        self.wait_rbep_type(RBEP_START_ACK)?;
+
+        self.started = true;
+        early_println!("[apple-afk] ep {}: started", self.ep);
+        Ok(())
+    }
+
+    /// Whether the endpoint has been fully started.
+    pub fn is_started(&self) -> bool {
+        self.started
+    }
+
+    /// Enqueue a message into the TX ring buffer and notify the coprocessor.
+    ///
+    /// Returns an error if the ring buffer is full.
+    pub fn send(&mut self, channel: u32, msg_type: u32, data: &[u8]) -> Result<(), &'static str> {
+        if !self.tx.ready {
+            return Err("apple-afk: TX ring buffer not ready");
+        }
+
+        let rb = &self.tx;
+        let rptr = self.read_rptr(rb.hdr);
+        let wptr = self.read_wptr(rb.hdr);
+
+        let entry_total = AfkQueueEntry::HEADER_SIZE + data.len();
+        let advance = block_align_up(entry_total);
+
+        if !self.has_space(wptr, rptr, advance, rb.bufsz as usize) {
+            return Err("apple-afk: TX ring buffer full");
+        }
+
+        let hdr_ptr = unsafe { rb.buf.add(wptr as usize) } as *mut AfkQueueEntry;
+        let mut new_wptr = wptr as usize;
+
+        // Write queue entry header
+        unsafe {
+            core::ptr::addr_of_mut!((*hdr_ptr).magic).write_volatile(QE_MAGIC);
+            core::ptr::addr_of_mut!((*hdr_ptr).size).write_volatile(data.len() as u32);
+            core::ptr::addr_of_mut!((*hdr_ptr).channel).write_volatile(channel);
+            core::ptr::addr_of_mut!((*hdr_ptr).msg_type).write_volatile(msg_type);
+        }
+
+        new_wptr += AfkQueueEntry::HEADER_SIZE;
+
+        // Handle wrap: if payload won't fit above wptr, write sentinel at start
+        if data.len() > rb.bufsz as usize - new_wptr {
+            let sentinel = unsafe { rb.buf as *mut AfkQueueEntry };
+            unsafe {
+                core::ptr::addr_of_mut!((*sentinel).magic).write_volatile(QE_MAGIC);
+                core::ptr::addr_of_mut!((*sentinel).size).write_volatile(data.len() as u32);
+                core::ptr::addr_of_mut!((*sentinel).channel).write_volatile(channel);
+                core::ptr::addr_of_mut!((*sentinel).msg_type).write_volatile(msg_type);
+            }
+            new_wptr = AfkQueueEntry::HEADER_SIZE;
+        }
+
+        // Write payload
+        unsafe {
+            core::ptr::copy_nonoverlapping(data.as_ptr(), rb.buf.add(new_wptr), data.len());
+        }
+        new_wptr += data.len();
+
+        // 64-byte align and wrap
+        new_wptr = block_align_up(new_wptr);
+        if new_wptr >= rb.bufsz as usize {
+            new_wptr = 0;
+        }
+
+        // Barrier + update write pointer
+        unsafe {
+            dma_wmb();
+            core::ptr::addr_of_mut!((*rb.hdr).wptr).write_volatile(new_wptr as u32);
+        }
+
+        // Notify coprocessor
+        self.send_rbep(RBEP_SEND, new_wptr as u64)?;
+
+        Ok(())
+    }
+
+    /// Peek at the next message in the RX ring buffer.
+    ///
+    /// Returns a copy of the queue entry header if a message is available.
+    /// Call [`recv_payload`](Self::recv_payload) to access the payload data,
+    /// then [`recv_ack`](Self::recv_ack) to advance the read pointer.
+    pub fn recv(&mut self) -> Option<AfkQueueEntry> {
+        if !self.rx.ready {
+            return None;
+        }
+
+        let rb = &self.rx;
+        let rptr = self.read_rptr(rb.hdr);
+        let hdr_ptr = unsafe { rb.buf.add(rptr as usize) } as *const AfkQueueEntry;
+
+        let magic = unsafe { core::ptr::addr_of!((*hdr_ptr).magic).read_volatile() };
+        if magic != QE_MAGIC {
+            return None;
+        }
+
+        let size = unsafe { core::ptr::addr_of!((*hdr_ptr).size).read_volatile() } as usize;
+
+        // Handle wrap: if entry crosses buffer end, re-read from start
+        if rptr as usize + AfkQueueEntry::HEADER_SIZE + size > rb.bufsz as usize {
+            unsafe {
+                core::ptr::addr_of_mut!((*rb.hdr).rptr).write_volatile(0);
+            }
+            let wrapped = unsafe { rb.buf as *const AfkQueueEntry };
+            let wrapped_magic = unsafe { core::ptr::addr_of!((*wrapped).magic).read_volatile() };
+            if wrapped_magic != QE_MAGIC {
+                return None;
+            }
+        }
+
+        // Read entry header (re-read in case of wrap)
+        let final_rptr = self.read_rptr(rb.hdr);
+        let entry = unsafe {
+            let p = rb.buf.add(final_rptr as usize) as *const AfkQueueEntry;
+            AfkQueueEntry {
+                magic: core::ptr::addr_of!((*p).magic).read_volatile(),
+                size: core::ptr::addr_of!((*p).size).read_volatile(),
+                channel: core::ptr::addr_of!((*p).channel).read_volatile(),
+                msg_type: core::ptr::addr_of!((*p).msg_type).read_volatile(),
+            }
+        };
+
+        Some(entry)
+    }
+
+    /// Get the payload data for a received queue entry.
+    ///
+    /// The returned slice borrows `self` and is valid until
+    /// [`recv_ack`](Self::recv_ack) is called.
+    pub fn recv_payload(&self, entry: &AfkQueueEntry) -> &[u8] {
+        let rb = &self.rx;
+        let rptr = self.read_rptr(rb.hdr);
+
+        let data_offset = if rptr as usize + AfkQueueEntry::HEADER_SIZE + entry.size as usize
+            > rb.bufsz as usize
+        {
+            // Wrapped: payload is at buffer start + header size
+            AfkQueueEntry::HEADER_SIZE
+        } else {
+            rptr as usize + AfkQueueEntry::HEADER_SIZE
+        };
+
+        unsafe { core::slice::from_raw_parts(rb.buf.add(data_offset), entry.size as usize) }
+    }
+
+    /// Acknowledge a received message and advance the RX read pointer.
+    pub fn recv_ack(&mut self) {
+        let rb = &self.rx;
+        let rptr = self.read_rptr(rb.hdr);
+        let hdr_ptr = unsafe { rb.buf.add(rptr as usize) } as *const AfkQueueEntry;
+
+        let magic = unsafe { core::ptr::addr_of!((*hdr_ptr).magic).read_volatile() };
+        if magic != QE_MAGIC {
+            return;
+        }
+
+        unsafe {
+            dma_mb();
+        }
+
+        let size = unsafe { core::ptr::addr_of!((*hdr_ptr).size).read_volatile() } as usize;
+        let mut new_rptr = rptr as usize + AfkQueueEntry::HEADER_SIZE + size;
+        new_rptr = block_align_up(new_rptr);
+        if new_rptr >= rb.bufsz as usize {
+            new_rptr = 0;
+        }
+
+        unsafe {
+            core::ptr::addr_of_mut!((*rb.hdr).rptr).write_volatile(new_rptr as u32);
+        }
+    }
+
+    /// Shutdown the AFK endpoint.
+    pub fn shutdown(&mut self) -> Result<(), &'static str> {
+        if !self.started {
+            return Ok(());
+        }
+
+        self.send_rbep(RBEP_SHUTDOWN, 0)?;
+        let _ = self.wait_rbep_type(RBEP_SHUTDOWN_ACK);
+        self.started = false;
+        early_println!("[apple-afk] ep {}: shutdown", self.ep);
+        Ok(())
+    }
+
+    /// Get the underlying RTKit instance.
+    pub fn rtkit(&self) -> &Arc<AppleRtkit> {
+        &self.rtkit
+    }
+
+    /// Get the RTKit endpoint number.
+    pub fn endpoint(&self) -> u8 {
+        self.ep
+    }
+
+    // =========================================================================
+    // Private: RBEP handshake
+    // =========================================================================
+
+    fn send_rbep(&self, msg_type: u64, payload: u64) -> Result<(), &'static str> {
+        self.rtkit.send(&RtkitMessage {
+            ep: self.ep,
+            msg: rbep_msg(msg_type, payload),
+        })
+    }
+
+    fn wait_rbep_type(&self, expected: u64) -> Result<u64, &'static str> {
+        let start = time::current_time();
+        loop {
+            let elapsed = time::current_time().saturating_sub(start);
+            if elapsed >= AFK_TIMEOUT_US {
+                return Err("apple-afk: timeout waiting for RBEP message");
+            }
+
+            let mut msg = RtkitMessage { ep: 0, msg: 0 };
+            match self.rtkit.recv(&mut msg) {
+                Ok(true) => {
+                    if msg.ep == self.ep && rbep_type(msg.msg) == expected {
+                        return Ok(msg.msg);
+                    }
+                    early_println!(
+                        "[apple-afk] ep {}: unexpected msg type={:#x} during handshake",
+                        self.ep,
+                        rbep_type(msg.msg)
+                    );
+                }
+                Ok(false) => time::udelay(AFK_POLL_DELAY_US),
+                Err(_) => time::udelay(AFK_POLL_DELAY_US),
+            }
+        }
+    }
+
+    /// Handle GETBUF: allocate a shared DMA buffer and reply with its DVA.
+    fn handle_getbuf(&mut self) -> Result<(), &'static str> {
+        let msg = self.wait_rbep_type(RBEP_GETBUF)?;
+        let size_blocks = field_get(msg, GETBUF_SIZE_MASK) as usize;
+        let tag = field_get(msg, GETBUF_TAG_MASK) as u32;
+        let size = size_blocks << BLOCK_SHIFT;
+
+        let pages = (size + 4095) / 4096;
+        let paddr = pmm::alloc_contiguous_pages(pages)
+            .ok_or("apple-afk: failed to allocate shared buffer")?;
+
+        let virt = vm::phys_to_virt(paddr);
+
+        // Zero the buffer
+        unsafe {
+            core::ptr::write_bytes(virt as *mut u8, 0, size);
+        }
+
+        // TODO: Proper DART IOMMU mapping. For now use physical address as DVA
+        // (works in bypass mode or when DART is not active).
+        let dva = paddr as u64;
+
+        early_println!(
+            "[apple-afk] ep {}: shared buffer {} bytes at paddr={:#x}, dva={:#x}",
+            self.ep,
+            size,
+            paddr,
+            dva
+        );
+
+        self.shared = Some(AfkSharedBuffer {
+            virt: virt as *mut u8,
+            paddr,
+            size,
+            tag,
+        });
+
+        self.send_rbep(RBEP_GETBUF_ACK, dva & GETBUF_ACK_DVA_MASK)
+    }
+
+    /// Wait for INIT_TX and INIT_RX messages and set up ring buffers.
+    fn wait_init_ringbuffers(&mut self) -> Result<(), &'static str> {
+        let mut tx_done = false;
+        let mut rx_done = false;
+
+        while !tx_done || !rx_done {
+            let start = time::current_time();
+            let mut got_msg = false;
+
+            while !got_msg {
+                let elapsed = time::current_time().saturating_sub(start);
+                if elapsed >= AFK_TIMEOUT_US {
+                    return Err("apple-afk: timeout waiting for INIT_TX/INIT_RX");
+                }
+
+                let mut msg = RtkitMessage { ep: 0, msg: 0 };
+                match self.rtkit.recv(&mut msg) {
+                    Ok(true) => {
+                        if msg.ep == self.ep {
+                            got_msg = true;
+                            match rbep_type(msg.msg) {
+                                RBEP_INIT_TX => {
+                                    let shared = self
+                                        .shared
+                                        .as_ref()
+                                        .ok_or("apple-afk: no shared buffer")?;
+                                    Self::init_ring_buffer(&mut self.tx, shared, msg.msg, "TX")?;
+                                    tx_done = true;
+                                }
+                                RBEP_INIT_RX => {
+                                    let shared = self
+                                        .shared
+                                        .as_ref()
+                                        .ok_or("apple-afk: no shared buffer")?;
+                                    Self::init_ring_buffer(&mut self.rx, shared, msg.msg, "RX")?;
+                                    rx_done = true;
+                                }
+                                _ => {
+                                    early_println!(
+                                        "[apple-afk] ep {}: unexpected type={:#x}",
+                                        self.ep,
+                                        rbep_type(msg.msg)
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Ok(false) => time::udelay(AFK_POLL_DELAY_US),
+                    Err(_) => time::udelay(AFK_POLL_DELAY_US),
+                }
+            }
+        }
+
+        if !self.tx.ready || !self.rx.ready {
+            return Err("apple-afk: ring buffers not initialized");
+        }
+
+        Ok(())
+    }
+
+    /// Initialize one ring buffer (TX or RX) from an INIT_TX/INIT_RX message.
+    fn init_ring_buffer(
+        rb: &mut AfkRingBuffer,
+        shared: &AfkSharedBuffer,
+        msg: u64,
+        label: &str,
+    ) -> Result<(), &'static str> {
+        let offset = field_get(msg, INITRB_OFFSET_MASK) as usize;
+        let size = field_get(msg, INITRB_SIZE_MASK) as usize;
+        let tag = field_get(msg, INITRB_TAG_MASK) as u32;
+
+        if tag != shared.tag {
+            return Err("apple-afk: ring buffer tag mismatch");
+        }
+
+        let base = offset << BLOCK_SHIFT;
+        let total_size = size << BLOCK_SHIFT;
+
+        if base + total_size > shared.size {
+            return Err("apple-afk: ring buffer out of bounds");
+        }
+
+        let hdr_ptr = unsafe { shared.virt.add(base) } as *mut AfkRingBufferHeader;
+        let hdr_bufsz = unsafe { core::ptr::addr_of!((*hdr_ptr).bufsz).read_volatile() } as usize;
+
+        // Validate: bufsz + header size == total ring buffer size
+        if hdr_bufsz + mem::size_of::<AfkRingBufferHeader>() != total_size {
+            return Err("apple-afk: ring buffer size mismatch");
+        }
+
+        let buf_ptr = unsafe { hdr_ptr.add(1) } as *mut u8;
+
+        rb.hdr = hdr_ptr;
+        rb.buf = buf_ptr;
+        rb.bufsz = hdr_bufsz as u32;
+        rb.ready = true;
+
+        early_println!(
+            "[apple-afk] ep {}: {} ring buffer at +{:#x}, data={:#x} bytes",
+            label,
+            label,
+            base,
+            hdr_bufsz
+        );
+
+        Ok(())
+    }
+
+    // =========================================================================
+    // Private: ring buffer helpers
+    // =========================================================================
+
+    fn read_rptr(&self, hdr: *mut AfkRingBufferHeader) -> u32 {
+        // SAFETY: hdr points to a valid, DMA-shared ring buffer header.
+        unsafe { core::ptr::addr_of!((*hdr).rptr).read_volatile() }
+    }
+
+    fn read_wptr(&self, hdr: *mut AfkRingBufferHeader) -> u32 {
+        // SAFETY: hdr points to a valid, DMA-shared ring buffer header.
+        unsafe { core::ptr::addr_of!((*hdr).wptr).read_volatile() }
+    }
+
+    /// Check whether `needed` bytes can be written at the current position.
+    fn has_space(&self, wptr: u32, rptr: u32, needed: usize, bufsz: usize) -> bool {
+        let w = wptr as usize;
+        let r = rptr as usize;
+
+        if w < r {
+            // Wrapped: space between wptr and rptr
+            needed < r - w
+        } else {
+            // Not wrapped: check if fits above wptr, or after wrapping to start
+            let space_above = bufsz - w;
+            let fits_above = needed < space_above || (needed == space_above && r != 0);
+            if fits_above {
+                true
+            } else {
+                // Try fitting after wrap
+                needed < r
+            }
+        }
+    }
+}
+
+impl Drop for AfkEndpoint {
+    fn drop(&mut self) {
+        if let Some(shared) = self.shared.take() {
+            let pages = (shared.size + 4095) / 4096;
+            pmm::free_contiguous_pages(shared.paddr, pages);
+            early_println!(
+                "[apple-afk] ep {}: freed shared buffer at {:#x}",
+                self.ep,
+                shared.paddr
+            );
+        }
+    }
+}

--- a/kernel/src/drivers/soc/apple_asc.rs
+++ b/kernel/src/drivers/soc/apple_asc.rs
@@ -1,0 +1,204 @@
+//! Apple ASC (Apple System Controller) mailbox driver.
+//!
+//! This driver provides the low-level MMIO transport used to communicate with
+//! Apple coprocessors through the ASC mailbox block.
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::arch::asm;
+
+use spin::Mutex;
+
+use crate::arch::mmio;
+use crate::device::manager::{DeviceManager, DriverPriority};
+use crate::device::platform::resource::PlatformDeviceResourceType;
+use crate::device::platform::{PlatformDeviceDriver, PlatformDeviceInfo};
+use crate::driver_initcall;
+use crate::time;
+use crate::vm;
+
+const ASC_CPU_CONTROL: usize = 0x0044;
+const ASC_CPU_CONTROL_START: u32 = 0x10;
+
+const ASC_MBOX_A2I_CONTROL: usize = 0x0110;
+const ASC_MBOX_I2A_CONTROL: usize = 0x0114;
+const ASC_MBOX_CTRL_FULL: u32 = 1 << 16;
+const ASC_MBOX_CTRL_EMPTY: u32 = 1 << 17;
+
+const ASC_MBOX_A2I_SEND0: usize = 0x0800;
+const ASC_MBOX_A2I_SEND1: usize = 0x0808;
+const ASC_MBOX_I2A_RECV0: usize = 0x0830;
+const ASC_MBOX_I2A_RECV1: usize = 0x0838;
+
+const ASC_SEND_TIMEOUT_US: u64 = 1_000_000;
+const ASC_POLL_DELAY_US: u64 = 1;
+
+/// One ASC mailbox message pair.
+pub struct AscMessage {
+    /// Primary 64-bit payload.
+    pub msg0: u64,
+    /// Secondary 32-bit payload (typically endpoint ID).
+    pub msg1: u32,
+}
+
+/// Apple ASC mailbox MMIO driver.
+pub struct AppleAsc {
+    base: usize,
+}
+
+impl AppleAsc {
+    /// Create a new ASC instance from an MMIO base address.
+    pub const fn new(base: usize) -> Self {
+        Self { base }
+    }
+
+    /// Start the ASC IOP CPU.
+    pub fn cpu_start(&self) {
+        // SAFETY: `self.base` points to a mapped ASC MMIO region.
+        unsafe {
+            mmio::write32(self.base + ASC_CPU_CONTROL, ASC_CPU_CONTROL_START);
+        }
+    }
+
+    /// Stop the ASC IOP CPU by clearing START bit.
+    pub fn cpu_stop(&self) {
+        // SAFETY: `self.base` points to a mapped ASC MMIO region.
+        let ctrl = unsafe { mmio::read32(self.base + ASC_CPU_CONTROL) };
+        // SAFETY: `self.base` points to a mapped ASC MMIO region.
+        unsafe {
+            mmio::write32(self.base + ASC_CPU_CONTROL, ctrl & !ASC_CPU_CONTROL_START);
+        }
+    }
+
+    /// Check whether there is a pending IOP->AP message.
+    pub fn can_recv(&self) -> bool {
+        // SAFETY: `self.base` points to a mapped ASC MMIO region.
+        let status = unsafe { mmio::read32(self.base + ASC_MBOX_I2A_CONTROL) };
+        (status & ASC_MBOX_CTRL_EMPTY) == 0
+    }
+
+    /// Send one AP->IOP message.
+    pub fn send(&self, msg: &AscMessage) -> Result<(), &'static str> {
+        let start = time::current_time();
+        loop {
+            // SAFETY: `self.base` points to a mapped ASC MMIO region.
+            let status = unsafe { mmio::read32(self.base + ASC_MBOX_A2I_CONTROL) };
+            if (status & ASC_MBOX_CTRL_FULL) == 0 {
+                break;
+            }
+
+            if time::current_time().saturating_sub(start) >= ASC_SEND_TIMEOUT_US {
+                return Err("apple-asc: send mailbox full timeout");
+            }
+
+            time::udelay(ASC_POLL_DELAY_US);
+        }
+
+        // SAFETY: MMIO transaction ordering for ASC mailbox writes requires dsb ish.
+        unsafe {
+            dsb_ish();
+        }
+
+        // SAFETY: `self.base` points to a mapped ASC MMIO region.
+        unsafe {
+            mmio::write64(self.base + ASC_MBOX_A2I_SEND0, msg.msg0);
+            mmio::write64(self.base + ASC_MBOX_A2I_SEND1, msg.msg1 as u64);
+        }
+
+        Ok(())
+    }
+
+    /// Receive one IOP->AP message.
+    pub fn recv(&self, msg: &mut AscMessage) -> Result<(), &'static str> {
+        if !self.can_recv() {
+            return Err("apple-asc: no message available");
+        }
+
+        // SAFETY: `self.base` points to a mapped ASC MMIO region.
+        unsafe {
+            msg.msg0 = mmio::read64(self.base + ASC_MBOX_I2A_RECV0);
+            msg.msg1 = mmio::read64(self.base + ASC_MBOX_I2A_RECV1) as u32;
+        }
+
+        // SAFETY: MMIO transaction ordering for ASC mailbox reads requires dsb ish.
+        unsafe {
+            dsb_ish();
+        }
+
+        Ok(())
+    }
+
+    /// Receive one message with timeout in microseconds.
+    pub fn recv_timeout(&self, msg: &mut AscMessage, timeout_us: u64) -> Result<(), &'static str> {
+        let start = time::current_time();
+        loop {
+            if self.can_recv() {
+                return self.recv(msg);
+            }
+
+            if time::current_time().saturating_sub(start) >= timeout_us {
+                return Err("apple-asc: recv timeout");
+            }
+
+            time::udelay(ASC_POLL_DELAY_US);
+        }
+    }
+}
+
+/// Registry of probed ASC mailbox instances.
+static ASC_REGISTRY: Mutex<Vec<Arc<AppleAsc>>> = Mutex::new(Vec::new());
+
+/// Get a probed ASC mailbox instance by index.
+pub fn get_apple_asc(id: u32) -> Option<Arc<AppleAsc>> {
+    ASC_REGISTRY.lock().get(id as usize).map(Arc::clone)
+}
+
+#[inline(always)]
+unsafe fn dsb_ish() {
+    // SAFETY: Emits the required AArch64 barrier instruction for MMIO ordering.
+    unsafe {
+        asm!("dsb ish", options(nostack, nomem, preserves_flags));
+    }
+}
+
+fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    let resource = device
+        .get_resources()
+        .iter()
+        .find(|resource| matches!(resource.res_type, PlatformDeviceResourceType::MEM))
+        .ok_or("apple-asc: no memory resource")?;
+
+    let paddr = resource.start;
+    let size = resource
+        .end
+        .checked_sub(resource.start)
+        .and_then(|value| value.checked_add(1))
+        .ok_or("apple-asc: invalid memory resource")?;
+
+    let base = vm::ioremap(paddr, size).map_err(|_| "apple-asc: ioremap failed")?;
+    ASC_REGISTRY.lock().push(Arc::new(AppleAsc::new(base)));
+
+    Ok(())
+}
+
+fn remove_fn(_device: &PlatformDeviceInfo) -> Result<(), &'static str> {
+    Ok(())
+}
+
+fn register_apple_asc_driver() {
+    let driver = PlatformDeviceDriver::new(
+        "apple-asc-mailbox",
+        probe_fn,
+        remove_fn,
+        alloc::vec![
+            "apple,t8103-asc-mailbox",
+            "apple,asc-mailbox-v4",
+            "apple,asc-mailbox",
+        ],
+    );
+
+    DeviceManager::get_manager().register_driver(Box::new(driver), DriverPriority::Core);
+}
+
+driver_initcall!(register_apple_asc_driver);

--- a/kernel/src/drivers/soc/apple_epic.rs
+++ b/kernel/src/drivers/soc/apple_epic.rs
@@ -1,0 +1,675 @@
+//! Apple EPIC (Endpoint IPC) protocol driver.
+//!
+//! EPIC provides structured command/reply and notify messaging on top of
+//! AFK ring buffers. It is used by Apple display coprocessor services
+//! (e.g., DCP DPTX port endpoint) for RPC-style communication.
+//!
+//! # Protocol Overview
+//!
+//! Each EPIC message contains:
+//! - **EPIC header**: version, sequence number, timestamp
+//! - **Sub-header**: category (REPORT/NOTIFY/REPLY/COMMAND), type, flags
+//! - **Payload**: depends on category (command struct, announce data, etc.)
+//!
+//! # Message Categories
+//!
+//! - `CAT_REPORT` + `ANNOUNCE`: service discovery
+//! - `CAT_COMMAND` + `STD_SERVICE`: RPC command with DMA buffer exchange
+//! - `CAT_REPLY`: command response with return code and DMA data
+//! - `CAT_NOTIFY`: asynchronous notifications
+//!
+//! Reference: m1n1 `src/afk.c`, `proxyclient/m1n1/fw/afk/epic.py`
+
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::mem;
+
+use crate::drivers::soc::apple_afk::{AfkEndpoint, AfkQueueEntry};
+use crate::early_println;
+use crate::mem::pmm;
+use crate::time;
+use crate::vm;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// EPIC header version.
+const EPIC_HDR_VERSION: u8 = 2;
+/// EPIC sub-header version.
+const EPIC_SUBHDR_VERSION: u8 = 4;
+
+/// DMA buffer size per EPIC endpoint (16 KB).
+const EPIC_BUFFER_SIZE: usize = 0x4000;
+
+/// Maximum number of channels per endpoint.
+pub const EPIC_MAX_CHANNELS: usize = 8;
+
+/// Service call magic value: `"epcx"`.
+const EPIC_SERVICE_CALL_MAGIC: u32 = 0x6970_6378;
+
+/// Timeout for EPIC command reply in microseconds.
+const EPIC_REPLY_TIMEOUT_US: u64 = 5_000_000;
+
+// EPIC message types (used as AFK queue entry msg_type).
+const TYPE_NOTIFY: u32 = 0;
+const TYPE_COMMAND: u32 = 3;
+const TYPE_REPLY: u32 = 4;
+const TYPE_NOTIFY_ACK: u32 = 8;
+
+// EPIC categories.
+const CAT_REPORT: u8 = 0x00;
+const CAT_NOTIFY: u8 = 0x10;
+const CAT_REPLY: u8 = 0x20;
+const CAT_COMMAND: u8 = 0x30;
+
+// EPIC subtypes.
+const SUBTYPE_ANNOUNCE: u16 = 0x30;
+const SUBTYPE_TEARDOWN: u16 = 0x32;
+const SUBTYPE_RETCODE: u16 = 0x84;
+const SUBTYPE_STRING: u16 = 0x8a;
+const SUBTYPE_STD_SERVICE: u16 = 0xc0;
+
+// Flags.
+const FLAG_INLINE: u8 = 0x08;
+
+// =============================================================================
+// Wire Structures (packed, little-endian, DMA-shared)
+// =============================================================================
+
+/// EPIC message header — precedes every EPIC payload in the ring buffer.
+#[repr(C, packed)]
+struct EpicHdr {
+    version: u8,
+    seq: u16,
+    _pad: u8,
+    unk: u32,
+    timestamp: u64,
+}
+
+/// EPIC sub-header — follows `EpicHdr`, describes the message category/type.
+#[repr(C, packed)]
+struct EpicSubHdr {
+    length: u32,
+    version: u8,
+    category: u8,
+    msg_type: u16,
+    timestamp: u64,
+    seq: u16,
+    unk: u8,
+    flags: u8,
+    inline_len: u32,
+}
+
+/// EPIC command/reply payload — carries DMA buffer addresses and sizes.
+#[repr(C, packed)]
+struct EpicCmd {
+    retcode: u32,
+    rxbuf: u64,
+    txbuf: u64,
+    rxlen: u32,
+    txlen: u32,
+    rxcookie: u8,
+    txcookie: u8,
+}
+
+/// EPIC service call header — used for `SUBTYPE_STD_SERVICE` messages.
+#[repr(C, packed)]
+struct EpicServiceCall {
+    _pad0: [u8; 2],
+    group: u16,
+    command: u32,
+    data_len: u32,
+    magic: u32,
+    _pad1: [u8; 48],
+}
+
+/// EPIC service announcement payload.
+///
+/// Serialized DCP properties follow the name field.
+#[repr(C, packed)]
+struct EpicAnnounce {
+    name: [u8; 32],
+}
+
+// =============================================================================
+// DMA Buffer
+// =============================================================================
+
+/// Per-endpoint DMA buffer pair for command/reply data exchange.
+struct EpicDmaBuffer {
+    /// Kernel virtual address of TX buffer (host → coprocessor).
+    tx_virt: usize,
+    /// Physical address (DVA) of TX buffer.
+    tx_paddr: usize,
+    /// Kernel virtual address of RX buffer (coprocessor → host).
+    rx_virt: usize,
+    /// Physical address (DVA) of RX buffer.
+    rx_paddr: usize,
+}
+
+impl EpicDmaBuffer {
+    fn alloc() -> Result<Self, &'static str> {
+        let pages = (EPIC_BUFFER_SIZE + 4095) / 4096;
+
+        let tx_paddr = pmm::alloc_contiguous_pages(pages)
+            .ok_or("apple-epic: failed to allocate TX DMA buffer")?;
+        let rx_paddr = pmm::alloc_contiguous_pages(pages)
+            .ok_or("apple-epic: failed to allocate RX DMA buffer")?;
+
+        let tx_virt = vm::phys_to_virt(tx_paddr);
+        let rx_virt = vm::phys_to_virt(rx_paddr);
+
+        // Zero buffers
+        unsafe {
+            core::ptr::write_bytes(tx_virt as *mut u8, 0, EPIC_BUFFER_SIZE);
+            core::ptr::write_bytes(rx_virt as *mut u8, 0, EPIC_BUFFER_SIZE);
+        }
+
+        Ok(Self {
+            tx_virt,
+            tx_paddr,
+            rx_virt,
+            rx_paddr,
+        })
+    }
+}
+
+impl Drop for EpicDmaBuffer {
+    fn drop(&mut self) {
+        let pages = (EPIC_BUFFER_SIZE + 4095) / 4096;
+        pmm::free_contiguous_pages(self.tx_paddr, pages);
+        pmm::free_contiguous_pages(self.rx_paddr, pages);
+    }
+}
+
+// =============================================================================
+// EPIC Service
+// =============================================================================
+
+/// A discovered EPIC service on a specific channel.
+pub struct EpicService {
+    /// Service name (e.g., `"dcpdptx-port-epic"`).
+    pub name: String,
+    /// Channel number within the AFK endpoint.
+    pub channel: u32,
+    /// Sequence number for outgoing messages.
+    seq: u16,
+}
+
+// =============================================================================
+// EPIC Endpoint
+// =============================================================================
+
+/// EPIC endpoint — manages service discovery and command/reply messaging
+/// on top of an AFK endpoint.
+pub struct EpicEndpoint {
+    afk: Arc<spin::Mutex<AfkEndpoint>>,
+    dma: EpicDmaBuffer,
+    /// Outgoing EPIC-level sequence number.
+    seq: u16,
+    /// Discovered services keyed by channel.
+    services: Vec<EpicService>,
+    /// Callback for received notifications (channel, subtype, data).
+    notify_handler: Option<fn(u32, u16, &[u8])>,
+}
+
+impl EpicEndpoint {
+    /// Create a new EPIC endpoint wrapping an AFK endpoint.
+    ///
+    /// The AFK endpoint must already be started before use.
+    pub fn new(afk: Arc<spin::Mutex<AfkEndpoint>>) -> Result<Self, &'static str> {
+        let dma = EpicDmaBuffer::alloc()?;
+
+        early_println!(
+            "[apple-epic] DMA buffers: TX={:#x} RX={:#x} ({} bytes each)",
+            dma.tx_paddr,
+            dma.rx_paddr,
+            EPIC_BUFFER_SIZE
+        );
+
+        Ok(Self {
+            afk,
+            dma,
+            seq: 0,
+            services: Vec::new(),
+            notify_handler: None,
+        })
+    }
+
+    /// Register a notification handler callback.
+    ///
+    /// Called when a `TYPE_NOTIFY` is received that is not a service announcement.
+    pub fn set_notify_handler(&mut self, handler: fn(u32, u16, &[u8])) {
+        self.notify_handler = Some(handler);
+    }
+
+    /// Poll for incoming messages and dispatch them.
+    ///
+    /// Call this periodically or from an interrupt handler. Handles:
+    /// - Service announcements (`CAT_REPORT` + `SUBTYPE_ANNOUNCE`)
+    /// - Notifications (`TYPE_NOTIFY`)
+    /// - Command replies (matched to pending commands)
+    pub fn poll(&mut self) {
+        loop {
+            let action = {
+                let mut afk = self.afk.lock();
+
+                match afk.recv() {
+                    Some(entry) => {
+                        let payload = afk.recv_payload(&entry).to_vec();
+                        let action = (entry.msg_type, entry.channel, payload);
+                        afk.recv_ack();
+                        Some(action)
+                    }
+                    None => None,
+                }
+            };
+
+            match action {
+                Some((msg_type, channel, payload)) => match msg_type {
+                    TYPE_NOTIFY => {
+                        self.handle_notify(channel, &payload);
+                    }
+                    TYPE_REPLY => {
+                        self.handle_notify_ack(channel, &payload);
+                    }
+                    _ => {
+                        early_println!(
+                            "[apple-epic] unhandled msg type={} ch={}",
+                            msg_type,
+                            channel
+                        );
+                    }
+                },
+                None => break,
+            }
+        }
+    }
+
+    /// Wait for service announcements and collect discovered services.
+    ///
+    /// Blocks until at least `min_services` services are discovered or
+    /// `timeout_us` elapses.
+    pub fn wait_for_services(
+        &mut self,
+        min_services: usize,
+        timeout_us: u64,
+    ) -> Result<(), &'static str> {
+        let start = time::current_time();
+
+        loop {
+            if self.services.len() >= min_services {
+                return Ok(());
+            }
+
+            if time::current_time().saturating_sub(start) >= timeout_us {
+                early_println!(
+                    "[apple-epic] timeout: found {} services, wanted {}",
+                    self.services.len(),
+                    min_services
+                );
+                if self.services.len() > 0 {
+                    return Ok(());
+                }
+                return Err("apple-epic: no services discovered");
+            }
+
+            self.poll();
+            // Small yield to avoid busy-polling
+            for _ in 0..100 {
+                core::hint::spin_loop();
+            }
+        }
+    }
+
+    /// Find a discovered service by name (prefix match).
+    pub fn find_service(&self, name_prefix: &str) -> Option<&EpicService> {
+        self.services
+            .iter()
+            .find(|s| s.name.starts_with(name_prefix))
+    }
+
+    /// Find a discovered service by channel number.
+    pub fn find_service_by_channel(&self, channel: u32) -> Option<&EpicService> {
+        self.services.iter().find(|s| s.channel == channel)
+    }
+
+    /// Get the list of discovered service names.
+    pub fn service_names(&self) -> Vec<&str> {
+        self.services.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    /// Send a standard service call (RPC command) and wait for the reply.
+    ///
+    /// This is the primary interface for communicating with DCP services.
+    ///
+    /// # Arguments
+    ///
+    /// * `service` - Target service (channel number)
+    /// * `group` - Service call group ID
+    /// * `command` - Service call command ID
+    /// * `data` - Request payload
+    ///
+    /// # Returns
+    ///
+    /// Reply payload on success, error string on failure.
+    pub fn call(
+        &mut self,
+        service: &EpicService,
+        group: u16,
+        command: u32,
+        data: &[u8],
+    ) -> Result<Vec<u8>, &'static str> {
+        self.send_command(service.channel, group, command, data)?;
+        self.wait_reply(service.channel)
+    }
+
+    /// Send a standard service call without waiting for a reply.
+    pub fn send_command(
+        &mut self,
+        channel: u32,
+        group: u16,
+        command: u32,
+        data: &[u8],
+    ) -> Result<(), &'static str> {
+        let total = mem::size_of::<EpicServiceCall>() + data.len();
+        if total > EPIC_BUFFER_SIZE {
+            return Err("apple-epic: command data too large");
+        }
+
+        let call = EpicServiceCall {
+            _pad0: [0; 2],
+            group,
+            command,
+            data_len: data.len() as u32,
+            magic: EPIC_SERVICE_CALL_MAGIC,
+            _pad1: [0; 48],
+        };
+
+        // Write service call header + data to TX DMA buffer
+        unsafe {
+            let dst = self.dma.tx_virt as *mut u8;
+            core::ptr::copy_nonoverlapping(
+                &call as *const EpicServiceCall as *const u8,
+                dst,
+                mem::size_of::<EpicServiceCall>(),
+            );
+            if !data.is_empty() {
+                core::ptr::copy_nonoverlapping(
+                    data.as_ptr(),
+                    dst.add(mem::size_of::<EpicServiceCall>()),
+                    data.len(),
+                );
+            }
+        }
+
+        let hdr_size =
+            mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>() + mem::size_of::<EpicCmd>();
+        let tx_data = unsafe { core::slice::from_raw_parts(self.dma.tx_virt as *const u8, total) };
+
+        let seq = self.next_seq();
+        let mut msg_buf = alloc::vec![0u8; hdr_size + tx_data.len()];
+        self.write_epic_headers(
+            &mut msg_buf,
+            CAT_COMMAND,
+            SUBTYPE_STD_SERVICE,
+            seq,
+            tx_data.len() as u32,
+        );
+
+        // Write EpicCmd after headers
+        let cmd = EpicCmd {
+            retcode: 0,
+            rxbuf: self.dma.rx_paddr as u64,
+            txbuf: self.dma.tx_paddr as u64,
+            rxlen: EPIC_BUFFER_SIZE as u32,
+            txlen: total as u32,
+            rxcookie: 0,
+            txcookie: 0,
+        };
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                &cmd as *const EpicCmd as *const u8,
+                msg_buf
+                    .as_mut_ptr()
+                    .add(mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>()),
+                mem::size_of::<EpicCmd>(),
+            );
+        }
+
+        // Append TX data
+        msg_buf[hdr_size..].copy_from_slice(tx_data);
+
+        let mut afk = self.afk.lock();
+        afk.send(channel, TYPE_COMMAND, &msg_buf)?;
+
+        Ok(())
+    }
+
+    /// Wait for a reply on the specified channel.
+    fn wait_reply(&mut self, channel: u32) -> Result<Vec<u8>, &'static str> {
+        let start = time::current_time();
+
+        loop {
+            if time::current_time().saturating_sub(start) >= EPIC_REPLY_TIMEOUT_US {
+                return Err("apple-epic: timeout waiting for command reply");
+            }
+
+            loop {
+                let action = {
+                    let mut afk = self.afk.lock();
+                    match afk.recv() {
+                        Some(entry) => {
+                            let payload = afk.recv_payload(&entry).to_vec();
+                            afk.recv_ack();
+                            Some((entry.msg_type, entry.channel, payload))
+                        }
+                        None => None,
+                    }
+                };
+
+                match action {
+                    Some((msg_type, ch, payload)) => {
+                        if ch == channel && msg_type == TYPE_REPLY {
+                            return self.parse_reply(&payload);
+                        }
+                        if msg_type == TYPE_NOTIFY {
+                            self.handle_notify(ch, &payload);
+                        } else if ch == channel {
+                            early_println!(
+                                "[apple-epic] unexpected type={} on ch={}",
+                                msg_type,
+                                channel
+                            );
+                        }
+                    }
+                    None => break,
+                }
+            }
+
+            for _ in 0..100 {
+                core::hint::spin_loop();
+            }
+        }
+    }
+
+    /// Get the underlying AFK endpoint reference.
+    pub fn afk(&self) -> &Arc<spin::Mutex<AfkEndpoint>> {
+        &self.afk
+    }
+
+    // =========================================================================
+    // Private: header construction
+    // =========================================================================
+
+    fn next_seq(&mut self) -> u16 {
+        let seq = self.seq;
+        self.seq = self.seq.wrapping_add(1);
+        seq
+    }
+
+    fn write_epic_headers(
+        &self,
+        buf: &mut [u8],
+        category: u8,
+        msg_type: u16,
+        seq: u16,
+        payload_len: u32,
+    ) {
+        let hdr = EpicHdr {
+            version: EPIC_HDR_VERSION,
+            seq: self.seq,
+            _pad: 0,
+            unk: 0,
+            timestamp: 0,
+        };
+
+        let sub_hdr_size = mem::size_of::<EpicSubHdr>() + payload_len as usize;
+        let sub = EpicSubHdr {
+            length: sub_hdr_size as u32,
+            version: EPIC_SUBHDR_VERSION,
+            category,
+            msg_type,
+            timestamp: 0,
+            seq,
+            unk: 0,
+            flags: 0,
+            inline_len: payload_len,
+        };
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                &hdr as *const EpicHdr as *const u8,
+                buf.as_mut_ptr(),
+                mem::size_of::<EpicHdr>(),
+            );
+            core::ptr::copy_nonoverlapping(
+                &sub as *const EpicSubHdr as *const u8,
+                buf.as_mut_ptr().add(mem::size_of::<EpicHdr>()),
+                mem::size_of::<EpicSubHdr>(),
+            );
+        }
+    }
+
+    // =========================================================================
+    // Private: message handling
+    // =========================================================================
+
+    fn handle_notify(&mut self, channel: u32, payload: &[u8]) {
+        if payload.len() < mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>() {
+            return;
+        }
+
+        let sub: EpicSubHdr = unsafe {
+            core::ptr::read_unaligned(
+                payload.as_ptr().add(mem::size_of::<EpicHdr>()) as *const EpicSubHdr
+            )
+        };
+
+        match (sub.category, sub.msg_type) {
+            (CAT_REPORT, SUBTYPE_ANNOUNCE) => {
+                self.handle_announce(channel, payload);
+            }
+            (CAT_NOTIFY, SUBTYPE_STD_SERVICE) => {
+                // Standard service notification — forward to handler
+                if let Some(handler) = self.notify_handler {
+                    let data_start = mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>();
+                    if payload.len() > data_start {
+                        handler(channel, sub.msg_type, &payload[data_start..]);
+                    }
+                }
+            }
+            _ => {
+                if let Some(handler) = self.notify_handler {
+                    let data_start = mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>();
+                    if payload.len() > data_start {
+                        handler(channel, sub.msg_type, &payload[data_start..]);
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_announce(&mut self, channel: u32, payload: &[u8]) {
+        let announce_offset = mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>();
+
+        if payload.len() < announce_offset + mem::size_of::<EpicAnnounce>() {
+            return;
+        }
+
+        let announce: EpicAnnounce = unsafe {
+            core::ptr::read_unaligned(payload.as_ptr().add(announce_offset) as *const EpicAnnounce)
+        };
+
+        let name_bytes: &[u8] = &announce.name;
+        let name_len = name_bytes
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(name_bytes.len());
+        let name = String::from_utf8_lossy(&name_bytes[..name_len]).into_owned();
+
+        // Check if we already have this service on this channel
+        if self.services.iter().any(|s| s.channel == channel) {
+            return;
+        }
+
+        early_println!("[apple-epic] service '{}' on channel {}", name, channel);
+
+        self.services.push(EpicService {
+            name,
+            channel,
+            seq: 0,
+        });
+    }
+
+    fn handle_notify_ack(&mut self, channel: u32, payload: &[u8]) {
+        if payload.len() < mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>() {
+            return;
+        }
+
+        let sub: EpicSubHdr = unsafe {
+            core::ptr::read_unaligned(
+                payload.as_ptr().add(mem::size_of::<EpicHdr>()) as *const EpicSubHdr
+            )
+        };
+
+        let ack_size = mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>();
+        let mut ack = alloc::vec![0u8; ack_size];
+
+        self.write_epic_headers(&mut ack, CAT_REPLY, sub.msg_type, sub.seq, 0);
+
+        let mut afk = self.afk.lock();
+        let _ = afk.send(channel, TYPE_NOTIFY_ACK, &ack);
+    }
+
+    /// Parse a reply message and extract the response payload.
+    fn parse_reply(&self, payload: &[u8]) -> Result<Vec<u8>, &'static str> {
+        let hdr_offset = mem::size_of::<EpicHdr>() + mem::size_of::<EpicSubHdr>();
+
+        if payload.len() < hdr_offset + mem::size_of::<EpicCmd>() {
+            return Err("apple-epic: reply too short for command struct");
+        }
+
+        let cmd: EpicCmd = unsafe {
+            core::ptr::read_unaligned(payload.as_ptr().add(hdr_offset) as *const EpicCmd)
+        };
+
+        if cmd.retcode != 0 {
+            let retcode = cmd.retcode;
+            early_println!("[apple-epic: command failed with retcode={:#x}", retcode);
+            return Err("apple-epic: command returned non-zero retcode");
+        }
+
+        let rx_len = cmd.rxlen as usize;
+        if rx_len > EPIC_BUFFER_SIZE {
+            return Err("apple-epic: reply rxlen exceeds buffer size");
+        }
+
+        let reply_data =
+            unsafe { core::slice::from_raw_parts(self.dma.rx_virt as *const u8, rx_len) };
+
+        Ok(reply_data.to_vec())
+    }
+}

--- a/kernel/src/drivers/soc/apple_epic.rs
+++ b/kernel/src/drivers/soc/apple_epic.rs
@@ -362,8 +362,20 @@ impl EpicEndpoint {
         command: u32,
         data: &[u8],
     ) -> Result<Vec<u8>, &'static str> {
-        self.send_command(service.channel, group, command, data)?;
-        self.wait_reply(service.channel)
+        self.call_by_channel(service.channel, group, command, data)
+    }
+
+    /// Like [`Self::call`] but accepts a channel number directly,
+    /// avoiding the borrow conflict of passing `&EpicService` alongside `&mut self`.
+    pub fn call_by_channel(
+        &mut self,
+        channel: u32,
+        group: u16,
+        command: u32,
+        data: &[u8],
+    ) -> Result<Vec<u8>, &'static str> {
+        self.send_command(channel, group, command, data)?;
+        self.wait_reply(channel)
     }
 
     /// Send a standard service call without waiting for a reply.

--- a/kernel/src/drivers/soc/apple_rtkit.rs
+++ b/kernel/src/drivers/soc/apple_rtkit.rs
@@ -1,0 +1,348 @@
+//! Apple RTKit protocol driver over ASC mailbox.
+//!
+//! This layer implements the RTKit management handshake and endpoint messaging
+//! on top of the `AppleAsc` transport.
+
+use alloc::sync::Arc;
+use core::cmp;
+
+use spin::Mutex;
+
+use crate::drivers::soc::apple_asc::{AppleAsc, AscMessage};
+use crate::early_println;
+use crate::time;
+
+/// RTKit message with endpoint and 64-bit payload.
+pub struct RtkitMessage {
+    /// Endpoint number.
+    pub ep: u8,
+    /// Message payload.
+    pub msg: u64,
+}
+
+/// RTKit shared buffer descriptor.
+pub struct RtkitBuffer {
+    /// Kernel virtual address.
+    pub buffer: *mut u8,
+    /// Buffer size in bytes.
+    pub size: usize,
+    /// IOVA exposed to firmware.
+    pub iova: u64,
+    /// Device virtual address alias.
+    pub dva: u64,
+}
+
+/// RTKit management endpoint.
+pub const RTKIT_EP_MGMT: u8 = 0;
+/// RTKit crashlog endpoint.
+pub const RTKIT_EP_CRASHLOG: u8 = 1;
+/// RTKit syslog endpoint.
+pub const RTKIT_EP_SYSLOG: u8 = 2;
+/// RTKit debug endpoint.
+pub const RTKIT_EP_DEBUG: u8 = 3;
+/// RTKit ioreport endpoint.
+pub const RTKIT_EP_IOREPORT: u8 = 4;
+/// RTKit oslog endpoint.
+pub const RTKIT_EP_OSLOG: u8 = 8;
+
+const MGMT_TYPE: u64 = 0x01FF_0000_0000_0000;
+const MGMT_PWR_STATE: u64 = 0x0000_0000_FFFF_FFFF;
+
+const MGMT_MSG_HELLO: u64 = 1;
+const MGMT_MSG_HELLO_ACK: u64 = 2;
+const MGMT_MSG_START_EP: u64 = 5;
+const MGMT_MSG_IOP_PWR_STATE: u64 = 6;
+const MGMT_MSG_IOP_PWR_STATE_ACK: u64 = 7;
+const MGMT_MSG_EPMAP: u64 = 8;
+const MGMT_MSG_AP_PWR_STATE: u64 = 0xb;
+
+const MGMT_MSG_HELLO_MINVER: u64 = 0x0000_0000_0000_FFFF;
+const MGMT_MSG_HELLO_MAXVER: u64 = 0x0000_0000_FFFF_0000;
+
+const MGMT_MSG_EPMAP_DONE: u64 = 1 << 51;
+const MGMT_MSG_EPMAP_BASE: u64 = 0x0000_0000_0000_0700;
+const MGMT_MSG_EPMAP_BITMAP: u64 = 0x0000_0000_FFFF_FFFF;
+
+const MGMT_MSG_EPMAP_REPLY_DONE: u64 = 1 << 51;
+const MGMT_MSG_EPMAP_REPLY_MORE: u64 = 1;
+
+const MGMT_MSG_START_EP_IDX: u64 = 0x0000_0000_FF00_0000;
+const MGMT_MSG_START_EP_FLAG: u64 = 1 << 1;
+
+const MSG_BUFFER_REQUEST: u64 = 1;
+const MSG_BUFFER_REQUEST_SIZE: u64 = 0x00FF_0000_0000_0000;
+const MSG_BUFFER_REQUEST_IOVA: u64 = 0x0000_07FF_FFFF_FFFF;
+
+/// RTKit powered off state.
+pub const RTKIT_POWER_OFF: u32 = 0x00;
+/// RTKit sleep state.
+pub const RTKIT_POWER_SLEEP: u32 = 0x01;
+/// RTKit quiesced state.
+pub const RTKIT_POWER_QUIESCED: u32 = 0x10;
+/// RTKit powered on state.
+pub const RTKIT_POWER_ON: u32 = 0x20;
+/// RTKit init state requested during boot.
+pub const RTKIT_POWER_INIT: u32 = 0x220;
+
+const RTKIT_MIN_VERSION: u32 = 11;
+const RTKIT_MAX_VERSION: u32 = 12;
+
+const RTKIT_BOOT_TIMEOUT_US: u64 = 1_000_000;
+
+#[inline(always)]
+const fn field_get(val: u64, mask: u64) -> u64 {
+    (val & mask) >> mask.trailing_zeros()
+}
+
+#[inline(always)]
+const fn field_prep(mask: u64, val: u64) -> u64 {
+    val << mask.trailing_zeros()
+}
+
+fn mgmt_msg(msg_type: u64, payload: u64) -> u64 {
+    field_prep(MGMT_TYPE, msg_type) | payload
+}
+
+/// RTKit protocol context.
+pub struct AppleRtkit {
+    asc: Arc<AppleAsc>,
+    iop_power: Mutex<u32>,
+    ap_power: Mutex<u32>,
+    crashed: Mutex<bool>,
+    ep_bitmap: Mutex<u64>,
+}
+
+impl AppleRtkit {
+    /// Create a new RTKit protocol instance over ASC.
+    pub fn new(asc: Arc<AppleAsc>) -> Self {
+        Self {
+            asc,
+            iop_power: Mutex::new(RTKIT_POWER_OFF),
+            ap_power: Mutex::new(RTKIT_POWER_OFF),
+            crashed: Mutex::new(false),
+            ep_bitmap: Mutex::new(0),
+        }
+    }
+
+    /// Perform the RTKit boot handshake.
+    pub fn boot(&self) -> Result<(), &'static str> {
+        self.asc.cpu_start();
+
+        self.send(&RtkitMessage {
+            ep: RTKIT_EP_MGMT,
+            msg: mgmt_msg(
+                MGMT_MSG_IOP_PWR_STATE,
+                field_prep(MGMT_PWR_STATE, RTKIT_POWER_INIT as u64),
+            ),
+        })?;
+
+        let hello = self.wait_mgmt_msg(MGMT_MSG_HELLO, RTKIT_BOOT_TIMEOUT_US)?;
+        self.handle_hello(hello)?;
+
+        self.handle_epmap_sequence()?;
+
+        for ep in [
+            RTKIT_EP_CRASHLOG,
+            RTKIT_EP_SYSLOG,
+            RTKIT_EP_DEBUG,
+            RTKIT_EP_IOREPORT,
+            RTKIT_EP_OSLOG,
+        ] {
+            self.start_ep(ep)?;
+        }
+
+        loop {
+            let msg = self.wait_any_mgmt_msg(RTKIT_BOOT_TIMEOUT_US)?;
+            let msg_type = field_get(msg, MGMT_TYPE);
+            if msg_type == MGMT_MSG_IOP_PWR_STATE_ACK {
+                let pwr = field_get(msg, MGMT_PWR_STATE) as u32;
+                *self.iop_power.lock() = pwr;
+                if pwr == RTKIT_POWER_ON {
+                    break;
+                }
+            }
+        }
+
+        self.send(&RtkitMessage {
+            ep: RTKIT_EP_MGMT,
+            msg: mgmt_msg(
+                MGMT_MSG_AP_PWR_STATE,
+                field_prep(MGMT_PWR_STATE, RTKIT_POWER_ON as u64),
+            ),
+        })?;
+        *self.ap_power.lock() = RTKIT_POWER_ON;
+
+        Ok(())
+    }
+
+    /// Send one endpoint message.
+    pub fn send(&self, msg: &RtkitMessage) -> Result<(), &'static str> {
+        let asc_msg = AscMessage {
+            msg0: msg.msg,
+            msg1: msg.ep as u32,
+        };
+        self.asc.send(&asc_msg)
+    }
+
+    /// Receive one message, handling system endpoints internally.
+    pub fn recv(&self, msg: &mut RtkitMessage) -> Result<bool, &'static str> {
+        if !self.asc.can_recv() {
+            return Ok(false);
+        }
+
+        let mut asc_msg = AscMessage { msg0: 0, msg1: 0 };
+        self.asc.recv(&mut asc_msg)?;
+
+        msg.ep = (asc_msg.msg1 & 0x3f) as u8;
+        msg.msg = asc_msg.msg0;
+
+        if self.handle_internal_message(msg)? {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    /// Start a specific RTKit endpoint.
+    pub fn start_ep(&self, ep: u8) -> Result<(), &'static str> {
+        let payload = field_prep(MGMT_MSG_START_EP_IDX, ep as u64) | MGMT_MSG_START_EP_FLAG;
+        self.send(&RtkitMessage {
+            ep: RTKIT_EP_MGMT,
+            msg: mgmt_msg(MGMT_MSG_START_EP, payload),
+        })
+    }
+
+    /// Check whether RTKit is fully running.
+    pub fn is_running(&self) -> bool {
+        *self.iop_power.lock() == RTKIT_POWER_ON
+            && *self.ap_power.lock() == RTKIT_POWER_ON
+            && !*self.crashed.lock()
+    }
+
+    /// Check whether RTKit reported crash state.
+    pub fn is_crashed(&self) -> bool {
+        *self.crashed.lock()
+    }
+
+    fn wait_any_mgmt_msg(&self, timeout_us: u64) -> Result<u64, &'static str> {
+        let mut asc_msg = AscMessage { msg0: 0, msg1: 0 };
+        self.asc.recv_timeout(&mut asc_msg, timeout_us)?;
+
+        let ep = (asc_msg.msg1 & 0x3f) as u8;
+        if ep != RTKIT_EP_MGMT {
+            let mut message = RtkitMessage {
+                ep,
+                msg: asc_msg.msg0,
+            };
+            let _ = self.handle_internal_message(&mut message)?;
+            return Err("apple-rtkit: unexpected non-management message during boot");
+        }
+
+        Ok(asc_msg.msg0)
+    }
+
+    fn wait_mgmt_msg(&self, expected_type: u64, timeout_us: u64) -> Result<u64, &'static str> {
+        let start = time::current_time();
+        loop {
+            let elapsed = time::current_time().saturating_sub(start);
+            if elapsed >= timeout_us {
+                return Err("apple-rtkit: timeout waiting for management message");
+            }
+
+            let remaining = timeout_us - elapsed;
+            let msg = self.wait_any_mgmt_msg(remaining)?;
+            if field_get(msg, MGMT_TYPE) == expected_type {
+                return Ok(msg);
+            }
+        }
+    }
+
+    fn handle_hello(&self, hello_msg: u64) -> Result<(), &'static str> {
+        let minver = field_get(hello_msg, MGMT_MSG_HELLO_MINVER) as u32;
+        let maxver = field_get(hello_msg, MGMT_MSG_HELLO_MAXVER) as u32;
+
+        let negotiated = cmp::min(maxver, RTKIT_MAX_VERSION);
+        if negotiated < RTKIT_MIN_VERSION || negotiated < minver {
+            return Err("apple-rtkit: unsupported RTKit version range");
+        }
+
+        let ack_payload = field_prep(MGMT_MSG_HELLO_MINVER, negotiated as u64)
+            | field_prep(MGMT_MSG_HELLO_MAXVER, negotiated as u64);
+        self.send(&RtkitMessage {
+            ep: RTKIT_EP_MGMT,
+            msg: mgmt_msg(MGMT_MSG_HELLO_ACK, ack_payload),
+        })
+    }
+
+    fn handle_epmap_sequence(&self) -> Result<(), &'static str> {
+        loop {
+            let msg = self.wait_mgmt_msg(MGMT_MSG_EPMAP, RTKIT_BOOT_TIMEOUT_US)?;
+
+            let base = field_get(msg, MGMT_MSG_EPMAP_BASE) as u32;
+            let bitmap = field_get(msg, MGMT_MSG_EPMAP_BITMAP);
+            let shift = base.saturating_mul(32);
+            if shift < 64 {
+                *self.ep_bitmap.lock() |= bitmap << shift;
+            }
+
+            let done = (msg & MGMT_MSG_EPMAP_DONE) != 0;
+            let reply_payload = if done {
+                MGMT_MSG_EPMAP_REPLY_DONE
+            } else {
+                MGMT_MSG_EPMAP_REPLY_MORE
+            };
+
+            self.send(&RtkitMessage {
+                ep: RTKIT_EP_MGMT,
+                msg: mgmt_msg(MGMT_MSG_EPMAP, reply_payload),
+            })?;
+
+            if done {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_internal_message(&self, msg: &mut RtkitMessage) -> Result<bool, &'static str> {
+        match msg.ep {
+            RTKIT_EP_MGMT => self.handle_mgmt_message(msg.msg).map(|_| true),
+            RTKIT_EP_SYSLOG | RTKIT_EP_CRASHLOG => self.handle_buffer_request(msg),
+            _ => Ok(false),
+        }
+    }
+
+    fn handle_mgmt_message(&self, mgmt_msg_raw: u64) -> Result<(), &'static str> {
+        let msg_type = field_get(mgmt_msg_raw, MGMT_TYPE);
+        match msg_type {
+            MGMT_MSG_IOP_PWR_STATE_ACK => {
+                let pwr = field_get(mgmt_msg_raw, MGMT_PWR_STATE) as u32;
+                *self.iop_power.lock() = pwr;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_buffer_request(&self, msg: &RtkitMessage) -> Result<bool, &'static str> {
+        if (msg.msg & 0xff) != MSG_BUFFER_REQUEST {
+            return Ok(false);
+        }
+
+        let requested_size = field_get(msg.msg, MSG_BUFFER_REQUEST_SIZE);
+        early_println!(
+            "[apple-rtkit] endpoint {} buffer request size={:#x}, replying dummy iova=0",
+            msg.ep,
+            requested_size
+        );
+
+        let reply = RtkitMessage {
+            ep: msg.ep,
+            msg: MSG_BUFFER_REQUEST | field_prep(MSG_BUFFER_REQUEST_IOVA, 0),
+        };
+        self.send(&reply)?;
+
+        Ok(true)
+    }
+}

--- a/kernel/src/drivers/soc/mod.rs
+++ b/kernel/src/drivers/soc/mod.rs
@@ -1,3 +1,4 @@
+pub mod apple_afk;
 pub mod apple_asc;
 pub mod apple_pmgr;
 pub mod apple_rtkit;

--- a/kernel/src/drivers/soc/mod.rs
+++ b/kernel/src/drivers/soc/mod.rs
@@ -1,1 +1,3 @@
+pub mod apple_asc;
 pub mod apple_pmgr;
+pub mod apple_rtkit;

--- a/kernel/src/drivers/soc/mod.rs
+++ b/kernel/src/drivers/soc/mod.rs
@@ -1,4 +1,5 @@
 pub mod apple_afk;
 pub mod apple_asc;
+pub mod apple_epic;
 pub mod apple_pmgr;
 pub mod apple_rtkit;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -755,6 +755,14 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
 
     fence(Ordering::SeqCst); // Ensure all initcalls are completed before proceeding
 
+    /* Attempt to mirror framebuffer to external DisplayPort (aarch64 only) */
+    #[cfg(target_arch = "aarch64")]
+    {
+        if let Err(e) = crate::drivers::display::dcpext::mirror_boot_fb() {
+            println!("[boot] dp mirror skipped: {}", e);
+        }
+    }
+
     /* Enable CPU interrupt reception (stage 2) */
     println!("[Scarlet Kernel] Enabling CPU interrupts...");
     InterruptManager::get_manager().enable_cpu_interrupts();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -755,14 +755,6 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
 
     fence(Ordering::SeqCst); // Ensure all initcalls are completed before proceeding
 
-    /* Attempt to mirror framebuffer to external DisplayPort (aarch64 only) */
-    #[cfg(target_arch = "aarch64")]
-    {
-        if let Err(e) = crate::drivers::display::dcpext::mirror_boot_fb() {
-            println!("[boot] dp mirror skipped: {}", e);
-        }
-    }
-
     /* Enable CPU interrupt reception (stage 2) */
     println!("[Scarlet Kernel] Enabling CPU interrupts...");
     InterruptManager::get_manager().enable_cpu_interrupts();


### PR DESCRIPTION
This pull request introduces two major new abstractions to the kernel device layer: a generic I2C bus interface (with protocol-level types and a shared adapter), and a display output abstraction for graphics devices. The changes lay the groundwork for supporting multi-output graphics devices and structured I2C communication, both of which are important for extensibility and hardware support.

**Graphics Output Abstraction and Multi-Output Support:**

* Added a new `DisplayOutput` trait in `graphics/output.rs`, representing a single display connector (e.g., HDMI, DP, internal panel), with methods for querying connection status, presenting a framebuffer, and retrieving a human-readable name. Also includes a sample implementation (`SimpleFbOutput`).
* Updated the `GraphicsDevice` trait to support multiple outputs via a new `get_outputs` method, defaulting to empty for devices without multi-output support.
* The `GraphicsManager` now provides two new methods: `mirror_all` to present a framebuffer on all connected outputs across all graphics devices, and `mirror_to` to present on a specific output by name.
* Refactored imports and module structure to integrate the new output abstraction. [[1]](diffhunk://#diff-7c998f6a66aadf3de1bd2d6e9007c119ecd9ac13c1e2d03fa149f21c6cb5b413R31) [[2]](diffhunk://#diff-422ec2c1890b1a367e6696c816aa7511f9334d9ef895c2060840c8d46704e960R10) [[3]](diffhunk://#diff-422ec2c1890b1a367e6696c816aa7511f9334d9ef895c2060840c8d46704e960R19)

**I2C Bus Abstraction:**

* Added a new `i2c` module with protocol-level types (`I2cAddress`, `I2cMessage`, `I2cMessageFlags`, `I2cError`, etc.) and a generic `I2cBus` trait for controller drivers, supporting multi-segment transactions and standard operations. [[1]](diffhunk://#diff-1cc7ccf9c4ebcf8eb57f2a47bb4295f6fde76d97d3ceb2321645bdf3ea4e8a98R1-R195) [[2]](diffhunk://#diff-090d7a73ece6ae7c4b20f25123af7e085841338905a158ec4f5549a3476ea488R12)
* Introduced an `I2cAdapter` wrapper for shared, thread-safe access to a single I2C bus, including helper methods for common operations (read, write, write-then-read, register access, device probe).

These changes provide a robust foundation for future work on display management (multi-monitor, hotplug, etc.) and I2C device drivers (sensors, display panels, etc.), while maintaining backward compatibility for simpler devices.