### PR TITLE
Refactor Linux ABI for RISC-V and AArch64 architectures

### DIFF
--- a/kernel/src/abi/linux/aarch64/mod.rs
+++ b/kernel/src/abi/linux/aarch64/mod.rs
@@ -15,6 +15,8 @@ use crate::{
     vm::setup_user_stack,
 };
 
+pub mod signal;
+
 #[derive(Clone)]
 pub struct LinuxAarch64Abi(pub generic::LinuxAbi);
 
@@ -65,6 +67,10 @@ impl AbiModule for LinuxAarch64Abi {
             return Ok(result);
         }
 
+        if let Some(result) = signal::dispatch_arch_syscall(self, trapframe, syscall_number) {
+            return Ok(result);
+        }
+
         crate::println!("Invalid Syscall number: {}", syscall_number);
         Err("Invalid syscall number")
     }
@@ -88,8 +94,7 @@ impl AbiModule for LinuxAarch64Abi {
             match action {
                 generic::signal::SignalAction::Custom(handler_addr) => {
                     let trapframe = target_task.get_trapframe();
-                    // TODO: aarch64-specific setup_signal_handler
-                    generic::signal::setup_signal_handler(trapframe, handler_addr, signal);
+                    signal::setup_signal_handler(trapframe, handler_addr, signal);
                 }
                 generic::signal::SignalAction::Ignore => {}
                 generic::signal::SignalAction::ForceTerminate => {

--- a/kernel/src/abi/linux/aarch64/mod.rs
+++ b/kernel/src/abi/linux/aarch64/mod.rs
@@ -16,30 +16,30 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct LinuxRiscv64Abi(pub generic::LinuxAbi);
+pub struct LinuxAarch64Abi(pub generic::LinuxAbi);
 
-impl Default for LinuxRiscv64Abi {
+impl Default for LinuxAarch64Abi {
     fn default() -> Self {
         Self(generic::LinuxAbi::default())
     }
 }
 
-impl core::ops::Deref for LinuxRiscv64Abi {
+impl core::ops::Deref for LinuxAarch64Abi {
     type Target = generic::LinuxAbi;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl core::ops::DerefMut for LinuxRiscv64Abi {
+impl core::ops::DerefMut for LinuxAarch64Abi {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl AbiModule for LinuxRiscv64Abi {
+impl AbiModule for LinuxAarch64Abi {
     fn name() -> &'static str {
-        "linux-riscv64"
+        "linux-aarch64"
     }
 
     fn get_name(&self) -> alloc::string::String {
@@ -88,6 +88,7 @@ impl AbiModule for LinuxRiscv64Abi {
             match action {
                 generic::signal::SignalAction::Custom(handler_addr) => {
                     let trapframe = target_task.get_trapframe();
+                    // TODO: aarch64-specific setup_signal_handler
                     generic::signal::setup_signal_handler(trapframe, handler_addr, signal);
                 }
                 generic::signal::SignalAction::Ignore => {}
@@ -244,7 +245,7 @@ impl AbiModule for LinuxRiscv64Abi {
                         resolve_interpreter: |requested| {
                             requested.map(|path| {
                                 if path.starts_with("/lib/ld-") || path.starts_with("/lib64/ld-") {
-                                    format!("/scarlet/system/linux-riscv64{}", path)
+                                    format!("/scarlet/system/linux-aarch64{}", path)
                                 } else {
                                     path.to_string()
                                 }
@@ -515,7 +516,7 @@ fn create_dir_if_not_exists(vfs: &Arc<VfsManager>, path: &str) -> Result<(), Fil
 }
 
 fn register_linux_abi() {
-    register_abi!(LinuxRiscv64Abi);
+    register_abi!(LinuxAarch64Abi);
 }
 
 late_initcall!(register_linux_abi);

--- a/kernel/src/abi/linux/aarch64/signal.rs
+++ b/kernel/src/abi/linux/aarch64/signal.rs
@@ -1,0 +1,38 @@
+//! AArch64 arch-specific signal handling
+//!
+//! Provides `setup_signal_handler` and `sys_rt_sigreturn` stubs for AArch64.
+//! Signal types and generic logic live in `generic::signal`.
+
+use crate::abi::linux::generic::signal::LinuxSignal;
+use crate::abi::linux::aarch64::LinuxAarch64Abi;
+use crate::arch::Trapframe;
+
+/// Set up user-space signal handler execution with context save/restore.
+///
+/// TODO: Implement proper AArch64 signal frame layout.
+pub fn setup_signal_handler(trapframe: &mut Trapframe, handler_addr: usize, signal: LinuxSignal) {
+    trapframe.set_pc(handler_addr as u64);
+    // TODO: Save context to signal frame on user stack
+    // TODO: Set up signal return trampoline (SVC #0 or similar)
+    let _ = signal;
+}
+
+/// Linux sys_rt_sigreturn — Restore context saved by `setup_signal_handler`.
+///
+/// TODO: Implement proper AArch64 signal frame restoration.
+pub fn sys_rt_sigreturn(_abi: &mut LinuxAarch64Abi, _trapframe: &mut Trapframe) -> usize {
+    // TODO: Restore registers and PC from signal frame
+    0
+}
+
+/// Arch-specific fallback syscall table for AArch64.
+pub fn dispatch_arch_syscall(
+    abi: &mut LinuxAarch64Abi,
+    trapframe: &mut Trapframe,
+    syscall_number: usize,
+) -> Option<usize> {
+    match syscall_number {
+        139 => Some(sys_rt_sigreturn(abi, trapframe)),
+        _ => None,
+    }
+}

--- a/kernel/src/abi/linux/aarch64/signal.rs
+++ b/kernel/src/abi/linux/aarch64/signal.rs
@@ -3,8 +3,8 @@
 //! Provides `setup_signal_handler` and `sys_rt_sigreturn` stubs for AArch64.
 //! Signal types and generic logic live in `generic::signal`.
 
-use crate::abi::linux::generic::signal::LinuxSignal;
 use crate::abi::linux::aarch64::LinuxAarch64Abi;
+use crate::abi::linux::generic::signal::LinuxSignal;
 use crate::arch::Trapframe;
 
 /// Set up user-space signal handler execution with context save/restore.

--- a/kernel/src/abi/linux/device/kvm/mod.rs
+++ b/kernel/src/abi/linux/device/kvm/mod.rs
@@ -13,8 +13,7 @@ use alloc::vec::Vec;
 use core::any::Any;
 use spin::{Once, RwLock};
 
-#[cfg(target_arch = "riscv64")]
-use crate::abi::linux::riscv64::LinuxRiscv64Abi;
+use crate::abi::linux::generic::LinuxAbi;
 use crate::device::manager::DeviceManager;
 use crate::device::{Device, DeviceType};
 use crate::hypervisor::memory::MemorySlotFlags;
@@ -338,11 +337,10 @@ pub fn free_vcpu_run_page(vcpu: &VcpuRef) {
 // System-level (/dev/kvm) ioctl dispatcher
 // ---------------------------------------------------------------------------
 
-#[cfg(target_arch = "riscv64")]
 pub fn handle_system_ioctl(
     request: u32,
     _arg: usize,
-    abi: &mut LinuxRiscv64Abi,
+    abi: &mut LinuxAbi,
 ) -> Result<Option<usize>, ()> {
     // crate::println!("[KVM] handle_system_ioctl: request={:#x} arg={}", request, _arg);
     match request {
@@ -384,12 +382,11 @@ pub fn handle_system_ioctl(
 // VM-level ioctl dispatcher
 // ---------------------------------------------------------------------------
 
-#[cfg(target_arch = "riscv64")]
 pub fn handle_vm_ioctl(
     request: u32,
     arg: usize,
     vm: &VmRef,
-    abi: &mut LinuxRiscv64Abi,
+    abi: &mut LinuxAbi,
 ) -> Result<Option<usize>, ()> {
     // crate::println!("[KVM] handle_vm_ioctl: request={:#x} arg={:#x}", request, arg);
     match request {

--- a/kernel/src/abi/linux/generic/errno.rs
+++ b/kernel/src/abi/linux/generic/errno.rs
@@ -1,0 +1,451 @@
+//! Linux errno constants
+//!
+//! This module defines the standard Linux error numbers used by system calls.
+//! These values match the Linux kernel errno definitions.
+
+/// Success (no error)
+pub const SUCCESS: usize = 0;
+
+/// Operation not permitted
+pub const EPERM: usize = 1;
+
+/// No such file or directory  
+pub const ENOENT: usize = 2;
+
+/// No such process
+pub const ESRCH: usize = 3;
+
+/// Interrupted system call
+pub const EINTR: usize = 4;
+
+/// I/O error
+pub const EIO: usize = 5;
+
+/// No such device or address
+pub const ENXIO: usize = 6;
+
+/// Argument list too long
+pub const E2BIG: usize = 7;
+
+/// Exec format error
+pub const ENOEXEC: usize = 8;
+
+/// Bad file number
+pub const EBADF: usize = 9;
+
+/// No child processes
+pub const ECHILD: usize = 10;
+
+/// Try again
+pub const EAGAIN: usize = 11;
+
+/// Out of memory
+pub const ENOMEM: usize = 12;
+
+/// Permission denied
+pub const EACCES: usize = 13;
+
+/// Bad address
+pub const EFAULT: usize = 14;
+
+/// Block device required
+pub const ENOTBLK: usize = 15;
+
+/// Device or resource busy
+pub const EBUSY: usize = 16;
+
+/// File exists
+pub const EEXIST: usize = 17;
+
+/// Cross-device link
+pub const EXDEV: usize = 18;
+
+/// No such device
+pub const ENODEV: usize = 19;
+
+/// Not a directory
+pub const ENOTDIR: usize = 20;
+
+/// Is a directory
+pub const EISDIR: usize = 21;
+
+/// Invalid argument
+pub const EINVAL: usize = 22;
+
+/// File table overflow
+pub const ENFILE: usize = 23;
+
+/// Too many open files
+pub const EMFILE: usize = 24;
+
+/// Not a typewriter
+pub const ENOTTY: usize = 25;
+
+/// Text file busy
+pub const ETXTBSY: usize = 26;
+
+/// File too large
+pub const EFBIG: usize = 27;
+
+/// No space left on device
+pub const ENOSPC: usize = 28;
+
+/// Illegal seek
+pub const ESPIPE: usize = 29;
+
+/// Read-only file system
+pub const EROFS: usize = 30;
+
+/// Too many links
+pub const EMLINK: usize = 31;
+
+/// Broken pipe
+pub const EPIPE: usize = 32;
+
+/// Math argument out of domain of func
+pub const EDOM: usize = 33;
+
+/// Math result not representable
+pub const ERANGE: usize = 34;
+
+/// Resource deadlock would occur
+pub const EDEADLK: usize = 35;
+
+/// File name too long
+pub const ENAMETOOLONG: usize = 36;
+
+/// No record locks available
+pub const ENOLCK: usize = 37;
+
+/// Function not implemented
+pub const ENOSYS: usize = 38;
+
+/// Directory not empty
+pub const ENOTEMPTY: usize = 39;
+
+/// Too many symbolic links encountered
+pub const ELOOP: usize = 40;
+
+/// Operation would block (same as EAGAIN)
+pub const EWOULDBLOCK: usize = EAGAIN;
+
+/// No message of desired type
+pub const ENOMSG: usize = 42;
+
+/// Identifier removed
+pub const EIDRM: usize = 43;
+
+/// Channel number out of range
+pub const ECHRNG: usize = 44;
+
+/// Level 2 not synchronized
+pub const EL2NSYNC: usize = 45;
+
+/// Level 3 halted
+pub const EL3HLT: usize = 46;
+
+/// Level 3 reset
+pub const EL3RST: usize = 47;
+
+/// Link number out of range
+pub const ELNRNG: usize = 48;
+
+/// Protocol driver not attached
+pub const EUNATCH: usize = 49;
+
+/// No CSI structure available
+pub const ENOCSI: usize = 50;
+
+/// Level 2 halted
+pub const EL2HLT: usize = 51;
+
+/// Invalid exchange
+pub const EBADE: usize = 52;
+
+/// Invalid request descriptor
+pub const EBADR: usize = 53;
+
+/// Exchange full
+pub const EXFULL: usize = 54;
+
+/// No anode
+pub const ENOANO: usize = 55;
+
+/// Invalid request code
+pub const EBADRQC: usize = 56;
+
+/// Invalid slot
+pub const EBADSLT: usize = 57;
+
+/// Resource deadlock would occur (same as EDEADLK)
+pub const EDEADLOCK: usize = EDEADLK;
+
+/// Bad font file format
+pub const EBFONT: usize = 59;
+
+/// Device not a stream
+pub const ENOSTR: usize = 60;
+
+/// No data available
+pub const ENODATA: usize = 61;
+
+/// Timer expired
+pub const ETIME: usize = 62;
+
+/// Out of streams resources
+pub const ENOSR: usize = 63;
+
+/// Machine is not on the network
+pub const ENONET: usize = 64;
+
+/// Package not installed
+pub const ENOPKG: usize = 65;
+
+/// Object is remote
+pub const EREMOTE: usize = 66;
+
+/// Link has been severed
+pub const ENOLINK: usize = 67;
+
+/// Advertise error
+pub const EADV: usize = 68;
+
+/// Srmount error
+pub const ESRMNT: usize = 69;
+
+/// Communication error on send
+pub const ECOMM: usize = 70;
+
+/// Protocol error
+pub const EPROTO: usize = 71;
+
+/// Multihop attempted
+pub const EMULTIHOP: usize = 72;
+
+/// RFS specific error
+pub const EDOTDOT: usize = 73;
+
+/// Not a data message
+pub const EBADMSG: usize = 74;
+
+/// Value too large for defined data type
+pub const EOVERFLOW: usize = 75;
+
+/// Name not unique on network
+pub const ENOTUNIQ: usize = 76;
+
+/// File descriptor in bad state
+pub const EBADFD: usize = 77;
+
+/// Remote address changed
+pub const EREMCHG: usize = 78;
+
+/// Can not access a needed shared library
+pub const ELIBACC: usize = 79;
+
+/// Accessing a corrupted shared library
+pub const ELIBBAD: usize = 80;
+
+/// .lib section in a.out corrupted
+pub const ELIBSCN: usize = 81;
+
+/// Attempting to link in too many shared libraries
+pub const ELIBMAX: usize = 82;
+
+/// Cannot exec a shared library directly
+pub const ELIBEXEC: usize = 83;
+
+/// Illegal byte sequence
+pub const EILSEQ: usize = 84;
+
+/// Interrupted system call should be restarted
+pub const ERESTART: usize = 85;
+
+/// Streams pipe error
+pub const ESTRPIPE: usize = 86;
+
+/// Too many users
+pub const EUSERS: usize = 87;
+
+/// Socket operation on non-socket
+pub const ENOTSOCK: usize = 88;
+
+/// Destination address required
+pub const EDESTADDRREQ: usize = 89;
+
+/// Message too long
+pub const EMSGSIZE: usize = 90;
+
+/// Protocol wrong type for socket
+pub const EPROTOTYPE: usize = 91;
+
+/// Protocol not available
+pub const ENOPROTOOPT: usize = 92;
+
+/// Protocol not supported
+pub const EPROTONOSUPPORT: usize = 93;
+
+/// Socket type not supported
+pub const ESOCKTNOSUPPORT: usize = 94;
+
+/// Operation not supported on transport endpoint
+pub const EOPNOTSUPP: usize = 95;
+
+/// Protocol family not supported
+pub const EPFNOSUPPORT: usize = 96;
+
+/// Address family not supported by protocol
+pub const EAFNOSUPPORT: usize = 97;
+
+/// Address already in use
+pub const EADDRINUSE: usize = 98;
+
+/// Cannot assign requested address
+pub const EADDRNOTAVAIL: usize = 99;
+
+/// Network is down
+pub const ENETDOWN: usize = 100;
+
+/// Network is unreachable
+pub const ENETUNREACH: usize = 101;
+
+/// Network dropped connection because of reset
+pub const ENETRESET: usize = 102;
+
+/// Software caused connection abort
+pub const ECONNABORTED: usize = 103;
+
+/// Connection reset by peer
+pub const ECONNRESET: usize = 104;
+
+/// No buffer space available
+pub const ENOBUFS: usize = 105;
+
+/// Transport endpoint is already connected
+pub const EISCONN: usize = 106;
+
+/// Transport endpoint is not connected
+pub const ENOTCONN: usize = 107;
+
+/// Cannot send after transport endpoint shutdown
+pub const ESHUTDOWN: usize = 108;
+
+/// Too many references: cannot splice
+pub const ETOOMANYREFS: usize = 109;
+
+/// Connection timed out
+pub const ETIMEDOUT: usize = 110;
+
+/// Connection refused
+pub const ECONNREFUSED: usize = 111;
+
+/// Host is down
+pub const EHOSTDOWN: usize = 112;
+
+/// No route to host
+pub const EHOSTUNREACH: usize = 113;
+
+/// Operation already in progress
+pub const EALREADY: usize = 114;
+
+/// Operation now in progress
+pub const EINPROGRESS: usize = 115;
+
+/// Stale file handle
+pub const ESTALE: usize = 116;
+
+/// Structure needs cleaning
+pub const EUCLEAN: usize = 117;
+
+/// Not a XENIX named type file
+pub const ENOTNAM: usize = 118;
+
+/// No XENIX semaphores available
+pub const ENAVAIL: usize = 119;
+
+/// Is a named type file
+pub const EISNAM: usize = 120;
+
+/// Remote I/O error
+pub const EREMOTEIO: usize = 121;
+
+/// Quota exceeded
+pub const EDQUOT: usize = 122;
+
+/// No medium found
+pub const ENOMEDIUM: usize = 123;
+
+/// Wrong medium type
+pub const EMEDIUMTYPE: usize = 124;
+
+/// Operation Canceled
+pub const ECANCELED: usize = 125;
+
+/// Required key not available
+pub const ENOKEY: usize = 126;
+
+/// Key has expired
+pub const EKEYEXPIRED: usize = 127;
+
+/// Key has been revoked
+pub const EKEYREVOKED: usize = 128;
+
+/// Key was rejected by service
+pub const EKEYREJECTED: usize = 129;
+
+/// Owner died
+pub const EOWNERDEAD: usize = 130;
+
+/// State not recoverable
+pub const ENOTRECOVERABLE: usize = 131;
+
+/// Operation not possible due to RF-kill
+pub const ERFKILL: usize = 132;
+
+/// Memory page has hardware error
+pub const EHWPOISON: usize = 133;
+
+/// Helper function to convert FileSystemErrorKind to Linux errno
+pub fn from_fs_error(error: &crate::fs::FileSystemError) -> usize {
+    use crate::fs::FileSystemErrorKind;
+
+    match error.kind {
+        FileSystemErrorKind::NotFound => ENOENT,
+        FileSystemErrorKind::PermissionDenied => EACCES,
+        FileSystemErrorKind::FileExists => EEXIST,
+        FileSystemErrorKind::AlreadyExists => EEXIST,
+        FileSystemErrorKind::NotADirectory => ENOTDIR,
+        FileSystemErrorKind::IsADirectory => EISDIR,
+        FileSystemErrorKind::NotAFile => EISDIR,
+        FileSystemErrorKind::DirectoryNotEmpty => ENOTEMPTY,
+        FileSystemErrorKind::InvalidPath => EINVAL,
+        FileSystemErrorKind::InvalidOperation => EPERM,
+        FileSystemErrorKind::CrossDevice => EXDEV,
+        FileSystemErrorKind::NoSpace => ENOSPC,
+        FileSystemErrorKind::ReadOnly => EROFS,
+        FileSystemErrorKind::IoError => EIO,
+        FileSystemErrorKind::DeviceError => EIO,
+        FileSystemErrorKind::InvalidData => EINVAL,
+        FileSystemErrorKind::NotSupported => ENOSYS,
+        FileSystemErrorKind::BrokenFileSystem => EIO,
+        FileSystemErrorKind::Busy => EBUSY,
+    }
+}
+
+/// Convert any error to Linux errno, defaulting to EIO for unknown errors
+pub fn from_error<E>(_error: E) -> usize {
+    EIO // Generic I/O error for unknown error types
+}
+
+/// Convert errno to negative value as required by Linux system calls
+/// Linux system calls return negative errno values on error
+pub fn to_result(errno_val: usize) -> usize {
+    if errno_val == SUCCESS {
+        SUCCESS
+    } else {
+        // Convert positive errno to negative value
+        // Using two's complement: -errno = !errno + 1
+        // But in usize, we use wrapping_neg() which is equivalent to (usize::MAX - errno + 1)
+        errno_val.wrapping_neg()
+    }
+}

--- a/kernel/src/abi/linux/generic/fs.rs
+++ b/kernel/src/abi/linux/generic/fs.rs
@@ -1,0 +1,4665 @@
+use crate::{
+    abi::linux::generic::LinuxAbi,
+    arch::Trapframe,
+    device::manager::DeviceManager,
+    executor::TransparentExecutor,
+    fs::{DirectoryEntry, FileType, SeekFrom},
+    library::std::string::{
+        cstring_to_string, parse_c_string_from_userspace, parse_string_array_from_userspace,
+    },
+    object::capability::StreamError,
+    sched::scheduler::get_scheduler,
+    task::mytask,
+};
+use alloc::{
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use super::errno;
+
+static XORSHIFT_STATE: AtomicU64 = AtomicU64::new(0);
+
+/// Copy bytes from a kernel buffer into a userspace virtual address range,
+/// resolving each page independently via `translate_to_kva`.
+///
+/// Returns the number of bytes actually copied.
+fn copy_to_user_pagewise(
+    dst_user_vaddr: usize,
+    src: &[u8],
+    vm_manager: &crate::vm::manager::VirtualMemoryManager,
+) -> usize {
+    let src_len = src.len();
+    if src_len == 0 {
+        return 0;
+    }
+    let mut copied = 0usize;
+    let mut cur_user = dst_user_vaddr;
+    while copied < src_len {
+        let page_off = cur_user & (crate::environment::PAGE_SIZE - 1);
+        let chunk = core::cmp::min(crate::environment::PAGE_SIZE - page_off, src_len - copied);
+        match vm_manager.translate_to_kva(cur_user) {
+            Some(kva) => unsafe {
+                core::ptr::copy_nonoverlapping(
+                    src.as_ptr().wrapping_add(copied),
+                    kva as *mut u8,
+                    chunk,
+                );
+            },
+            None => break,
+        }
+        copied += chunk;
+        cur_user += chunk;
+    }
+    copied
+}
+
+/// Copy bytes from a userspace virtual address range into a kernel buffer,
+/// resolving each page independently via `translate_to_kva`.
+///
+/// Returns the number of bytes actually copied.
+fn copy_from_user_pagewise(
+    dst: &mut [u8],
+    src_user_vaddr: usize,
+    vm_manager: &crate::vm::manager::VirtualMemoryManager,
+) -> usize {
+    let dst_len = dst.len();
+    if dst_len == 0 {
+        return 0;
+    }
+    let mut copied = 0usize;
+    let mut cur_user = src_user_vaddr;
+    while copied < dst_len {
+        let page_off = cur_user & (crate::environment::PAGE_SIZE - 1);
+        let chunk = core::cmp::min(crate::environment::PAGE_SIZE - page_off, dst_len - copied);
+        match vm_manager.translate_to_kva(cur_user) {
+            Some(kva) => unsafe {
+                core::ptr::copy_nonoverlapping(
+                    kva as *const u8,
+                    dst.as_mut_ptr().wrapping_add(copied),
+                    chunk,
+                );
+            },
+            None => break,
+        }
+        copied += chunk;
+        cur_user += chunk;
+    }
+    copied
+}
+
+fn remap_shm_path(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("/dev/shm/") {
+        alloc::format!("/tmp/{}", rest)
+    } else if path == "/dev/shm" || path == "/dev/shm/" {
+        "/tmp".to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+fn is_wl_shm_path(path: &str) -> bool {
+    path.starts_with("/tmp/wl_shm-")
+}
+
+/// Linux stat structure
+/// Matches asm-generic struct stat layout used by musl on 64-bit.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct LinuxStat {
+    pub st_dev: u64,        // Device ID of device containing file
+    pub st_ino: u64,        // Inode number
+    pub st_mode: u32,       // File type and mode
+    pub st_nlink: u32,      // Number of hard links
+    pub st_uid: u32,        // User ID of owner
+    pub st_gid: u32,        // Group ID of owner
+    pub st_rdev: u64,       // Device ID (if special file)
+    pub __pad1: u64,        // Padding for alignment
+    pub st_size: i64,       // Total size, in bytes
+    pub st_blksize: i32,    // Block size for filesystem I/O
+    pub __pad2: i32,        // Padding for alignment
+    pub st_blocks: i64,     // Number of 512B blocks allocated
+    pub st_atime: i64,      // Time of last access (seconds)
+    pub st_atime_nsec: u64, // Time of last access (nanoseconds)
+    pub st_mtime: i64,      // Time of last modification (seconds)
+    pub st_mtime_nsec: u64, // Time of last modification (nanoseconds)
+    pub st_ctime: i64,      // Time of last status change (seconds)
+    pub st_ctime_nsec: u64, // Time of last status change (nanoseconds)
+    pub __unused4: u32,     // Reserved
+    pub __unused5: u32,     // Reserved
+}
+
+/// Linux statx timestamp structure
+#[derive(Debug, Clone, Copy, Default)]
+#[repr(C)]
+pub struct LinuxStatxTimestamp {
+    pub tv_sec: i64,
+    pub tv_nsec: u32,
+    pub __reserved: i32,
+}
+
+/// Linux statx structure (matches Linux UAPI layout)
+#[derive(Debug, Clone, Copy, Default)]
+#[repr(C)]
+pub struct LinuxStatx {
+    pub stx_mask: u32,
+    pub stx_blksize: u32,
+    pub stx_attributes: u64,
+    pub stx_nlink: u32,
+    pub stx_uid: u32,
+    pub stx_gid: u32,
+    pub stx_mode: u16,
+    pub __spare0: [u16; 1],
+    pub stx_ino: u64,
+    pub stx_size: u64,
+    pub stx_blocks: u64,
+    pub stx_attributes_mask: u64,
+    pub stx_atime: LinuxStatxTimestamp,
+    pub stx_btime: LinuxStatxTimestamp,
+    pub stx_ctime: LinuxStatxTimestamp,
+    pub stx_mtime: LinuxStatxTimestamp,
+    pub stx_rdev_major: u32,
+    pub stx_rdev_minor: u32,
+    pub stx_dev_major: u32,
+    pub stx_dev_minor: u32,
+    pub stx_mnt_id: u64,
+    pub stx_dio_mem_align: u32,
+    pub stx_dio_offset_align: u32,
+    pub stx_subvol: u64,
+    pub stx_atomic_write_unit_min: u32,
+    pub stx_atomic_write_unit_max: u32,
+    pub stx_atomic_write_segments_max: u32,
+    pub stx_dio_read_offset_align: u32,
+    pub __spare3: [u64; 9],
+}
+
+// Linux file type constants for st_mode field
+#[allow(dead_code)]
+pub const S_IFMT: u32 = 0o170000; // Bit mask for the file type bit field
+pub const S_IFSOCK: u32 = 0o140000; // Socket
+pub const S_IFLNK: u32 = 0o120000; // Symbolic link
+pub const S_IFREG: u32 = 0o100000; // Regular file
+pub const S_IFBLK: u32 = 0o060000; // Block device
+pub const S_IFDIR: u32 = 0o040000; // Directory
+pub const S_IFCHR: u32 = 0o020000; // Character device
+pub const S_IFIFO: u32 = 0o010000; // FIFO
+
+// Linux permission constants
+#[allow(dead_code)]
+pub const S_IRWXU: u32 = 0o0700; // User (file owner) has read, write, and execute permission
+pub const S_IRUSR: u32 = 0o0400; // User has read permission
+pub const S_IWUSR: u32 = 0o0200; // User has write permission
+pub const S_IXUSR: u32 = 0o0100; // User has execute permission
+#[allow(dead_code)]
+pub const S_IRWXG: u32 = 0o0070; // Group has read, write, and execute permission
+pub const S_IRGRP: u32 = 0o0040; // Group has read permission
+#[allow(dead_code)]
+pub const S_IWGRP: u32 = 0o0020; // Group has write permission
+pub const S_IXGRP: u32 = 0o0010; // Group has execute permission
+#[allow(dead_code)]
+pub const S_IRWXO: u32 = 0o0007; // Others have read, write, and execute permission
+pub const S_IROTH: u32 = 0o0004; // Others have read permission
+#[allow(dead_code)]
+pub const S_IWOTH: u32 = 0o0002; // Others have write permission
+pub const S_IXOTH: u32 = 0o0001; // Others have execute permission
+
+// Linux statx mask bits
+#[allow(dead_code)]
+pub const STATX_TYPE: u32 = 0x00000001;
+#[allow(dead_code)]
+pub const STATX_MODE: u32 = 0x00000002;
+#[allow(dead_code)]
+pub const STATX_NLINK: u32 = 0x00000004;
+#[allow(dead_code)]
+pub const STATX_UID: u32 = 0x00000008;
+#[allow(dead_code)]
+pub const STATX_GID: u32 = 0x00000010;
+#[allow(dead_code)]
+pub const STATX_ATIME: u32 = 0x00000020;
+#[allow(dead_code)]
+pub const STATX_MTIME: u32 = 0x00000040;
+#[allow(dead_code)]
+pub const STATX_CTIME: u32 = 0x00000080;
+#[allow(dead_code)]
+pub const STATX_INO: u32 = 0x00000100;
+#[allow(dead_code)]
+pub const STATX_SIZE: u32 = 0x00000200;
+#[allow(dead_code)]
+pub const STATX_BLOCKS: u32 = 0x00000400;
+pub const STATX_BASIC_STATS: u32 = 0x000007ff;
+#[allow(dead_code)]
+pub const STATX_BTIME: u32 = 0x00000800;
+
+// Linux getrandom flags
+#[allow(dead_code)]
+pub const GRND_NONBLOCK: u32 = 0x0001;
+#[allow(dead_code)]
+pub const GRND_RANDOM: u32 = 0x0002;
+#[allow(dead_code)]
+pub const GRND_INSECURE: u32 = 0x0004;
+
+// Linux fcntl command constants
+pub const F_DUPFD: u32 = 0; // Duplicate file descriptor
+pub const F_GETFD: u32 = 1; // Get file descriptor flags
+pub const F_SETFD: u32 = 2; // Set file descriptor flags
+pub const F_GETFL: u32 = 3; // Get file status flags
+pub const F_SETFL: u32 = 4; // Set file status flags
+pub const F_GETLK: u32 = 5; // Get record locking information
+pub const F_SETLK: u32 = 6; // Set record lock (non-blocking)
+pub const F_SETLKW: u32 = 7; // Set record lock (blocking)
+pub const F_SETOWN: u32 = 8; // Set owner (process receiving SIGIO/SIGURG)
+pub const F_GETOWN: u32 = 9; // Get owner (process receiving SIGIO/SIGURG)
+pub const F_SETSIG: u32 = 10; // Set signal sent when I/O is possible
+pub const F_GETSIG: u32 = 11; // Get signal sent when I/O is possible
+pub const F_SETLEASE: u32 = 1024; // Set a lease
+pub const F_GETLEASE: u32 = 1025; // Get current lease
+pub const F_NOTIFY: u32 = 1026; // Request notifications on a directory
+pub const F_DUPFD_CLOEXEC: u32 = 1030; // Duplicate with close-on-exec
+
+// Linux file descriptor flags
+pub const FD_CLOEXEC: u32 = 1; // Close-on-exec flag
+
+// Linux open flags
+#[allow(dead_code)]
+pub const O_RDONLY: i32 = 0o0; // Read only
+#[allow(dead_code)]
+pub const O_WRONLY: i32 = 0o1; // Write only
+#[allow(dead_code)]
+pub const O_RDWR: i32 = 0o2; // Read and write
+pub const O_CREAT: i32 = 0o100; // Create file if it doesn't exist
+pub const O_EXCL: i32 = 0o200; // Fail if file exists (with O_CREAT)
+#[allow(dead_code)]
+pub const O_NOCTTY: i32 = 0o400; // Don't assign controlling terminal
+pub const O_TRUNC: i32 = 0o1000; // Truncate file to zero length
+pub const O_APPEND: i32 = 0o2000; // Append mode
+#[allow(dead_code)]
+pub const O_NONBLOCK: i32 = 0o4000; // Non-blocking mode
+#[allow(dead_code)]
+pub const O_DSYNC: i32 = 0o10000; // Data sync
+#[allow(dead_code)]
+pub const O_ASYNC: i32 = 0o20000; // Asynchronous I/O
+#[allow(dead_code)]
+pub const O_DIRECT: i32 = 0o40000; // Direct I/O
+#[allow(dead_code)]
+pub const O_LARGEFILE: i32 = 0o100000; // Large file support
+pub const O_DIRECTORY: i32 = 0o200000; // Must be a directory
+#[allow(dead_code)]
+pub const O_NOFOLLOW: i32 = 0o400000; // Don't follow symlinks
+#[allow(dead_code)]
+pub const O_NOATIME: i32 = 0o1000000; // Don't update access time
+pub const O_CLOEXEC: i32 = 0o2000000; // Close-on-exec
+#[allow(dead_code)]
+pub const O_SYNC: i32 = O_DSYNC; // Data and metadata sync
+#[allow(dead_code)]
+pub const O_PATH: i32 = 0o10000000; // Path-based operations only
+#[allow(dead_code)]
+pub const O_TMPFILE: i32 = 0o20000000; // Create temporary file
+
+use crate::device::DeviceCapability;
+
+impl LinuxStat {
+    /// Create a new LinuxStat from Scarlet FileMetadata
+    pub fn from_metadata(metadata: &crate::fs::FileMetadata) -> Self {
+        let st_mode = match metadata.file_type {
+            FileType::RegularFile => S_IFREG,
+            FileType::Directory => S_IFDIR,
+            FileType::CharDevice(_) => S_IFCHR,
+            FileType::BlockDevice(_) => S_IFBLK,
+            FileType::SymbolicLink(_) => S_IFLNK,
+            FileType::Pipe => S_IFIFO,
+            FileType::Socket(_) => S_IFSOCK,
+            FileType::Unknown => S_IFREG, // Default to regular file
+        } | if metadata.permissions.read {
+            S_IRUSR | S_IRGRP | S_IXGRP | S_IROTH
+        } else {
+            0
+        } | if metadata.permissions.write {
+            S_IWUSR
+        } else {
+            0
+        } | if metadata.permissions.execute {
+            S_IXUSR | S_IXGRP | S_IXOTH
+        } else {
+            0
+        };
+
+        Self {
+            st_dev: 0, // Virtual device ID
+            st_ino: metadata.file_id,
+            st_mode,
+            st_nlink: metadata.link_count as u32,
+            st_uid: 0,  // Root user
+            st_gid: 0,  // Root group
+            st_rdev: 0, // Not a special file by default
+            __pad1: 0,
+            st_size: metadata.size as i64,
+            st_blksize: 4096, // Standard block size
+            __pad2: 0,
+            st_blocks: ((metadata.size + 511) / 512) as i64, // Number of 512-byte blocks
+            st_atime: metadata.accessed_time as i64,
+            st_atime_nsec: 0,
+            st_mtime: metadata.modified_time as i64,
+            st_mtime_nsec: 0,
+            st_ctime: metadata.created_time as i64,
+            st_ctime_nsec: 0,
+            __unused4: 0,
+            __unused5: 0,
+        }
+    }
+}
+
+fn statx_timestamp_from_secs(seconds: u64) -> LinuxStatxTimestamp {
+    LinuxStatxTimestamp {
+        tv_sec: seconds as i64,
+        tv_nsec: 0,
+        __reserved: 0,
+    }
+}
+
+fn next_pseudo_random_u64() -> u64 {
+    loop {
+        let mut state = XORSHIFT_STATE.load(Ordering::Relaxed);
+        if state == 0 {
+            state = crate::time::current_time() ^ 0x9e3779b97f4a7c15;
+            if state == 0 {
+                state = 0x4f1bbcdcb7a43413;
+            }
+        }
+        let mut x = state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        if XORSHIFT_STATE
+            .compare_exchange(state, x, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return x;
+        }
+    }
+}
+
+fn fill_pseudo_random(buffer: &mut [u8]) {
+    let mut offset = 0;
+    while offset < buffer.len() {
+        let bytes = next_pseudo_random_u64().to_le_bytes();
+        let to_copy = core::cmp::min(bytes.len(), buffer.len() - offset);
+        buffer[offset..offset + to_copy].copy_from_slice(&bytes[..to_copy]);
+        offset += to_copy;
+    }
+}
+
+fn fill_statx_from_stat(
+    statx: &mut LinuxStatx,
+    stat: &LinuxStat,
+    created_time: u64,
+    requested_mask: u32,
+) {
+    let supported_mask = STATX_BASIC_STATS | STATX_BTIME;
+    let effective_mask = if requested_mask == 0 {
+        STATX_BASIC_STATS
+    } else {
+        requested_mask
+    };
+
+    statx.stx_mask = supported_mask & effective_mask;
+    statx.stx_blksize = stat.st_blksize as u32;
+    statx.stx_attributes = 0;
+    statx.stx_nlink = stat.st_nlink;
+    statx.stx_uid = stat.st_uid;
+    statx.stx_gid = stat.st_gid;
+    statx.stx_mode = stat.st_mode as u16;
+    statx.__spare0 = [0; 1];
+    statx.stx_ino = stat.st_ino;
+    statx.stx_size = stat.st_size as u64;
+    statx.stx_blocks = stat.st_blocks as u64;
+    statx.stx_attributes_mask = 0;
+    statx.stx_atime = statx_timestamp_from_secs(stat.st_atime as u64);
+    statx.stx_btime = statx_timestamp_from_secs(created_time);
+    statx.stx_ctime = statx_timestamp_from_secs(stat.st_ctime as u64);
+    statx.stx_mtime = statx_timestamp_from_secs(stat.st_mtime as u64);
+    statx.stx_rdev_major = 0;
+    statx.stx_rdev_minor = 0;
+    statx.stx_dev_major = 0;
+    statx.stx_dev_minor = 0;
+    statx.stx_mnt_id = 0;
+    statx.stx_dio_mem_align = 0;
+    statx.stx_dio_offset_align = 0;
+    statx.stx_subvol = 0;
+    statx.stx_atomic_write_unit_min = 0;
+    statx.stx_atomic_write_unit_max = 0;
+    statx.stx_atomic_write_segments_max = 0;
+    statx.stx_dio_read_offset_align = 0;
+    statx.__spare3 = [0; 9];
+}
+
+// /// Convert Scarlet DirectoryEntry to Linux Dirent and write to buffer
+// fn read_directory_as_Linux_dirent(buf_ptr: *mut u8, count: usize, buffer_data: &[u8]) -> usize {
+//     if count < Dirent::DIRENT_SIZE {
+//         return 0; // Buffer too small for even one entry
+//     }
+
+//     // Parse DirectoryEntry from buffer data
+//     if let Some(dir_entry) = DirectoryEntry::parse(buffer_data) {
+//         // Convert Scarlet DirectoryEntry to Linux Dirent
+//         let inum = (dir_entry.file_id & 0xFFFF) as u16; // Use lower 16 bits as inode number
+//         let name = dir_entry.name_str().unwrap_or("");
+
+//         let Linux_dirent = Dirent::new(inum, name);
+
+//         // Check if we have enough space
+//         if count >= Dirent::DIRENT_SIZE {
+//             // Copy the dirent to the buffer
+//             let dirent_bytes = Linux_dirent.as_bytes();
+//             unsafe {
+//                 core::ptr::copy_nonoverlapping(
+//                     dirent_bytes.as_ptr(),
+//                     buf_ptr,
+//                     Dirent::DIRENT_SIZE
+//                 );
+//             }
+//             return Dirent::DIRENT_SIZE;
+//         }
+//     }
+
+//     0 // No data or error
+// }
+
+const MAX_PATH_LENGTH: usize = 1024; // Increased to handle long command lines
+const MAX_ARG_COUNT: usize = 64;
+
+/// Linux sys_exec system call implementation
+/// Executes a program specified by the given path, replacing the current process image with a new one.
+/// Also allows passing arguments and environment variables to the new program.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+#[allow(dead_code)]
+pub fn sys_exec(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+
+    // Increment PC to avoid infinite loop if execve fails
+    trapframe.increment_pc_next(task);
+
+    // Get arguments from trapframe
+    let path_ptr = trapframe.get_arg(0);
+    let argv_ptr = trapframe.get_arg(1);
+
+    // Parse path
+    let path_str = match parse_c_string_from_userspace(task, path_ptr, MAX_PATH_LENGTH) {
+        Ok(path) => match to_absolute_path_v2(&task, &path) {
+            Ok(abs_path) => abs_path,
+            Err(_) => return usize::MAX, // Path error
+        },
+        Err(_) => return usize::MAX, // Path parsing error
+    };
+
+    // Parse argv and envp
+    let argv_strings =
+        match parse_string_array_from_userspace(task, argv_ptr, MAX_ARG_COUNT, MAX_PATH_LENGTH) {
+            Ok(args) => args,
+            Err(_) => return usize::MAX, // argv parsing error
+        };
+
+    // Convert Vec<String> to Vec<&str> for TransparentExecutor
+    let argv_refs: Vec<&str> = argv_strings.iter().map(|s| s.as_str()).collect();
+
+    // Use TransparentExecutor for cross-ABI execution
+    match TransparentExecutor::execute_binary(&path_str, &argv_refs, &[], task, trapframe, false) {
+        Ok(_) => {
+            // execve normally should not return on success - the process is replaced
+            // However, if ABI module sets trapframe return value and returns here,
+            // we should respect that value instead of hardcoding 0
+            trapframe.get_return_value()
+        }
+        Err(_) => {
+            // Execution failed - return error code
+            // The trap handler will automatically set trapframe return value from our return
+            usize::MAX // Error return value
+        }
+    }
+}
+
+#[repr(i32)]
+#[allow(dead_code)]
+enum OpenMode {
+    ReadOnly = 0x000,
+    WriteOnly = 0x001,
+    ReadWrite = 0x002,
+    Create = 0x200,
+    Truncate = 0x400,
+}
+
+/// Linux sys_openat implementation for Scarlet VFS v2
+///
+/// Opens a file relative to a directory file descriptor (dirfd) and path.
+/// If dirfd == AT_FDCWD, uses the current working directory as the base.
+/// Otherwise, resolves the base directory from the file descriptor.
+/// Uses VfsManager::open_relative for safe and efficient path resolution.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///
+/// Returns:
+/// - File descriptor on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_openat(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let dirfd = trapframe.get_arg(0) as i32;
+    let path_ptr = task
+        .vm_manager
+        .translate_to_kva(trapframe.get_arg(1))
+        .unwrap() as *const u8;
+    let flags = trapframe.get_arg(2) as i32;
+
+    // Increment PC to avoid infinite loop if openat fails
+    trapframe.increment_pc_next(task);
+
+    // Parse path from user space
+    let path_str = match cstring_to_string(path_ptr, MAX_PATH_LENGTH) {
+        Ok((path, _)) => path,
+        Err(_) => return errno::to_result(errno::EFAULT), // Invalid UTF-8 or bad address
+    };
+
+    let path_str = remap_shm_path(&path_str);
+
+    // crate::println!("sys_openat: epc={:#x}, dirfd={}, path='{}', flags={:#o}", trapframe.epc, dirfd, path_str, flags);
+
+    let vfs_guard = task.vfs.read();
+    let vfs = vfs_guard.as_deref().unwrap();
+
+    // Determine base directory (entry and mount) for path resolution
+    use crate::fs::vfs_v2::core::VfsFileObject;
+
+    const AT_FDCWD: i32 = -100;
+    let (base_entry, base_mount) = if dirfd == AT_FDCWD {
+        // Use current working directory as base
+        vfs.get_cwd().unwrap_or_else(|| {
+            let root_mount = vfs.mount_tree.root_mount.read().clone();
+            (root_mount.root.clone(), root_mount)
+        })
+    } else {
+        // Use directory file descriptor as base
+        let handle = match abi.get_handle(dirfd as usize) {
+            Some(h) => h,
+            None => return errno::to_result(errno::EBADF), // Bad file descriptor
+        };
+        let kernel_obj = match task.handle_table.get(handle) {
+            Some(obj) => obj,
+            None => return errno::to_result(errno::EBADF), // Bad file descriptor
+        };
+        let file_obj = match kernel_obj.as_file() {
+            Some(f) => f,
+            None => return errno::to_result(errno::ENOTDIR), // Not a directory
+        };
+        let vfs_file_obj = file_obj
+            .as_any()
+            .downcast_ref::<VfsFileObject>()
+            .ok_or(())
+            .unwrap();
+        (
+            vfs_file_obj.get_vfs_entry().clone(),
+            vfs_file_obj.get_mount_point().clone(),
+        )
+    };
+
+    // Open the file using VfsManager::open_relative
+    // Apply a few Linux-compat path translations for devices
+    let mapped_path = if path_str == "/dev/tty" {
+        "/dev/tty0".to_string()
+    } else if let Some(rest) = path_str.strip_prefix("/dev/vc/") {
+        // Map /dev/vc/N -> /dev/ttyN; if ttyN doesn't exist, we may further alias below
+        alloc::format!("/dev/tty{}", rest)
+    } else if let Some(n) = path_str.strip_prefix("/dev/tty") {
+        // If requesting a numbered tty other than 0, alias to tty0 for minimal support
+        // This is a compatibility shim until multiple VTs are implemented
+        if n != "0" && n.chars().all(|c| c.is_ascii_digit()) {
+            "/dev/tty0".to_string()
+        } else {
+            path_str.clone()
+        }
+    } else {
+        path_str.clone()
+    };
+
+    // crate::println!("sys_openat: attempting to open '{}' with flags {:#o} (dirfd={})", mapped_path, flags, dirfd);
+
+    // // Log flags details
+    // let flags_table = [
+    //     (O_RDONLY, "O_RDONLY"),
+    //     (O_WRONLY, "O_WRONLY"),
+    //     (O_RDWR, "O_RDWR"),
+    //     (O_CREAT, "O_CREAT"),
+    //     (O_EXCL, "O_EXCL"),
+    //     (O_TRUNC, "O_TRUNC"),
+    //     (O_APPEND, "O_APPEND"),
+    //     (O_DIRECTORY, "O_DIRECTORY"),
+    //     (O_CLOEXEC, "O_CLOEXEC"),
+    // ];
+    // for (flag, name) in flags_table.iter() {
+    //     if (flags & *flag) != 0 {
+    //         crate::println!("  Flag set: {}", name);
+    //     }
+    // }
+
+    let file = vfs.open_from(&base_entry, &base_mount, &mapped_path, flags as u32);
+
+    let kernel_obj = match file {
+        Ok(obj) => {
+            // crate::println!("sys_openat: successfully opened '{}'", mapped_path);
+            obj
+        }
+        Err(e) => {
+            // crate::println!("sys_openat: failed to open '{}' -> {:?}", mapped_path, e);
+            // If open failed and O_CREAT flag is set, try to create the file
+            if flags & O_CREAT != 0 {
+                // crate::println!("sys_openat: O_CREAT flag set, attempting to create file '{}'", path_str);
+                // Build absolute path for file creation before getting mutable VFS reference
+                let absolute_path = if mapped_path.starts_with('/') {
+                    mapped_path.to_string()
+                } else {
+                    // Construct absolute path by resolving relative to current working directory
+                    match to_absolute_path_v2(&task, &mapped_path) {
+                        Ok(p) => p,
+                        Err(_) => return errno::to_result(errno::ENOENT), // Path resolution failed
+                    }
+                };
+
+                // Get mutable VFS reference for file creation
+                let vfs_mut = match task.vfs.read().clone() {
+                    Some(v) => v,
+                    None => return errno::to_result(errno::EIO), // VFS not available
+                };
+
+                // Create the file (regular file type)
+                match vfs_mut.create_file(&absolute_path, FileType::RegularFile) {
+                    Ok(_) => {
+                        // File created successfully, now try to open it
+                        // Get immutable VFS reference again for opening
+                        let vfs_guard = task.vfs.read();
+                        let vfs = vfs_guard.as_deref().unwrap();
+                        match vfs.open_from(&base_entry, &base_mount, &mapped_path, flags as u32) {
+                            Ok(obj) => obj,
+                            Err(err) => return errno::to_result(errno::from_fs_error(&err)),
+                        }
+                    }
+                    Err(create_err) => {
+                        // Check if file already exists and O_EXCL is set
+                        if flags & O_EXCL != 0
+                            && create_err.kind == crate::fs::FileSystemErrorKind::AlreadyExists
+                        {
+                            return errno::to_result(errno::EEXIST); // File exists and O_EXCL is set
+                        }
+                        // Try to open the existing file
+                        let vfs_guard = task.vfs.read();
+                        let vfs = vfs_guard.as_deref().unwrap();
+                        let reopen_flags = (flags as u32) & !((O_CREAT | O_EXCL) as u32);
+                        match vfs.open_from(&base_entry, &base_mount, &mapped_path, reopen_flags) {
+                            Ok(obj) => obj,
+                            Err(open_err) => {
+                                return errno::to_result(errno::from_fs_error(&open_err));
+                            }
+                        }
+                    }
+                }
+            } else {
+                return errno::to_result(errno::from_fs_error(&e)); // Return appropriate error based on VFS error
+            }
+        }
+    };
+
+    // Post-open flag handling (O_DIRECTORY, O_TRUNC, O_APPEND)
+    if let Some(file_obj) = kernel_obj.as_file() {
+        if (flags & O_DIRECTORY) != 0 {
+            if let Ok(meta) = file_obj.metadata() {
+                if !matches!(meta.file_type, FileType::Directory) {
+                    return errno::to_result(errno::ENOTDIR);
+                }
+            }
+        }
+        if (flags & O_TRUNC) != 0 {
+            let _ = file_obj.truncate(0);
+        }
+        if (flags & O_APPEND) != 0 {
+            let _ = file_obj.seek(SeekFrom::End(0));
+        }
+    }
+
+    // Register the file with the task using HandleTable
+    let handle = task.handle_table.insert(kernel_obj);
+    match handle {
+        Ok(handle) => {
+            match abi.allocate_fd(handle as u32) {
+                Ok(fd) => {
+                    // crate::println!("sys_openat: allocated fd {} for '{}'", fd, path_str);
+                    // Initialize file status flags (e.g., O_NONBLOCK) from open flags
+                    let mut status_flags: u32 = 0;
+                    if (flags & O_NONBLOCK) != 0 {
+                        status_flags |= O_NONBLOCK as u32;
+                    }
+                    let _ = abi.set_file_status_flags(fd, status_flags);
+
+                    // Propagate non-blocking to the underlying object Selectable if available
+                    if let Some(obj) = task.handle_table.get(handle) {
+                        if let Some(sel) = obj.as_selectable() {
+                            sel.set_nonblocking(((status_flags as i32) & O_NONBLOCK) != 0);
+                        }
+                    }
+                    fd
+                }
+                Err(_) => errno::to_result(errno::EMFILE), // Too many open files
+            }
+        }
+        Err(_) => errno::to_result(errno::ENFILE), // Handle table full
+    }
+}
+
+pub fn sys_dup(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    trapframe.increment_pc_next(task);
+
+    // Get handle from Linux fd
+    if let Some(old_handle) = abi.get_handle(fd) {
+        // Use clone_for_dup to get proper dup() semantics (increments Pipe reader/writer counts etc.)
+        if let Some(kernel_obj) = task.handle_table.clone_for_dup(old_handle) {
+            let handle = task.handle_table.insert(kernel_obj);
+            match handle {
+                Ok(new_handle) => {
+                    match abi.allocate_fd(new_handle as u32) {
+                        Ok(fd) => fd,
+                        Err(_) => errno::to_result(errno::EMFILE), // Too many open files
+                    }
+                }
+                Err(_) => errno::to_result(errno::ENFILE), // Handle table full
+            }
+        } else {
+            errno::to_result(errno::EBADF) // Handle not found in handle table
+        }
+    } else {
+        errno::to_result(errno::EBADF) // Invalid file descriptor
+    }
+}
+
+pub fn sys_dup3(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let oldfd = trapframe.get_arg(0) as usize;
+    let newfd = trapframe.get_arg(1) as usize;
+    let flags = trapframe.get_arg(2) as u32;
+    trapframe.increment_pc_next(task);
+
+    // dup3 does not allow oldfd and newfd to be the same
+    if oldfd == newfd {
+        return usize::MAX; // EINVAL
+    }
+
+    // Only O_CLOEXEC flag is valid for dup3
+    if flags != 0 && flags != (O_CLOEXEC as u32) {
+        return usize::MAX; // EINVAL
+    }
+
+    // Get handle from old fd
+    if let Some(old_handle) = abi.get_handle(oldfd) {
+        // Use clone_for_dup to get proper dup() semantics (increments Pipe reader/writer counts etc.)
+        if let Some(kernel_obj) = task.handle_table.clone_for_dup(old_handle) {
+            let handle = task.handle_table.insert(kernel_obj);
+            match handle {
+                Ok(new_handle) => {
+                    // Close newfd if it's already open
+                    if abi.get_handle(newfd).is_some() {
+                        if let Some(old_new_handle) = abi.remove_fd(newfd) {
+                            let _ = task.handle_table.remove(old_new_handle);
+                        }
+                    }
+
+                    // Allocate specific fd
+                    match abi.allocate_specific_fd(newfd, new_handle as u32) {
+                        Ok(()) => {
+                            // Set flags if O_CLOEXEC is specified
+                            if flags & (O_CLOEXEC as u32) != 0 {
+                                let _ = abi.set_fd_flags(newfd, FD_CLOEXEC);
+                            }
+                            newfd
+                        }
+                        Err(_) => usize::MAX, // Cannot allocate specific fd
+                    }
+                }
+                Err(_) => usize::MAX, // Handle table full
+            }
+        } else {
+            usize::MAX // Handle not found in handle table
+        }
+    } else {
+        usize::MAX // Invalid old file descriptor
+    }
+}
+
+pub fn sys_close(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    trapframe.increment_pc_next(task);
+
+    // Get handle from Linux fd and remove mapping
+    if let Some(handle) = abi.remove_fd(fd) {
+        if task.handle_table.remove(handle).is_some() {
+            0 // Success
+        } else {
+            usize::MAX // Handle not found in handle table
+        }
+    } else {
+        usize::MAX // Invalid file descriptor
+    }
+}
+
+pub fn sys_read(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let user_buf = trapframe.get_arg(1);
+    let count = trapframe.get_arg(2) as usize;
+
+    // Get handle from Linux fd
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => {
+            trapframe.increment_pc_next(task);
+            return usize::MAX;
+        }
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => {
+            trapframe.increment_pc_next(task);
+            return usize::MAX;
+        }
+    };
+
+    // Determine non-blocking mode
+    let nonblocking = abi
+        .get_file_status_flags(fd)
+        .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+        .unwrap_or(false);
+
+    // Check if this is a directory by getting file metadata
+    let is_directory = if let Some(file_obj) = kernel_obj.as_file() {
+        if let Ok(metadata) = file_obj.metadata() {
+            matches!(metadata.file_type, FileType::Directory)
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    let stream = match kernel_obj.as_stream() {
+        Some(stream) => stream,
+        None => {
+            trapframe.increment_pc_next(task);
+            return usize::MAX;
+        }
+    };
+
+    if is_directory {
+        trapframe.increment_pc_next(task);
+        return usize::MAX;
+    }
+
+    // Fast path: buffer fits within a single page
+    let page_offset = user_buf & (crate::environment::PAGE_SIZE - 1);
+    if page_offset + count <= crate::environment::PAGE_SIZE {
+        let buf_ptr = match task.vm_manager.translate_to_kva(user_buf) {
+            Some(kva) => kva as *mut u8,
+            None => {
+                trapframe.increment_pc_next(task);
+                return usize::MAX;
+            }
+        };
+        let mut buffer = unsafe { core::slice::from_raw_parts_mut(buf_ptr, count) };
+        match stream.read(&mut buffer) {
+            Ok(n) => {
+                trapframe.increment_pc_next(task);
+                n
+            }
+            Err(e) => {
+                trapframe.increment_pc_next(task);
+                match e {
+                    StreamError::EndOfStream => 0,
+                    StreamError::WouldBlock => {
+                        if nonblocking {
+                            return errno::to_result(errno::EAGAIN);
+                        } else {
+                            get_scheduler().schedule(trapframe);
+                            usize::MAX
+                        }
+                    }
+                    _ => usize::MAX,
+                }
+            }
+        }
+    } else {
+        // Multi-page path: read in PAGE_SIZE chunks via kernel stack buffer
+        let mut page_buf = [0u8; crate::environment::PAGE_SIZE];
+        let mut total_read = 0usize;
+        let mut remaining = count;
+        let mut cur_user = user_buf;
+
+        while remaining > 0 {
+            let page_off = cur_user & (crate::environment::PAGE_SIZE - 1);
+            let chunk_size = core::cmp::min(crate::environment::PAGE_SIZE - page_off, remaining);
+            let mut chunk_buf = &mut page_buf[..chunk_size];
+
+            let n = match stream.read(&mut chunk_buf) {
+                Ok(n) => n,
+                Err(StreamError::EndOfStream) => break,
+                Err(StreamError::WouldBlock) => {
+                    if nonblocking {
+                        if total_read > 0 {
+                            break;
+                        }
+                        trapframe.increment_pc_next(task);
+                        return errno::to_result(errno::EAGAIN);
+                    } else {
+                        break;
+                    }
+                }
+                Err(_) => {
+                    if total_read == 0 {
+                        trapframe.increment_pc_next(task);
+                        return usize::MAX;
+                    }
+                    break;
+                }
+            };
+
+            if n == 0 {
+                break;
+            }
+
+            let copied = copy_to_user_pagewise(cur_user, &page_buf[..n], &task.vm_manager);
+            if copied != n {
+                break;
+            }
+
+            total_read += n;
+            remaining -= n;
+            cur_user += n;
+        }
+
+        trapframe.increment_pc_next(task);
+        total_read
+    }
+}
+
+pub fn sys_write(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let user_buf = trapframe.get_arg(1);
+    let count = trapframe.get_arg(2) as usize;
+
+    trapframe.increment_pc_next(task);
+
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => return usize::MAX,
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return usize::MAX,
+    };
+
+    let stream = match kernel_obj.as_stream() {
+        Some(stream) => stream,
+        None => return usize::MAX,
+    };
+
+    let nonblocking = abi
+        .get_file_status_flags(fd)
+        .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+        .unwrap_or(false);
+
+    // Fast path: buffer fits within a single page
+    let page_offset = user_buf & (crate::environment::PAGE_SIZE - 1);
+    if page_offset + count <= crate::environment::PAGE_SIZE {
+        let buf_ptr = match task.vm_manager.translate_to_kva(user_buf) {
+            Some(kva) => kva as *const u8,
+            None => return usize::MAX,
+        };
+        let buffer = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
+        match stream.write(buffer) {
+            Ok(n) => n,
+            Err(StreamError::WouldBlock) => {
+                if nonblocking {
+                    return errno::to_result(errno::EAGAIN);
+                } else {
+                    get_scheduler().schedule(trapframe);
+                    usize::MAX
+                }
+            }
+            Err(_) => usize::MAX,
+        }
+    } else {
+        // Multi-page path: copy from userspace page-by-page into kernel buffer
+        let mut page_buf = [0u8; crate::environment::PAGE_SIZE];
+        let mut total_written = 0usize;
+        let mut remaining = count;
+        let mut cur_user = user_buf;
+
+        while remaining > 0 {
+            let page_off = cur_user & (crate::environment::PAGE_SIZE - 1);
+            let chunk_size = core::cmp::min(crate::environment::PAGE_SIZE - page_off, remaining);
+
+            let copied =
+                copy_from_user_pagewise(&mut page_buf[..chunk_size], cur_user, &task.vm_manager);
+            if copied != chunk_size {
+                break;
+            }
+
+            let n = match stream.write(&page_buf[..chunk_size]) {
+                Ok(n) => n,
+                Err(StreamError::WouldBlock) => {
+                    if nonblocking && total_written == 0 {
+                        return errno::to_result(errno::EAGAIN);
+                    }
+                    break;
+                }
+                Err(_) => {
+                    if total_written == 0 {
+                        return usize::MAX;
+                    }
+                    break;
+                }
+            };
+
+            total_written += n;
+            remaining -= n;
+            cur_user += n;
+        }
+
+        total_written
+    }
+}
+
+pub fn sys_pread64(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let buf_addr = trapframe.get_arg(1);
+    let count = trapframe.get_arg(2) as usize;
+    let position = trapframe.get_arg(3) as i64;
+
+    if position < 0 {
+        trapframe.increment_pc_next(task);
+        return errno::to_result(errno::EINVAL);
+    }
+
+    if count == 0 {
+        trapframe.increment_pc_next(task);
+        return 0;
+    }
+
+    let buf_ptr = match task.vm_manager.translate_to_kva(buf_addr) {
+        Some(ptr) => ptr as *mut u8,
+        None => {
+            trapframe.increment_pc_next(task);
+            return errno::to_result(errno::EFAULT);
+        }
+    };
+
+    if buf_ptr.is_null() {
+        trapframe.increment_pc_next(task);
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => {
+            trapframe.increment_pc_next(task);
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => {
+            trapframe.increment_pc_next(task);
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let file = match kernel_obj.as_file() {
+        Some(file) => file,
+        None => {
+            trapframe.increment_pc_next(task);
+            if kernel_obj.as_stream().is_some() {
+                return errno::to_result(errno::ESPIPE);
+            }
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let mut buffer = unsafe { core::slice::from_raw_parts_mut(buf_ptr, count) };
+
+    let nonblocking = abi
+        .get_file_status_flags(fd)
+        .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+        .unwrap_or(false);
+
+    match file.read_at(position as u64, &mut buffer) {
+        Ok(n) => {
+            trapframe.increment_pc_next(task);
+            n
+        }
+        Err(StreamError::EndOfStream) => {
+            trapframe.increment_pc_next(task);
+            0
+        }
+        Err(StreamError::WouldBlock) => {
+            if nonblocking {
+                trapframe.increment_pc_next(task);
+                errno::to_result(errno::EAGAIN)
+            } else {
+                get_scheduler().schedule(trapframe);
+                usize::MAX
+            }
+        }
+        Err(err) => {
+            trapframe.increment_pc_next(task);
+            errno::to_result(stream_error_to_errno(err))
+        }
+    }
+}
+
+pub fn sys_pwrite64(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let buf_addr = trapframe.get_arg(1);
+    let count = trapframe.get_arg(2) as usize;
+    let position = trapframe.get_arg(3) as i64;
+
+    if position < 0 {
+        trapframe.increment_pc_next(task);
+        return errno::to_result(errno::EINVAL);
+    }
+
+    if count == 0 {
+        trapframe.increment_pc_next(task);
+        return 0;
+    }
+
+    let buf_ptr = match task.vm_manager.translate_to_kva(buf_addr) {
+        Some(ptr) => ptr as *const u8,
+        None => {
+            trapframe.increment_pc_next(task);
+            return errno::to_result(errno::EFAULT);
+        }
+    };
+
+    if buf_ptr.is_null() {
+        trapframe.increment_pc_next(task);
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => {
+            trapframe.increment_pc_next(task);
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => {
+            trapframe.increment_pc_next(task);
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let file = match kernel_obj.as_file() {
+        Some(file) => file,
+        None => {
+            trapframe.increment_pc_next(task);
+            if kernel_obj.as_stream().is_some() {
+                return errno::to_result(errno::ESPIPE);
+            }
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let buffer = unsafe { core::slice::from_raw_parts(buf_ptr, count) };
+
+    let nonblocking = abi
+        .get_file_status_flags(fd)
+        .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+        .unwrap_or(false);
+
+    match file.write_at(position as u64, buffer) {
+        Ok(n) => {
+            trapframe.increment_pc_next(task);
+            n
+        }
+        Err(StreamError::WouldBlock) => {
+            if nonblocking {
+                trapframe.increment_pc_next(task);
+                errno::to_result(errno::EAGAIN)
+            } else {
+                get_scheduler().schedule(trapframe);
+                usize::MAX
+            }
+        }
+        Err(err) => {
+            trapframe.increment_pc_next(task);
+            errno::to_result(stream_error_to_errno(err))
+        }
+    }
+}
+
+fn stream_error_to_errno(err: StreamError) -> usize {
+    match err {
+        StreamError::EndOfStream => errno::SUCCESS,
+        StreamError::WouldBlock => errno::EAGAIN,
+        StreamError::IoError => errno::EIO,
+        StreamError::Closed => errno::EBADF,
+        StreamError::InvalidArgument => errno::EINVAL,
+        StreamError::Interrupted => errno::EINTR,
+        StreamError::PermissionDenied => errno::EACCES,
+        StreamError::DeviceError => errno::EIO,
+        StreamError::NotSupported | StreamError::SeekError => errno::ESPIPE,
+        StreamError::NoSpace => errno::ENOSPC,
+        StreamError::BrokenPipe => errno::EPIPE,
+        StreamError::FileSystemError(fs_err) => errno::from_fs_error(&fs_err),
+        StreamError::Other(_) => errno::EIO,
+    }
+}
+
+/// Linux writev system call implementation
+///
+/// This system call writes data from multiple buffers (I/O vectors) to a file descriptor.
+/// It provides scatter-gather I/O functionality, allowing efficient writes from multiple
+/// non-contiguous memory regions in a single system call.
+///
+/// # Arguments
+/// - fd: File descriptor
+/// - iovec: Array of iovec structures describing the buffers
+/// - iovcnt: Number of iovec structures in the array
+///
+/// # Returns
+/// - Number of bytes written on success
+/// - usize::MAX on error
+pub fn sys_writev(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let iovec_ptr = trapframe.get_arg(1);
+    let iovcnt = trapframe.get_arg(2) as usize;
+
+    // Increment PC to avoid infinite loop if writev fails
+    trapframe.increment_pc_next(task);
+
+    // Validate parameters
+    if iovcnt == 0 {
+        return 0; // Nothing to write
+    }
+
+    // Linux typically limits iovcnt to prevent resource exhaustion
+    const IOV_MAX: usize = 1024;
+    if iovcnt > IOV_MAX {
+        return usize::MAX; // Too many vectors
+    }
+
+    // Get handle from Linux fd
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => return usize::MAX, // Invalid file descriptor
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return usize::MAX, // Invalid file descriptor
+    };
+
+    let stream = match kernel_obj.as_stream() {
+        Some(stream) => stream,
+        None => return usize::MAX, // Not a stream object
+    };
+
+    let nonblocking = abi
+        .get_file_status_flags(fd)
+        .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+        .unwrap_or(false);
+
+    // Translate and validate iovec array pointer
+    let iovec_vaddr = match task.vm_manager.translate_to_kva(iovec_ptr) {
+        Some(addr) => addr as *const IoVec,
+        None => return usize::MAX, // Invalid address
+    };
+
+    if iovec_vaddr.is_null() {
+        return usize::MAX; // NULL pointer
+    }
+
+    // Read iovec structures from user space
+    let iovecs = unsafe { core::slice::from_raw_parts(iovec_vaddr, iovcnt) };
+
+    let mut total_written = 0usize;
+
+    // Process each iovec
+    for iovec in iovecs {
+        if iovec.iov_len == 0 {
+            continue; // Skip empty buffers
+        }
+
+        // Translate buffer address
+        let buf_vaddr = match task.vm_manager.translate_to_kva(iovec.iov_base as usize) {
+            Some(addr) => addr as *const u8,
+            None => return usize::MAX, // Invalid buffer address
+        };
+
+        if buf_vaddr.is_null() {
+            return usize::MAX; // NULL buffer pointer
+        }
+
+        // Create a slice from the user buffer
+        let buffer = unsafe { core::slice::from_raw_parts(buf_vaddr, iovec.iov_len) };
+
+        // Write data from this buffer
+        match stream.write(buffer) {
+            Ok(n) => {
+                total_written = total_written.saturating_add(n);
+
+                // If partial write occurred, stop processing remaining vectors
+                // This matches Linux behavior for writev
+                if n < iovec.iov_len {
+                    break;
+                }
+            }
+            Err(StreamError::WouldBlock) => {
+                if nonblocking {
+                    // If some bytes were written, return them; otherwise, EAGAIN
+                    if total_written == 0 {
+                        return errno::to_result(errno::EAGAIN);
+                    } else {
+                        break;
+                    }
+                } else {
+                    get_scheduler().schedule(trapframe);
+                    return usize::MAX;
+                }
+            }
+            Err(_) => {
+                // If no bytes were written at all, return error
+                // If some bytes were written, return the count
+                if total_written == 0 {
+                    return usize::MAX;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    total_written
+}
+
+pub fn sys_lseek(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let offset = trapframe.get_arg(1) as i64;
+    let whence = trapframe.get_arg(2) as i32;
+
+    // Increment PC to avoid infinite loop if lseek fails
+    trapframe.increment_pc_next(task);
+
+    // Get handle from Linux fd
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => return usize::MAX, // Invalid file descriptor
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return usize::MAX, // Invalid file descriptor
+    };
+
+    let file = match kernel_obj.as_file() {
+        Some(file) => file,
+        None => return usize::MAX, // Not a file object
+    };
+
+    let whence = match whence {
+        0 => SeekFrom::Start(offset as u64),
+        1 => SeekFrom::Current(offset),
+        2 => SeekFrom::End(offset),
+        _ => return usize::MAX, // Invalid whence
+    };
+
+    match file.seek(whence) {
+        Ok(pos) => pos as usize,
+        Err(e) => {
+            crate::println!("sys_lseek: seek error: {:?}", e);
+            usize::MAX // Seek error
+        }
+    }
+}
+
+// // Create device file
+// pub fn sys_mknod(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+//     let task = mytask().unwrap();
+//     trapframe.increment_pc_next(task);
+//     let name_ptr = task.vm_manager.translate_vaddr(trapframe.get_arg(0)).unwrap() as *const u8;
+//     let name = get_path_str_v2(name_ptr).unwrap();
+//     let path = to_absolute_path_v2(&task, &name).unwrap();
+
+//     let major = trapframe.get_arg(1) as u32;
+//     let minor = trapframe.get_arg(2) as u32;
+
+//     match (major, minor) {
+//         (1, 0) => {
+//             // Create a console device
+//             let console_dev = Some(DeviceManager::get_manager().register_device(Arc::new(
+//                 crate::abi::Linux::drivers::console::ConsoleDevice::new(0, "console")
+//             )));
+
+//             let vfs = task.vfs.read().clone().unwrap();
+//             let _res = vfs.create_file(&path, FileType::CharDevice(
+//                 DeviceFileInfo {
+//                     device_id: console_dev.unwrap(),
+//                     device_type: crate::device::DeviceType::Char,
+//                 }
+//             ));
+//             // crate::println!("Created console device at {}", path);
+//         },
+//         _ => {},
+//     }
+//     0
+// }
+
+// pub fn sys_fstat(abi: &mut LinuxAbi, trapframe: &mut crate::arch::Trapframe) -> usize {
+//     let fd = trapframe.get_arg(0) as usize;
+
+//     let task = mytask()
+//         .expect("sys_fstat: No current task found");
+//     trapframe.increment_pc_next(task); // Increment the program counter
+
+//     let stat_ptr = task.vm_manager.translate_vaddr(trapframe.get_arg(1) as usize)
+//         .expect("sys_fstat: Failed to translate stat pointer") as *mut Stat;
+
+//     // Get handle from Linux fd
+//     let handle = match abi.get_handle(fd) {
+//         Some(h) => h,
+//         None => return usize::MAX, // Invalid file descriptor
+//     };
+
+//     let kernel_obj = match task.handle_table.get(handle) {
+//         Some(obj) => obj,
+//         None => return usize::MAX, // Return -1 on error
+//     };
+
+//     let file = match kernel_obj.as_file() {
+//         Some(file) => file,
+//         None => return usize::MAX, // Not a file object
+//     };
+
+//     let metadata = file.metadata()
+//         .expect("sys_fstat: Failed to get file metadata");
+
+//     if stat_ptr.is_null() {
+//         return usize::MAX; // Return -1 if stat pointer is null
+//     }
+
+//     let stat = unsafe { &mut *stat_ptr };
+
+//     *stat = Stat {
+//         dev: 0,
+//         ino: metadata.file_id as u32,
+//         file_type: match metadata.file_type {
+//             FileType::Directory => 1, // T_DIR
+//             FileType::RegularFile => 2,      // T_FILE
+//             FileType::CharDevice(_) => 3, // T_DEVICE
+//             FileType::BlockDevice(_) => 3, // T_DEVICE
+//             _ => 0, // Unknown type
+//         },
+//         nlink: 1,
+//         size: metadata.size as u64,
+//     };
+
+//     0
+// }
+
+/// Linux sys_newfstatat implementation for Scarlet VFS v2
+///
+/// Gets file status relative to a directory file descriptor (dirfd) and path.
+/// If dirfd == AT_FDCWD, uses the current working directory as the base.
+/// Otherwise, resolves the base directory from the file descriptor.
+/// Uses VfsManager::resolve_path_from for safe and efficient path resolution.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_newfstatat(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let dirfd = trapframe.get_arg(0) as i32;
+    let path_ptr = task
+        .vm_manager
+        .translate_to_kva(trapframe.get_arg(1))
+        .unwrap() as *const u8;
+    let stat_ptr = task
+        .vm_manager
+        .translate_to_kva(trapframe.get_arg(2))
+        .unwrap() as *mut u8;
+    let flags = trapframe.get_arg(3) as i32;
+
+    // Increment PC to avoid infinite loop if fstatat fails
+    trapframe.increment_pc_next(task);
+
+    // Parse path from user space
+    let path_str = match cstring_to_string(path_ptr, MAX_PATH_LENGTH) {
+        Ok((path, _)) => path,
+        Err(_) => return usize::MAX, // Invalid UTF-8
+    };
+
+    let path_str = remap_shm_path(&path_str);
+
+    // crate::println!(
+    //     "sys_newfstatat: dirfd={}, path='{}', flags={:#o}",
+    //     dirfd,
+    //     path_str,
+    //     flags
+    // );
+
+    let vfs_guard = task.vfs.read();
+    let vfs = vfs_guard.as_deref().unwrap();
+
+    // Determine base directory (entry and mount) for path resolution
+    use crate::fs::vfs_v2::core::VfsFileObject;
+
+    const AT_FDCWD: i32 = -100;
+    const AT_SYMLINK_NOFOLLOW: i32 = 0x100;
+
+    // TODO: Handle AT_SYMLINK_NOFOLLOW flag properly
+    // For now, we always follow symbolic links
+    let _follow_symlinks = (flags & AT_SYMLINK_NOFOLLOW) == 0;
+
+    let (base_entry, base_mount) = if dirfd == AT_FDCWD {
+        // Use current working directory as base
+        vfs.get_cwd().unwrap_or_else(|| {
+            let root_mount = vfs.mount_tree.root_mount.read().clone();
+            (root_mount.root.clone(), root_mount)
+        })
+    } else {
+        // Use directory file descriptor as base
+        let handle = match abi.get_handle(dirfd as usize) {
+            Some(h) => h,
+            None => return usize::MAX,
+        };
+        let kernel_obj = match task.handle_table.get(handle) {
+            Some(obj) => obj,
+            None => return usize::MAX,
+        };
+        let file_obj = match kernel_obj.as_file() {
+            Some(f) => f,
+            None => return usize::MAX,
+        };
+        let vfs_file_obj = file_obj
+            .as_any()
+            .downcast_ref::<VfsFileObject>()
+            .ok_or(())
+            .unwrap();
+        (
+            vfs_file_obj.get_vfs_entry().clone(),
+            vfs_file_obj.get_mount_point().clone(),
+        )
+    };
+
+    // Resolve the path from the base directory
+    match vfs.resolve_path_from(&base_entry, &base_mount, &path_str) {
+        Ok((entry, _mount_point)) => {
+            // Get metadata from the resolved VfsEntry
+            let node = entry.node();
+            match node.metadata() {
+                Ok(metadata) => {
+                    if stat_ptr.is_null() {
+                        return usize::MAX; // Return -1 if stat pointer is null
+                    }
+
+                    let stat = unsafe { &mut *(stat_ptr as *mut LinuxStat) };
+                    *stat = LinuxStat::from_metadata(&metadata);
+                    // crate::println!(
+                    //     "sys_newfstatat: path='{}' size={}",
+                    //     path_str,
+                    //     metadata.size
+                    // );
+                    0 // Success
+                }
+                Err(_) => usize::MAX, // Error getting metadata
+            }
+        }
+        Err(_) => usize::MAX, // Error resolving path
+    }
+}
+
+/// Linux sys_statx implementation for Scarlet VFS v2
+///
+/// Gets extended file status relative to a directory file descriptor (dirfd) and path.
+/// If dirfd == AT_FDCWD, uses the current working directory as the base.
+/// Supports AT_EMPTY_PATH for file-descriptor based queries.
+pub fn sys_statx(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::EIO),
+    };
+
+    let dirfd = trapframe.get_arg(0) as i32;
+    let pathname_ptr = trapframe.get_arg(1);
+    let flags = trapframe.get_arg(2) as u32;
+    let mask = trapframe.get_arg(3) as u32;
+    let statx_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(4)) {
+        Some(ptr) => ptr as *mut LinuxStatx,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    if statx_ptr.is_null() {
+        return errno::to_result(errno::EFAULT);
+    }
+
+    const AT_FDCWD: i32 = -100;
+    const AT_SYMLINK_NOFOLLOW: u32 = 0x100;
+    const AT_EMPTY_PATH: u32 = 0x1000;
+
+    let path_str = match parse_c_string_from_userspace(task, pathname_ptr, MAX_PATH_LENGTH) {
+        Ok(s) => s,
+        Err(_) => return errno::to_result(errno::EFAULT),
+    };
+    let path_str = remap_shm_path(&path_str);
+    // crate::println!(
+    //     "sys_statx: dirfd={} path='{}' flags={:#x} mask={:#x}",
+    //     dirfd,
+    //     path_str,
+    //     flags,
+    //     mask
+    // );
+
+    let vfs = match task.vfs.read().clone() {
+        Some(v) => v,
+        None => return errno::to_result(errno::EIO),
+    };
+
+    // Support AT_EMPTY_PATH for stat-by-fd
+    if path_str.is_empty() && (flags & AT_EMPTY_PATH) != 0 {
+        let handle = match abi.get_handle(dirfd as usize) {
+            Some(h) => h,
+            None => return errno::to_result(errno::EBADF),
+        };
+        let kernel_obj = match task.handle_table.get(handle) {
+            Some(obj) => obj,
+            None => return errno::to_result(errno::EBADF),
+        };
+        let file_obj = match kernel_obj.as_file() {
+            Some(f) => f,
+            None => return errno::to_result(errno::EBADF),
+        };
+
+        use crate::fs::vfs_v2::core::VfsFileObject;
+        if let Some(vfs_file_obj) = file_obj.as_any().downcast_ref::<VfsFileObject>() {
+            let entry = vfs_file_obj.get_vfs_entry();
+            let node = entry.node();
+            let metadata = match node.metadata() {
+                Ok(m) => m,
+                Err(e) => return errno::to_result(errno::from_fs_error(&e)),
+            };
+            let stat = LinuxStat::from_metadata(&metadata);
+            let statx_ref = unsafe { &mut *statx_ptr };
+            fill_statx_from_stat(statx_ref, &stat, metadata.created_time, mask);
+            // crate::println!(
+            //     "sys_statx: empty_path name='{}' size={}",
+            //     entry.name(),
+            //     metadata.size
+            // );
+            return 0;
+        }
+
+        let stat = LinuxStat {
+            st_dev: 0,
+            st_ino: handle as u64,
+            st_mode: S_IFCHR | 0o666,
+            st_nlink: 1,
+            st_uid: 0,
+            st_gid: 0,
+            st_rdev: handle as u64,
+            __pad1: 0,
+            st_size: 0,
+            st_blksize: 4096,
+            __pad2: 0,
+            st_blocks: 0,
+            st_atime: 0,
+            st_atime_nsec: 0,
+            st_mtime: 0,
+            st_mtime_nsec: 0,
+            st_ctime: 0,
+            st_ctime_nsec: 0,
+            __unused4: 0,
+            __unused5: 0,
+        };
+        let statx_ref = unsafe { &mut *statx_ptr };
+        fill_statx_from_stat(statx_ref, &stat, 0, mask);
+        return 0;
+    }
+
+    // Determine base directory (entry and mount) for path resolution
+    use crate::fs::vfs_v2::core::VfsFileObject;
+
+    let (base_entry, base_mount) = if dirfd == AT_FDCWD {
+        vfs.get_cwd().unwrap_or_else(|| {
+            let root_mount = vfs.mount_tree.root_mount.read().clone();
+            (root_mount.root.clone(), root_mount)
+        })
+    } else {
+        let handle = match abi.get_handle(dirfd as usize) {
+            Some(h) => h,
+            None => return errno::to_result(errno::EBADF),
+        };
+        let kernel_obj = match task.handle_table.get(handle) {
+            Some(obj) => obj,
+            None => return errno::to_result(errno::EBADF),
+        };
+        let file_obj = match kernel_obj.as_file() {
+            Some(f) => f,
+            None => return errno::to_result(errno::ENOTDIR),
+        };
+        let vfs_file_obj = match file_obj.as_any().downcast_ref::<VfsFileObject>() {
+            Some(vfs_obj) => vfs_obj,
+            None => return errno::to_result(errno::ENOTDIR),
+        };
+        (
+            vfs_file_obj.get_vfs_entry().clone(),
+            vfs_file_obj.get_mount_point().clone(),
+        )
+    };
+
+    // TODO: Handle AT_SYMLINK_NOFOLLOW flag properly; for now, always follow.
+    let _follow_symlinks = (flags & AT_SYMLINK_NOFOLLOW) == 0;
+
+    let (entry, _mount_point) = match vfs.resolve_path_from(&base_entry, &base_mount, &path_str) {
+        Ok(v) => v,
+        Err(e) => return errno::to_result(errno::from_fs_error(&e)),
+    };
+
+    let node = entry.node();
+    let metadata = match node.metadata() {
+        Ok(m) => m,
+        Err(e) => return errno::to_result(errno::from_fs_error(&e)),
+    };
+
+    let stat = LinuxStat::from_metadata(&metadata);
+    let statx_ref = unsafe { &mut *statx_ptr };
+    fill_statx_from_stat(statx_ref, &stat, metadata.created_time, mask);
+    // crate::println!(
+    //     "sys_statx: path='{}' size={}",
+    //     path_str,
+    //     metadata.size
+    // );
+    0
+}
+
+#[allow(dead_code)]
+pub fn sys_mkdir(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    let path_ptr = task
+        .vm_manager
+        .translate_to_kva(trapframe.get_arg(0))
+        .unwrap() as *const u8;
+    let path = match get_path_str_v2(path_ptr) {
+        Ok(p) => to_absolute_path_v2(&task, &p).unwrap(),
+        Err(_) => return usize::MAX, // Invalid path
+    };
+
+    // Try to create the directory
+    let vfs = task.vfs.read().clone().unwrap();
+    match vfs.create_dir(&path) {
+        Ok(_) => 0,           // Success
+        Err(_) => usize::MAX, // Error
+    }
+}
+
+#[allow(dead_code)]
+pub fn sys_unlink(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    let path_ptr = task
+        .vm_manager
+        .translate_to_kva(trapframe.get_arg(0))
+        .unwrap() as *const u8;
+    let path = match cstring_to_string(path_ptr, MAX_PATH_LENGTH) {
+        Ok((p, _)) => to_absolute_path_v2(&task, &p).unwrap(),
+        Err(_) => return usize::MAX, // Invalid path
+    };
+
+    // Try to remove the file or directory
+    let vfs = task.vfs.read().clone().unwrap();
+    match vfs.remove(&path) {
+        Ok(_) => 0,           // Success
+        Err(_) => usize::MAX, // Error
+    }
+}
+
+#[allow(dead_code)]
+pub fn sys_link(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    let src_path_ptr = task
+        .vm_manager
+        .translate_to_kva(trapframe.get_arg(0))
+        .unwrap() as *const u8;
+    let dst_path_ptr = task
+        .vm_manager
+        .translate_to_kva(trapframe.get_arg(1))
+        .unwrap() as *const u8;
+
+    let src_path = match cstring_to_string(src_path_ptr, MAX_PATH_LENGTH) {
+        Ok((p, _)) => to_absolute_path_v2(&task, &p).unwrap(),
+        Err(_) => return usize::MAX, // Invalid path
+    };
+
+    let dst_path = match cstring_to_string(dst_path_ptr, MAX_PATH_LENGTH) {
+        Ok((p, _)) => to_absolute_path_v2(&task, &p).unwrap(),
+        Err(_) => return usize::MAX, // Invalid path
+    };
+
+    let vfs_guard = task.vfs.read();
+    let vfs = vfs_guard.as_deref().unwrap();
+    match vfs.create_hardlink(&src_path, &dst_path) {
+        Ok(_) => 0, // Success
+        Err(err) => {
+            // Map VFS errors to appropriate errno values for Linux
+            errno::to_result(errno::from_fs_error(&err))
+        }
+    }
+}
+
+/// Linux sys_linkat implementation for Scarlet VFS v2
+///
+/// Creates a hard link to an existing file. Both oldpath and newpath
+/// can be relative to their respective directory file descriptors.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: olddirfd (old directory file descriptor)
+///   - arg1: oldpath_ptr (pointer to source path string)
+///   - arg2: newdirfd (new directory file descriptor)
+///   - arg3: newpath_ptr (pointer to destination path string)
+///   - arg4: flags (link flags)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_linkat(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let olddirfd = trapframe.get_arg(0) as i32;
+    let oldpath_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(1)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+    let newdirfd = trapframe.get_arg(2) as i32;
+    let newpath_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(3)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+    let flags = trapframe.get_arg(4) as i32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Parse paths from user space
+    let oldpath_str = match cstring_to_string(oldpath_ptr, MAX_PATH_LENGTH) {
+        Ok((path, _)) => path,
+        Err(_) => return usize::MAX, // Invalid UTF-8
+    };
+
+    let newpath_str = match cstring_to_string(newpath_ptr, MAX_PATH_LENGTH) {
+        Ok((path, _)) => path,
+        Err(_) => return usize::MAX, // Invalid UTF-8
+    };
+
+    // Linux constants for linkat
+    const AT_FDCWD: i32 = -100;
+    const AT_SYMLINK_FOLLOW: i32 = 0x400;
+    const AT_EMPTY_PATH: i32 = 0x1000;
+
+    let vfs = match task.vfs.read().clone() {
+        Some(v) => v,
+        None => return usize::MAX,
+    };
+
+    // Determine base directory for old path resolution
+    use crate::fs::vfs_v2::core::VfsFileObject;
+
+    let (old_base_entry, old_base_mount) = if olddirfd == AT_FDCWD {
+        // Use current working directory as base
+        vfs.get_cwd().unwrap_or_else(|| {
+            let root_mount = vfs.mount_tree.root_mount.read().clone();
+            (root_mount.root.clone(), root_mount)
+        })
+    } else {
+        // Use directory file descriptor as base
+        let handle = match abi.get_handle(olddirfd as usize) {
+            Some(h) => h,
+            None => return usize::MAX,
+        };
+        let kernel_obj = match task.handle_table.get(handle) {
+            Some(obj) => obj,
+            None => return usize::MAX,
+        };
+        let file_obj = match kernel_obj.as_file() {
+            Some(f) => f,
+            None => return usize::MAX,
+        };
+        let vfs_file_obj = file_obj
+            .as_any()
+            .downcast_ref::<VfsFileObject>()
+            .ok_or(())
+            .unwrap();
+        (
+            vfs_file_obj.get_vfs_entry().clone(),
+            vfs_file_obj.get_mount_point().clone(),
+        )
+    };
+
+    // Determine base directory for new path resolution
+    let (_new_base_entry, _new_base_mount) = if newdirfd == AT_FDCWD {
+        // Use current working directory as base
+        vfs.get_cwd().unwrap_or_else(|| {
+            let root_mount = vfs.mount_tree.root_mount.read().clone();
+            (root_mount.root.clone(), root_mount)
+        })
+    } else {
+        // Use directory file descriptor as base
+        let handle = match abi.get_handle(newdirfd as usize) {
+            Some(h) => h,
+            None => return usize::MAX,
+        };
+        let kernel_obj = match task.handle_table.get(handle) {
+            Some(obj) => obj,
+            None => return usize::MAX,
+        };
+        let file_obj = match kernel_obj.as_file() {
+            Some(f) => f,
+            None => return usize::MAX,
+        };
+        let vfs_file_obj = file_obj
+            .as_any()
+            .downcast_ref::<VfsFileObject>()
+            .ok_or(())
+            .unwrap();
+        (
+            vfs_file_obj.get_vfs_entry().clone(),
+            vfs_file_obj.get_mount_point().clone(),
+        )
+    };
+
+    // Resolve the source path to verify it exists
+    let _source_entry = match vfs.resolve_path_from(&old_base_entry, &old_base_mount, &oldpath_str)
+    {
+        Ok((entry, _mount_point)) => entry,
+        Err(_) => return usize::MAX, // Source file doesn't exist
+    };
+
+    // For now, we'll implement a simplified version using absolute paths
+    // since VFS v2 may not have direct hard link support yet
+
+    // Convert paths to absolute paths
+    let _old_absolute_path = if oldpath_str.starts_with('/') {
+        oldpath_str.to_string()
+    } else {
+        match to_absolute_path_v2(&task, &oldpath_str) {
+            Ok(p) => p,
+            Err(_) => return usize::MAX,
+        }
+    };
+
+    let _new_absolute_path = if newpath_str.starts_with('/') {
+        newpath_str.to_string()
+    } else {
+        match to_absolute_path_v2(&task, &newpath_str) {
+            Ok(p) => p,
+            Err(_) => return usize::MAX,
+        }
+    };
+
+    // Get mutable VFS reference for link creation
+    let _vfs_mut = match task.vfs.write().clone() {
+        Some(v) => v,
+        None => return usize::MAX,
+    };
+
+    // TODO: Handle flags properly
+    // AT_SYMLINK_FOLLOW: follow symbolic links in oldpath
+    // AT_EMPTY_PATH: allow empty oldpath if olddirfd refers to a file
+    let _follow_symlinks = (flags & AT_SYMLINK_FOLLOW) != 0;
+    let _empty_path = (flags & AT_EMPTY_PATH) != 0;
+
+    // Try to create the hard link
+    // Note: This is a simplified implementation. A full implementation would:
+    // 1. Check if source and destination are on the same filesystem
+    // 2. Verify the source is not a directory (unless allowed)
+    // 3. Handle proper hard link semantics
+    // 4. Update inode reference counts
+
+    // For now, we'll return success as a stub implementation
+    // since VFS v2 might not support true hard links yet.
+    // Real hard link functionality would require:
+    // - Filesystem-level support for hard links
+    // - Inode reference counting
+    // - Cross-filesystem link prevention
+
+    // Stub implementation: just return success
+    // This prevents applications from crashing when they use linkat
+    // but doesn't provide true hard link semantics
+    0 // Success (stub implementation)
+}
+
+/// VFS v2 helper function for path absolutization using VfsManager
+fn to_absolute_path_v2(task: &crate::task::Task, path: &str) -> Result<String, ()> {
+    if path.starts_with('/') {
+        Ok(path.to_string())
+    } else {
+        let vfs_guard = task.vfs.read();
+        let vfs = vfs_guard.as_ref().ok_or(())?;
+        Ok(vfs.resolve_path_to_absolute(path))
+    }
+}
+
+/// Helper function to replace the missing get_path_str function
+/// TODO: This should be moved to a shared helper when VFS v2 provides public API
+fn get_path_str_v2(ptr: *const u8) -> Result<String, ()> {
+    const MAX_PATH_LENGTH: usize = 1024; // Match the global constant
+    cstring_to_string(ptr, MAX_PATH_LENGTH)
+        .map(|(s, _)| s)
+        .map_err(|_| ())
+}
+
+/// Linux ioctl system call implementation
+///
+/// This system call performs device-specific control operations on file descriptors,
+/// similar to the POSIX ioctl system call. It acts as a bridge between Linux ABI
+/// and Scarlet's native HandleControl functionality.
+///
+/// # Arguments
+/// - fd: File descriptor
+/// - request: Control operation command
+/// - arg: Argument for the control operation (often a pointer)
+///
+/// # Returns
+/// - 0 or positive value on success
+/// - usize::MAX on error (-1 in Linux)
+pub fn sys_ioctl(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let request = trapframe.get_arg(1) as u32;
+    let arg = trapframe.get_arg(2);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Get handle from Linux fd
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => return usize::MAX, // Invalid file descriptor
+    };
+
+    // Get the kernel object from the handle table
+    let kernel_object = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return usize::MAX, // Invalid handle
+    };
+
+    // Dispatch hypervisor (KVM) ioctls before capability-based routing
+    #[cfg(feature = "hypervisor")]
+    match &kernel_object {
+        crate::object::KernelObject::HypervisorVm(vm) => {
+            let result = crate::abi::linux::device::kvm::handle_vm_ioctl(request, arg, vm, abi);
+            return match result {
+                Ok(Some(ret)) => ret,
+                Ok(None) => errno::to_result(errno::ENOTTY),
+                Err(_) => errno::to_result(errno::EINVAL),
+            };
+        }
+        crate::object::KernelObject::HypervisorVcpu(vcpu) => {
+            let result = crate::abi::linux::device::kvm::handle_vcpu_ioctl(request, arg, vcpu);
+            return match result {
+                Ok(Some(ret)) => ret,
+                Ok(None) => errno::to_result(errno::ENOTTY),
+                Err(_) => errno::to_result(errno::EINVAL),
+            };
+        }
+        _ => {}
+    }
+
+    // Determine device capabilities for per-device translation
+    let mut caps: Option<&'static [DeviceCapability]> = None;
+    if let Some(file_obj) = kernel_object.as_file() {
+        if let Ok(metadata) = file_obj.metadata() {
+            if let FileType::CharDevice(info) = metadata.file_type {
+                if let Some(dev) = DeviceManager::get_manager().get_device(info.device_id) {
+                    #[cfg(feature = "hypervisor")]
+                    if dev.name() == crate::abi::linux::device::kvm::KVM_DEVICE_NAME {
+                        let result =
+                            crate::abi::linux::device::kvm::handle_system_ioctl(request, arg, abi);
+                        return match result {
+                            Ok(Some(ret)) => ret,
+                            Ok(None) => errno::to_result(errno::ENOTTY),
+                            Err(_) => errno::to_result(errno::EINVAL),
+                        };
+                    }
+                    caps = Some(dev.capabilities());
+                }
+            }
+        }
+    }
+
+    if let Some(caps) = caps {
+        // TTY translation
+        if caps.iter().any(|c| *c == DeviceCapability::Tty) {
+            match crate::abi::linux::device::tty::handle_ioctl(request, arg, &kernel_object) {
+                Ok(Some(ret)) => return ret,
+                Ok(None) => {
+                    // Do NOT pass through unknown TTY ioctls to device-specific control.
+                    // Return ENOTTY to match Linux behavior and avoid accidental derefs.
+                    return errno::to_result(errno::ENOTTY);
+                }
+                Err(_) => return errno::to_result(errno::ENOTTY),
+            }
+        }
+        // Future: match on other capabilities here
+    }
+
+    // Default path: pass-through to ControlOps if available
+    let result = match kernel_object.as_control() {
+        Some(control_ops) => control_ops.control(request, arg),
+        None => Err("Inappropriate ioctl for device"),
+    };
+
+    match result {
+        Ok(value) => {
+            if value >= 0 {
+                value as usize
+            } else {
+                errno::to_result(errno::EINVAL)
+            }
+        }
+        Err(_) => errno::to_result(errno::ENOTTY),
+    }
+}
+
+/// Linux execve system call implementation
+///
+/// This system call executes a program specified by the given path, replacing the
+/// current process image with a new one. It also allows passing arguments and
+/// environment variables to the new program.
+///
+/// # Arguments
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///
+/// # Returns
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_execve(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+
+    // Increment PC to avoid infinite loop if execve fails
+    trapframe.increment_pc_next(task);
+
+    // Get arguments from trapframe
+    let path_ptr = trapframe.get_arg(0);
+    let argv_ptr = trapframe.get_arg(1);
+    let envp_ptr = trapframe.get_arg(2);
+
+    // Parse path
+    let path_str = match parse_c_string_from_userspace(task, path_ptr, MAX_PATH_LENGTH) {
+        Ok(path) => match to_absolute_path_v2(&task, &path) {
+            Ok(abs_path) => abs_path,
+            Err(_) => return usize::MAX, // Path error
+        },
+        Err(_) => return usize::MAX, // Path parsing error
+    };
+
+    // Parse argv
+    let argv_strings =
+        match parse_string_array_from_userspace(task, argv_ptr, MAX_ARG_COUNT, MAX_PATH_LENGTH) {
+            Ok(args) => args,
+            Err(_) => return usize::MAX, // argv parsing error
+        };
+
+    // Parse envp (optional)
+    let envp_strings =
+        match parse_string_array_from_userspace(task, envp_ptr, MAX_ARG_COUNT, MAX_PATH_LENGTH) {
+            Ok(envs) => envs,
+            Err(_) => return usize::MAX, // envp parsing error
+        };
+
+    crate::println!(
+        "sys_execve: path: {}, argv: {:?}, envp: {:?}",
+        path_str,
+        argv_strings,
+        envp_strings
+    );
+
+    // Debug: Print each argv element individually
+    for (i, arg) in argv_strings.iter().enumerate() {
+        crate::println!("  argv[{}]: \"{}\" (len={})", i, arg, arg.len());
+        for (j, byte) in arg.bytes().enumerate() {
+            if byte < 32 || byte > 126 {
+                crate::println!("    byte[{}]: 0x{:02x} (non-printable)", j, byte);
+            }
+        }
+    }
+
+    // Convert Vec<String> to Vec<&str> for TransparentExecutor
+    let argv_refs: Vec<&str> = argv_strings.iter().map(|s| s.as_str()).collect();
+    let envp_refs: Vec<&str> = envp_strings.iter().map(|s| s.as_str()).collect();
+
+    // Use TransparentExecutor for cross-ABI execution
+    match TransparentExecutor::execute_binary(
+        &path_str, &argv_refs, &envp_refs, task, trapframe, false,
+    ) {
+        Ok(_) => {
+            // execve normally should not return on success - the process is replaced
+            // However, if ABI module sets trapframe return value and returns here,
+            // we should respect that value instead of hardcoding 0
+            trapframe.get_return_value()
+        }
+        Err(_) => {
+            // Execution failed - return error code
+            // The trap handler will automatically set trapframe return value from our return
+            usize::MAX // Error return value
+        }
+    }
+}
+
+/// Linux iovec structure for vectored I/O operations
+/// This structure matches the Linux kernel's definition for struct iovec
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct IoVec {
+    /// Base address of the buffer
+    pub iov_base: *mut u8,
+    /// Length of the buffer
+    pub iov_len: usize,
+}
+
+/// Linux sys_fcntl implementation for Scarlet VFS v2
+/// Currently provides basic logging of commands to understand usage patterns
+///
+/// This is a minimal implementation that logs the fcntl commands being used
+/// to help understand what functionality needs to be implemented.
+const LOG_FCNTL: bool = false;
+pub fn sys_fcntl(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let cmd = trapframe.get_arg(1) as u32;
+    let arg = trapframe.get_arg(2);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Log the fcntl command to understand usage patterns
+    match cmd {
+        F_DUPFD => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_DUPFD: fd={}, arg={} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            if fd >= super::MAX_FDS {
+                return errno::to_result(errno::EBADF);
+            }
+            let min_fd = arg as usize;
+            if min_fd >= super::MAX_FDS {
+                return errno::to_result(errno::EMFILE);
+            }
+            let old_handle = match abi.get_handle(fd) {
+                Some(h) => h,
+                None => return errno::to_result(errno::EBADF),
+            };
+            let kernel_obj = match task.handle_table.clone_for_dup(old_handle) {
+                Some(obj) => obj,
+                None => return errno::to_result(errno::EBADF),
+            };
+            let mut new_fd = None;
+            for candidate in min_fd..super::MAX_FDS {
+                if abi.get_handle(candidate).is_none() {
+                    new_fd = Some(candidate);
+                    break;
+                }
+            }
+            let new_fd = match new_fd {
+                Some(fd) => fd,
+                None => return errno::to_result(errno::EMFILE),
+            };
+            let new_handle = match task.handle_table.insert(kernel_obj) {
+                Ok(handle) => handle,
+                Err(_) => return errno::to_result(errno::ENFILE),
+            };
+            if abi.allocate_specific_fd(new_fd, new_handle as u32).is_err() {
+                let _ = task.handle_table.remove(new_handle as u32);
+                return errno::to_result(errno::EMFILE);
+            }
+            if let Some(flags) = abi.get_file_status_flags(fd) {
+                let _ = abi.set_file_status_flags(new_fd, flags);
+            }
+            let _ = abi.set_fd_flags(new_fd, 0);
+            return new_fd;
+        }
+        F_GETFD => {
+            // Get file descriptor flags (IMPLEMENTED)
+            if let Some(_handle) = abi.get_handle(fd) {
+                if let Some(flags) = abi.get_fd_flags(fd) {
+                    return flags as usize; // Return the flags
+                } else {
+                    return usize::MAX; // Invalid file descriptor
+                }
+            } else {
+                return usize::MAX; // Invalid file descriptor
+            }
+        }
+        F_SETFD => {
+            // Set file descriptor flags (IMPLEMENTED)
+            if let Some(_handle) = abi.get_handle(fd) {
+                match abi.set_fd_flags(fd, arg as u32) {
+                    Ok(()) => return 0,          // Success
+                    Err(_) => return usize::MAX, // Error
+                }
+            } else {
+                return usize::MAX; // Invalid file descriptor
+            }
+        }
+        F_GETFL => {
+            if let Some(_handle) = abi.get_handle(fd) {
+                if let Some(flags) = abi.get_file_status_flags(fd) {
+                    return flags as usize;
+                } else {
+                    return usize::MAX;
+                }
+            } else {
+                return usize::MAX;
+            }
+        }
+        F_SETFL => {
+            // Only honor a subset (currently O_NONBLOCK). Preserve other bits as-is.
+            if let Some(_handle) = abi.get_handle(fd) {
+                // Get current status flags and update O_NONBLOCK bit only
+                let curr = abi.get_file_status_flags(fd).unwrap_or(0);
+                let mut new_flags = curr;
+                const O_NONBLOCK_U32: u32 = O_NONBLOCK as u32;
+                if (arg as u32) & O_NONBLOCK_U32 != 0 {
+                    new_flags |= O_NONBLOCK_U32;
+                } else {
+                    new_flags &= !O_NONBLOCK_U32;
+                }
+                if abi.set_file_status_flags(fd, new_flags).is_err() {
+                    return usize::MAX;
+                }
+                // Also propagate O_NONBLOCK to the object-level Selectable if available
+                if let Some(handle) = abi.get_handle(fd) {
+                    if let Some(obj) = task.handle_table.get(handle) {
+                        if let Some(sel) = obj.as_selectable() {
+                            sel.set_nonblocking(((new_flags as i32) & O_NONBLOCK) != 0);
+                        }
+                    }
+                }
+
+                return 0;
+            } else {
+                return usize::MAX;
+            }
+        }
+        F_GETLK => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_GETLK: fd={}, lock_ptr={:#x} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            // TODO: Implement file locking
+        }
+        F_SETLK => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_SETLK: fd={}, lock_ptr={:#x} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            // TODO: Implement file locking
+        }
+        F_SETLKW => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_SETLKW: fd={}, lock_ptr={:#x} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            // TODO: Implement file locking
+        }
+        F_SETOWN => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_SETOWN: fd={}, owner={} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            // TODO: Implement F_SETOWN
+        }
+        F_GETOWN => {
+            if LOG_FCNTL {
+                crate::println!("[sys_fcntl] F_GETOWN: fd={} - NOT IMPLEMENTED", fd);
+            }
+            // TODO: Implement F_GETOWN
+        }
+        F_SETSIG => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_SETSIG: fd={}, sig={} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            // TODO: Implement F_SETSIG
+        }
+        F_GETSIG => {
+            if LOG_FCNTL {
+                crate::println!("[sys_fcntl] F_GETSIG: fd={} - NOT IMPLEMENTED", fd);
+            }
+            // TODO: Implement F_GETSIG
+        }
+        F_SETLEASE => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_SETLEASE: fd={}, lease_type={} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            // TODO: Implement F_SETLEASE
+        }
+        F_GETLEASE => {
+            if LOG_FCNTL {
+                crate::println!("[sys_fcntl] F_GETLEASE: fd={} - NOT IMPLEMENTED", fd);
+            }
+            // TODO: Implement F_GETLEASE
+        }
+        F_NOTIFY => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_NOTIFY: fd={}, events={:#x} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            // TODO: Implement F_NOTIFY
+        }
+        F_DUPFD_CLOEXEC => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] F_DUPFD_CLOEXEC: fd={}, arg={} - NOT IMPLEMENTED",
+                    fd,
+                    arg
+                );
+            }
+            if fd >= super::MAX_FDS {
+                return errno::to_result(errno::EBADF);
+            }
+            let min_fd = arg as usize;
+            if min_fd >= super::MAX_FDS {
+                return errno::to_result(errno::EMFILE);
+            }
+            let old_handle = match abi.get_handle(fd) {
+                Some(h) => h,
+                None => return errno::to_result(errno::EBADF),
+            };
+            let kernel_obj = match task.handle_table.clone_for_dup(old_handle) {
+                Some(obj) => obj,
+                None => return errno::to_result(errno::EBADF),
+            };
+            let mut new_fd = None;
+            for candidate in min_fd..super::MAX_FDS {
+                if abi.get_handle(candidate).is_none() {
+                    new_fd = Some(candidate);
+                    break;
+                }
+            }
+            let new_fd = match new_fd {
+                Some(fd) => fd,
+                None => return errno::to_result(errno::EMFILE),
+            };
+            let new_handle = match task.handle_table.insert(kernel_obj) {
+                Ok(handle) => handle,
+                Err(_) => return errno::to_result(errno::ENFILE),
+            };
+            if abi.allocate_specific_fd(new_fd, new_handle as u32).is_err() {
+                let _ = task.handle_table.remove(new_handle as u32);
+                return errno::to_result(errno::EMFILE);
+            }
+            if let Some(flags) = abi.get_file_status_flags(fd) {
+                let _ = abi.set_file_status_flags(new_fd, flags);
+            }
+            let _ = abi.set_fd_flags(new_fd, FD_CLOEXEC);
+            return new_fd;
+        }
+        _ => {
+            if LOG_FCNTL {
+                crate::println!(
+                    "[sys_fcntl] UNKNOWN_CMD: fd={}, cmd={}, arg={:#x} - NOT IMPLEMENTED",
+                    fd,
+                    cmd,
+                    arg
+                );
+            }
+        }
+    }
+
+    // All unimplemented commands return ENOSYS (already logged above)
+    errno::to_result(errno::ENOSYS)
+}
+
+/// Linux sys_flock - Apply or remove an advisory lock on an open file
+///
+/// Apply or remove an advisory lock on the open file specified by fd.
+/// This is a simplified implementation that always succeeds.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: fd (file descriptor)
+///   - arg1: operation (LOCK_SH, LOCK_EX, LOCK_UN, etc.)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_flock(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let fd = trapframe.get_arg(0) as i32;
+    let _operation = trapframe.get_arg(1) as i32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Verify fd is valid
+    if abi.get_handle(fd as usize).is_none() {
+        return usize::MAX;
+    }
+
+    // Simplified implementation: always succeed
+    // Real flock would require managing lock state per file descriptor
+    // For Wayland SHM operations, advisory locks aren't critical
+    0
+}
+
+/// Linux sys_fallocate - Manipulate file space
+///
+/// This is used by glib/Wayland to extend shared memory file size.
+/// When mode is 0 (default), it extends the file to at least offset + len.
+///
+/// Arguments:
+/// - fd: File descriptor
+/// - mode: Operation mode (0 = allocate, FALLOC_FL_KEEP_SIZE, etc.)
+/// - offset: Starting offset
+/// - len: Length of the allocation
+///
+/// Returns:
+/// - 0 on success
+/// - negative errno on failure
+pub fn sys_fallocate(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    use super::errno;
+
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let fd = trapframe.get_arg(0) as usize;
+    let mode = trapframe.get_arg(1) as i32;
+    let offset = trapframe.get_arg(2) as i64;
+    let len = trapframe.get_arg(3) as i64;
+
+    trapframe.increment_pc_next(task);
+
+    if offset < 0 || len <= 0 {
+        return errno::to_result(errno::EINVAL);
+    }
+
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => return errno::to_result(errno::EBADF),
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return errno::to_result(errno::EBADF),
+    };
+
+    // Handle SharedMemory (memfd)
+    if let Some(shared_memory) = kernel_obj.as_shared_memory() {
+        // FALLOC_FL_KEEP_SIZE = 0x01 - don't change file size
+        const FALLOC_FL_KEEP_SIZE: i32 = 0x01;
+
+        let new_size = (offset + len) as usize;
+        let current_size = shared_memory.size();
+
+        // If mode doesn't have KEEP_SIZE, extend the file
+        if (mode & FALLOC_FL_KEEP_SIZE) == 0 && new_size > current_size {
+            if let Err(_e) = shared_memory.resize(new_size) {
+                return errno::to_result(errno::ENOSPC);
+            }
+        }
+
+        return 0;
+    }
+
+    // For regular files, just succeed (no-op for now)
+    // Real implementation would preallocate disk space
+    0
+}
+
+/// Linux struct linux_dirent64 (for getdents64 syscall)
+#[repr(C)]
+pub struct LinuxDirent64 {
+    pub d_ino: u64,
+    pub d_off: i64,
+    pub d_reclen: u16,
+    pub d_type: u8,
+    pub d_name: [u8; 256], // Linux allows up to 255 + null
+}
+
+impl LinuxDirent64 {
+    pub fn new(entry: &DirectoryEntry, d_off: i64) -> Self {
+        let mut d_name = [0u8; 256];
+        let name_len = entry.name_len as usize;
+        d_name[..name_len].copy_from_slice(&entry.name[..name_len]);
+        d_name[name_len] = 0; // null-terminated
+        Self {
+            d_ino: entry.file_id,
+            d_off,
+            d_reclen: (core::mem::size_of::<u64>()
+                + core::mem::size_of::<i64>()
+                + core::mem::size_of::<u16>()
+                + core::mem::size_of::<u8>()
+                + name_len
+                + 1) as u16,
+            d_type: entry.file_type,
+            d_name,
+        }
+    }
+    pub fn as_bytes(&self) -> &[u8] {
+        let len = self.d_reclen as usize;
+        unsafe { core::slice::from_raw_parts(self as *const _ as *const u8, len) }
+    }
+}
+
+/// getdents64 syscall implementation
+pub fn sys_getdents64(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let buf_ptr = task
+        .vm_manager
+        .translate_to_kva(trapframe.get_arg(1))
+        .unwrap() as *mut u8;
+    let buf_size = trapframe.get_arg(2) as usize;
+    trapframe.increment_pc_next(task);
+
+    // Get handle from Linux fd
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => return usize::MAX,
+    };
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return usize::MAX,
+    };
+    let stream = match kernel_obj.as_stream() {
+        Some(s) => s,
+        None => return usize::MAX,
+    };
+
+    let mut dir_buffer = vec![0u8; core::mem::size_of::<DirectoryEntry>()];
+    let mut written = 0usize;
+    let mut d_off = 0i64;
+    while written + core::mem::size_of::<LinuxDirent64>() <= buf_size {
+        match stream.read(&mut dir_buffer) {
+            Ok(n) if n == dir_buffer.len() => {
+                if let Some(entry) = DirectoryEntry::parse(&dir_buffer) {
+                    let dirent = LinuxDirent64::new(&entry, d_off);
+                    let dirent_bytes = dirent.as_bytes();
+                    if written + dirent_bytes.len() > buf_size {
+                        break;
+                    }
+                    unsafe {
+                        core::ptr::copy_nonoverlapping(
+                            dirent_bytes.as_ptr(),
+                            buf_ptr.add(written),
+                            dirent_bytes.len(),
+                        );
+                    }
+                    written += dirent_bytes.len();
+                    d_off += 1;
+                } else {
+                    break;
+                }
+            }
+            Ok(0) => break, // EOF
+            Ok(_) => break, // partial read, treat as error/EOF
+            Err(StreamError::EndOfStream) => break,
+            Err(StreamError::WouldBlock) => {
+                get_scheduler().schedule(trapframe);
+                return usize::MAX;
+            }
+            Err(_) => break,
+        }
+    }
+    written
+}
+
+/// Linux readv system call implementation
+///
+/// This system call reads data into multiple buffers (iovec) in a single call.
+///
+/// # Arguments
+/// - fd: File descriptor
+/// - iovec: Array of iovec structures
+/// - iovcnt: Number of elements in the array
+///
+/// # Returns
+/// - On success: number of bytes read
+/// - On error: usize::MAX
+pub fn sys_readv(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let fd = trapframe.get_arg(0) as usize;
+    let iovec_ptr = trapframe.get_arg(1);
+    let iovcnt = trapframe.get_arg(2) as usize;
+    trapframe.increment_pc_next(task);
+
+    if iovcnt == 0 {
+        return 0;
+    }
+    const IOV_MAX: usize = 1024;
+    if iovcnt > IOV_MAX {
+        return usize::MAX;
+    }
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => return usize::MAX,
+    };
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return usize::MAX,
+    };
+    let stream = match kernel_obj.as_stream() {
+        Some(s) => s,
+        None => return usize::MAX, // Not a stream object
+    };
+
+    let nonblocking = abi
+        .get_file_status_flags(fd)
+        .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+        .unwrap_or(false);
+    let iovec_vaddr = match task.vm_manager.translate_to_kva(iovec_ptr) {
+        Some(addr) => addr as *mut IoVec,
+        None => return usize::MAX,
+    };
+    if iovec_vaddr.is_null() {
+        return usize::MAX;
+    }
+    let iovecs = unsafe { core::slice::from_raw_parts_mut(iovec_vaddr, iovcnt) };
+    let mut total_read = 0usize;
+    for iovec in iovecs.iter_mut() {
+        if iovec.iov_len == 0 {
+            continue;
+        }
+        let buf_vaddr = match task.vm_manager.translate_to_kva(iovec.iov_base as usize) {
+            Some(addr) => addr as *mut u8,
+            None => return usize::MAX,
+        };
+        if buf_vaddr.is_null() {
+            return usize::MAX;
+        }
+        let buffer = unsafe { core::slice::from_raw_parts_mut(buf_vaddr, iovec.iov_len) };
+        match stream.read(buffer) {
+            Ok(n) => {
+                total_read = total_read.saturating_add(n);
+                // If partial read occurred, stop processing remaining vectors
+                // This matches Linux behavior for readv
+                if n < iovec.iov_len {
+                    break;
+                }
+            }
+            Err(StreamError::EndOfStream) => break,
+            Err(StreamError::WouldBlock) => {
+                if nonblocking {
+                    if total_read == 0 {
+                        return errno::to_result(errno::EAGAIN);
+                    } else {
+                        break;
+                    }
+                } else {
+                    get_scheduler().schedule(trapframe);
+                    return usize::MAX;
+                }
+            }
+            Err(_) => {
+                if total_read == 0 {
+                    return usize::MAX;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    total_read
+}
+
+/// Linux sys_fsync system call implementation (stub)
+/// Synchronize a file's in-core state with storage device
+///
+/// Arguments:
+/// - fd: File descriptor to synchronize
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX on error
+pub fn sys_fsync(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let _fd = trapframe.get_arg(0);
+    trapframe.increment_pc_next(task);
+
+    // TODO: Implement actual file synchronization
+    // For now, return success as a stub implementation
+    0
+}
+
+/// Linux sys_ftruncate implementation
+///
+/// Truncate a file to a specified length using a file descriptor.
+///
+/// Arguments:
+/// - fd: File descriptor to truncate
+/// - length: New file length
+///
+/// Returns:
+/// - 0 on success
+/// - negative errno on failure
+pub fn sys_ftruncate(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let fd = trapframe.get_arg(0) as usize;
+    let length = trapframe.get_arg(1) as i64;
+
+    trapframe.increment_pc_next(task);
+
+    if length < 0 {
+        return errno::to_result(errno::EINVAL);
+    }
+
+    let handle = match abi.get_handle(fd) {
+        Some(h) => h,
+        None => return errno::to_result(errno::EBADF),
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return errno::to_result(errno::EBADF),
+    };
+
+    if let Some(shared_memory) = kernel_obj.as_shared_memory() {
+        if let Err(_err) = shared_memory.resize(length as usize) {
+            return errno::to_result(errno::EINVAL);
+        }
+        return 0;
+    }
+
+    let file_obj = match kernel_obj.as_file() {
+        Some(f) => f,
+        None => return errno::to_result(errno::EINVAL),
+    };
+
+    let mut is_shm = false;
+    let mut shm_path = None;
+    if let Some(vfs_obj) = file_obj
+        .as_any()
+        .downcast_ref::<crate::fs::vfs_v2::core::VfsFileObject>()
+    {
+        let path = vfs_obj.get_original_path();
+        if path.contains("wl_shm-") {
+            is_shm = true;
+            shm_path = Some(path);
+            crate::println!("sys_ftruncate: shm path='{}' len={}", path, length);
+        }
+    }
+
+    match file_obj.truncate(length as u64) {
+        Ok(()) => 0,
+        Err(err) => {
+            if is_shm {
+                if let Ok(meta) = file_obj.metadata() {
+                    crate::println!(
+                        "sys_ftruncate: shm truncate failed len={} file_type={:?} size={}",
+                        length,
+                        meta.file_type,
+                        meta.size
+                    );
+                }
+                crate::println!("sys_ftruncate: shm truncate error={:?}", err);
+            } else if length > 0 {
+                let kind = match kernel_obj {
+                    crate::object::KernelObject::File(_) => "File",
+                    crate::object::KernelObject::Pipe(_) => "Pipe",
+                    crate::object::KernelObject::Counter(_) => "Counter",
+                    crate::object::KernelObject::EventChannel(_) => "EventChannel",
+                    crate::object::KernelObject::EventSubscription(_) => "EventSubscription",
+                    crate::object::KernelObject::SharedMemory(_) => "SharedMemory",
+                    #[cfg(feature = "network")]
+                    crate::object::KernelObject::Socket(_) => "Socket",
+                    #[cfg(feature = "hypervisor")]
+                    crate::object::KernelObject::HypervisorVm(_) => "HypervisorVm",
+                    #[cfg(feature = "hypervisor")]
+                    crate::object::KernelObject::HypervisorVcpu(_) => "HypervisorVcpu",
+                };
+                crate::println!(
+                    "sys_ftruncate: fd={} kind={} path={:?} len={} err={:?}",
+                    fd,
+                    kind,
+                    shm_path,
+                    length,
+                    err
+                );
+            }
+            errno::to_result(errno::EIO)
+        }
+    }
+}
+
+/// Linux sys_faccessat implementation (dummy: always returns 0)
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///
+/// Returns:
+/// - 0 (success)
+pub fn sys_faccessat(_abi: &mut LinuxAbi, trapframe: &mut crate::arch::Trapframe) -> usize {
+    let task = crate::task::mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    let dirfd = trapframe.get_arg(0) as i32;
+    let path_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(1)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+    let mode = trapframe.get_arg(2) as i32;
+    let path_str = match get_path_str_v2(path_ptr) {
+        Ok(p) => p,
+        Err(_) => return usize::MAX,
+    };
+
+    // crate::println!(
+    //     "sys_faccessat: epc={:#x}, dirfd={}, path='{}', mode={:#o}",
+    //     trapframe.epc,
+    //     dirfd,
+    //     path_str,
+    //     mode
+    // );
+
+    0
+}
+
+/// Linux faccessat2 system call (syscall 439)
+///
+/// Checks user's permissions for a file. Similar to faccessat but with
+/// additional flag support (AT_EACCESS, AT_SYMLINK_NOFOLLOW).
+///
+/// Signature: int faccessat2(int dirfd, const char *pathname, int mode, int flags);
+///
+/// Returns:
+/// - 0 (success)
+pub fn sys_faccessat2(_abi: &mut LinuxAbi, trapframe: &mut crate::arch::Trapframe) -> usize {
+    let task = crate::task::mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    let dirfd = trapframe.get_arg(0) as i32;
+    let path_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(1)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+    let mode = trapframe.get_arg(2) as i32;
+    let flags = trapframe.get_arg(3) as i32;
+    let path_str = match get_path_str_v2(path_ptr) {
+        Ok(p) => p,
+        Err(_) => return usize::MAX,
+    };
+
+    // crate::println!(
+    //     "sys_faccessat2: epc={:#x}, dirfd={}, path='{}', mode={:#o}, flags={:#x}",
+    //     trapframe.epc,
+    //     dirfd,
+    //     path_str,
+    //     mode,
+    //     flags
+    // );
+
+    0
+}
+
+/// Linux sys_mkdirat implementation
+///
+/// Currently supports only AT_FDCWD (current working directory) as dirfd.
+///
+pub fn sys_mkdirat(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+    trapframe.increment_pc_next(task);
+    let dirfd = trapframe.get_arg(0) as i32;
+    let path_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(1)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+    let path = match cstring_to_string(path_ptr, 128) {
+        Ok((p, _)) => p,
+        Err(_) => return usize::MAX,
+    };
+    // NOTE: Currently only AT_FDCWD is supported
+    if dirfd != -100 {
+        // AT_FDCWD
+        return usize::MAX;
+    }
+
+    let abs_path = match to_absolute_path_v2(&task, &path) {
+        Ok(p) => p,
+        Err(_) => return usize::MAX,
+    };
+    let vfs = match task.vfs.write().clone() {
+        Some(v) => v,
+        None => return usize::MAX,
+    };
+    match vfs.create_dir(&abs_path) {
+        Ok(_) => 0,
+        Err(_) => usize::MAX,
+    }
+}
+
+/// Linux sys_newfstat implementation for Scarlet VFS v2
+///
+/// Gets file status information from a file descriptor.
+/// This is equivalent to stat() but uses a file descriptor instead of a path.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: fd (file descriptor)
+///   - arg1: stat_ptr (pointer to LinuxStat structure)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_newfstat(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let fd = trapframe.get_arg(0) as i32;
+    let stat_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(1)) {
+        Some(ptr) => ptr as *mut u8,
+        None => return usize::MAX,
+    };
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Validate arguments
+    if stat_ptr.is_null() {
+        return usize::MAX; // Return -1 if stat pointer is null
+    }
+
+    // Get handle from file descriptor
+    let handle = match abi.get_handle(fd as usize) {
+        Some(h) => h,
+        None => return usize::MAX, // Invalid file descriptor
+    };
+
+    // Get kernel object from handle
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return usize::MAX, // Handle not found
+    };
+
+    // Get file object
+    let file_obj = match kernel_obj.as_file() {
+        Some(f) => f,
+        None => return usize::MAX, // Not a file object
+    };
+
+    // Get VFS file object to access metadata
+    use crate::fs::vfs_v2::core::VfsFileObject;
+    let vfs_file_obj = match file_obj.as_any().downcast_ref::<VfsFileObject>() {
+        Some(vfs_obj) => vfs_obj,
+        None => {
+            // For non-VFS files (like devices), create a basic stat with minimal info
+            let stat = unsafe { &mut *(stat_ptr as *mut LinuxStat) };
+            *stat = LinuxStat {
+                st_dev: 0,
+                st_ino: handle as u64,    // Use handle as inode
+                st_mode: S_IFCHR | 0o666, // Character device with rw-rw-rw- permissions
+                st_nlink: 1,
+                st_uid: 0,
+                st_gid: 0,
+                st_rdev: handle as u64,
+                __pad1: 0,
+                st_size: 0,
+                st_blksize: 4096,
+                __pad2: 0,
+                st_blocks: 0,
+                st_atime: 0,
+                st_atime_nsec: 0,
+                st_mtime: 0,
+                st_mtime_nsec: 0,
+                st_ctime: 0,
+                st_ctime_nsec: 0,
+                __unused4: 0,
+                __unused5: 0,
+            };
+            return 0; // Success
+        }
+    };
+
+    // Get VFS entry and metadata
+    let entry = vfs_file_obj.get_vfs_entry();
+    let node = entry.node();
+
+    match node.metadata() {
+        Ok(metadata) => {
+            let stat = unsafe { &mut *(stat_ptr as *mut LinuxStat) };
+            *stat = LinuxStat::from_metadata(&metadata);
+            // crate::println!(
+            //     "sys_newfstat: fd={} name='{}' size={}",
+            //     fd,
+            //     entry.name(),
+            //     metadata.size
+            // );
+            0 // Success
+        }
+        Err(_) => usize::MAX, // Error getting metadata
+    }
+}
+
+/// Linux sys_unlinkat implementation for Scarlet VFS v2
+///
+/// Removes a file or directory relative to a directory file descriptor.
+/// If dirfd == AT_FDCWD, uses the current working directory as the base.
+/// Otherwise, resolves the base directory from the file descriptor.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: dirfd (directory file descriptor)
+///   - arg1: path_ptr (pointer to path string)
+///   - arg2: flags (unlink flags)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_unlinkat(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let dirfd = trapframe.get_arg(0) as i32;
+    let path_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(1)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+    let flags = trapframe.get_arg(2) as i32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Parse path from user space
+    let path_str = match cstring_to_string(path_ptr, MAX_PATH_LENGTH) {
+        Ok((path, _)) => path,
+        Err(_) => return usize::MAX, // Invalid UTF-8
+    };
+
+    let path_str = remap_shm_path(&path_str);
+    if is_wl_shm_path(&path_str) {
+        crate::println!("sys_unlinkat: shm ignore path='{}'", path_str);
+        return 0;
+    }
+
+    // Linux constants for unlinkat
+    const AT_FDCWD: i32 = -100;
+    const AT_REMOVEDIR: i32 = 0x200;
+
+    let vfs = match task.vfs.read().clone() {
+        Some(v) => v,
+        None => return usize::MAX,
+    };
+
+    // Determine base directory for path resolution
+    use crate::fs::vfs_v2::core::VfsFileObject;
+
+    let (base_entry, base_mount) = if dirfd == AT_FDCWD {
+        // Use current working directory as base
+        vfs.get_cwd().unwrap_or_else(|| {
+            let root_mount = vfs.mount_tree.root_mount.read().clone();
+            (root_mount.root.clone(), root_mount)
+        })
+    } else {
+        // Use directory file descriptor as base
+        let handle = match abi.get_handle(dirfd as usize) {
+            Some(h) => h,
+            None => return usize::MAX,
+        };
+        let kernel_obj = match task.handle_table.get(handle) {
+            Some(obj) => obj,
+            None => return usize::MAX,
+        };
+        let file_obj = match kernel_obj.as_file() {
+            Some(f) => f,
+            None => return usize::MAX,
+        };
+        let vfs_file_obj = match file_obj.as_any().downcast_ref::<VfsFileObject>() {
+            Some(vfs_obj) => vfs_obj,
+            None => return usize::MAX,
+        };
+        (
+            vfs_file_obj.get_vfs_entry().clone(),
+            vfs_file_obj.get_mount_point().clone(),
+        )
+    };
+
+    // Resolve the target path and perform the removal operation
+    match vfs.resolve_path_from(&base_entry, &base_mount, &path_str) {
+        Ok((entry, _mount_point)) => {
+            // Prepare absolute path before getting mutable VFS reference
+            let absolute_path = if path_str.starts_with('/') {
+                path_str.to_string()
+            } else {
+                // Construct absolute path by resolving relative to current working directory
+                match to_absolute_path_v2(&task, &path_str) {
+                    Ok(p) => p,
+                    Err(_) => return usize::MAX,
+                }
+            };
+
+            // Get mutable reference to VFS for removal operations
+            let vfs_mut = match task.vfs.write().clone() {
+                Some(v) => v,
+                None => return usize::MAX,
+            };
+
+            // Check if AT_REMOVEDIR flag is set
+            if flags & AT_REMOVEDIR != 0 {
+                // Remove directory - check if it's actually a directory
+                let node = entry.node();
+                match node.metadata() {
+                    Ok(metadata) => {
+                        if metadata.file_type == FileType::Directory {
+                            // Try to remove the directory using VFS remove operation
+                            match vfs_mut.remove(&absolute_path) {
+                                Ok(_) => 0,           // Success
+                                Err(_) => usize::MAX, // Error removing directory
+                            }
+                        } else {
+                            usize::MAX // Not a directory, cannot use AT_REMOVEDIR
+                        }
+                    }
+                    Err(_) => usize::MAX, // Cannot get metadata
+                }
+            } else {
+                // Remove file or directory (standard removal)
+                match vfs_mut.remove(&absolute_path) {
+                    Ok(_) => 0,           // Success
+                    Err(_) => usize::MAX, // Error removing file
+                }
+            }
+        }
+        Err(_) => usize::MAX, // Path resolution failed
+    }
+}
+
+/// Linux epoll_create1 implementation (stub)
+///
+/// Creates an epoll file descriptor. This is a stub implementation that
+/// simply returns a dummy file descriptor to prevent application crashes.
+/// Real epoll functionality is not implemented.
+///
+/// Arguments:
+/// - abi: LinuxAbi context  
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: flags (epoll creation flags)
+///
+/// Returns:
+/// - file descriptor on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_epoll_create1(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let _flags = trapframe.get_arg(0) as i32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Create a dummy file handle to act as an epoll fd
+    // This is a workaround since we don't have real epoll implementation
+    // We'll use a simple placeholder handle
+
+    // Use a high handle number that's unlikely to conflict with real handles
+    const EPOLL_DUMMY_HANDLE: u32 = 0x1000_0000;
+
+    // For now, just return a dummy fd number that doesn't conflict with real fds
+    // This is not a proper implementation, but it prevents crashes
+    match abi.allocate_fd(EPOLL_DUMMY_HANDLE) {
+        Ok(fd) => fd,
+        Err(_) => usize::MAX,
+    }
+}
+
+/// Linux epoll_ctl implementation (stub)
+///
+/// Controls an epoll file descriptor by adding, modifying, or removing
+/// file descriptors from the epoll interest list. This is a stub implementation
+/// that simply returns success without doing anything.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: epfd (epoll file descriptor)
+///   - arg1: op (operation: EPOLL_CTL_ADD, EPOLL_CTL_MOD, EPOLL_CTL_DEL)
+///   - arg2: fd (target file descriptor)
+///   - arg3: event (pointer to epoll_event structure)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_epoll_ctl(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let _epfd = trapframe.get_arg(0) as i32;
+    let _op = trapframe.get_arg(1) as i32;
+    let _fd = trapframe.get_arg(2) as i32;
+    let _event_ptr = trapframe.get_arg(3);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Stub implementation: just return success
+    // In a real implementation, we would:
+    // 1. Validate the epoll fd
+    // 2. Parse the operation (EPOLL_CTL_ADD/MOD/DEL)
+    // 3. Manage the interest list
+    // 4. Set up event monitoring
+    0 // Success
+}
+
+/// Linux epoll_wait implementation (stub)
+///
+/// Waits for events on an epoll file descriptor. This is a stub implementation
+/// that immediately returns 0 (no events ready) to prevent blocking.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: epfd (epoll file descriptor)
+///   - arg1: events (pointer to epoll_event array)
+///   - arg2: maxevents (maximum number of events)
+///   - arg3: timeout (timeout in milliseconds)
+///
+/// Returns:
+/// - number of ready events
+/// - usize::MAX (Linux -1) on error
+pub fn sys_epoll_wait(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let _epfd = trapframe.get_arg(0) as i32;
+    let _events_ptr = trapframe.get_arg(1);
+    let _maxevents = trapframe.get_arg(2) as i32;
+    let _timeout = trapframe.get_arg(3) as i32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Stub implementation: return 0 (no events ready)
+    // In a real implementation, we would:
+    // 1. Validate the epoll fd
+    // 2. Check for ready events
+    // 3. Block if no events and timeout > 0
+    // 4. Fill the events array with ready events
+    0 // No events ready
+}
+
+/// Linux epoll_pwait implementation (stub)
+///
+/// Like epoll_wait but with signal mask. This is a stub implementation
+/// that immediately returns 0 (no events ready).
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: epfd (epoll file descriptor)  
+///   - arg1: events (pointer to epoll_event array)
+///   - arg2: maxevents (maximum number of events)
+///   - arg3: timeout (timeout in milliseconds)
+///   - arg4: sigmask (signal mask)
+///
+/// Returns:
+/// - number of ready events
+/// - usize::MAX (Linux -1) on error
+pub fn sys_epoll_pwait(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let _epfd = trapframe.get_arg(0) as i32;
+    let _events_ptr = trapframe.get_arg(1);
+    let _maxevents = trapframe.get_arg(2) as i32;
+    let _timeout = trapframe.get_arg(3) as i32;
+    let _sigmask_ptr = trapframe.get_arg(4);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Stub implementation: return 0 (no events ready)
+    0 // No events ready
+}
+
+/// Minimal Linux pselect6 implementation (stub)
+///
+/// Temporary reset: always returns immediately with 0 (no fds ready) and
+/// does not block. This avoids complex readiness/timeout semantics until
+/// the final design is in place.
+///
+/// Arguments (register usage):
+///   arg0: nfds (number of file descriptors to check)
+///   arg1: readfds pointer (fd_set*)
+///   arg2: writefds pointer (fd_set*)
+///   arg3: exceptfds pointer (fd_set*)
+///   arg4: timeout pointer (timespec*) or NULL
+///   arg5: sigmask pointer (ignored)
+///
+/// Returns: number of ready descriptors, or -1 (usize::MAX) on error.
+pub fn sys_pselect6(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    use crate::object::capability::selectable::{ReadyInterest, ReadySet};
+    use crate::timer::ns_to_ticks;
+
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let nfds = trapframe.get_arg(0) as usize;
+    let readfds_ptr = trapframe.get_arg(1);
+    let writefds_ptr = trapframe.get_arg(2);
+    let exceptfds_ptr = trapframe.get_arg(3);
+    let timeout_ptr = trapframe.get_arg(4);
+    let _sigmask_ptr = trapframe.get_arg(5);
+
+    // Only support up to 64 fds in this minimal implementation
+    let max_fds = core::cmp::min(nfds, 64);
+
+    // Translate fd_set user pointers (treat as u64 bitmask)
+    let mut in_read: u64 = 0;
+    let mut in_write: u64 = 0;
+    let mut in_except: u64 = 0;
+    if readfds_ptr != 0 {
+        let kptr = task.vm_manager.translate_to_kva(readfds_ptr).unwrap() as *const u64;
+        unsafe { in_read = core::ptr::read_unaligned(kptr) };
+    }
+    if writefds_ptr != 0 {
+        let kptr = task.vm_manager.translate_to_kva(writefds_ptr).unwrap() as *const u64;
+        unsafe { in_write = core::ptr::read_unaligned(kptr) };
+    }
+    if exceptfds_ptr != 0 {
+        let kptr = task.vm_manager.translate_to_kva(exceptfds_ptr).unwrap() as *const u64;
+        unsafe { in_except = core::ptr::read_unaligned(kptr) };
+    }
+
+    // Parse timeout (timespec)
+    #[repr(C)]
+    struct LinuxTimespec {
+        tv_sec: i64,
+        tv_nsec: i64,
+    }
+    let mut timeout_ticks: Option<u64> = None;
+    if timeout_ptr != 0 {
+        let kptr = task.vm_manager.translate_to_kva(timeout_ptr).unwrap() as *const LinuxTimespec;
+        let ts = unsafe { core::ptr::read_unaligned(kptr) };
+        // Zero timeout behaves as poll
+        if ts.tv_sec == 0 && ts.tv_nsec == 0 {
+            timeout_ticks = Some(0);
+        } else {
+            let ns = (ts.tv_sec as i128) * 1_000_000_000i128 + (ts.tv_nsec as i128);
+            let ns_u = if ns <= 0 { 0 } else { (ns as u128) as u64 };
+            timeout_ticks = Some(ns_to_ticks(ns_u));
+        }
+    }
+
+    // First pass: compute immediate readiness; default-ready for non-selectables
+    let mut out_read: u64 = 0;
+    let mut out_write: u64 = 0;
+    let mut out_except: u64 = 0;
+    let mut any_ready = false;
+    let mut first_selectable_fd: Option<usize> = None;
+
+    for fd in 0..max_fds {
+        let bit = 1u64 << fd;
+        let want_read = (in_read & bit) != 0;
+        let want_write = (in_write & bit) != 0;
+        let want_except = (in_except & bit) != 0;
+        if !(want_read || want_write || want_except) {
+            continue;
+        }
+
+        // Resolve handle → KernelObject
+        let Some(handle) = abi.get_handle(fd) else {
+            continue;
+        };
+        let Some(kobj) = task.handle_table.get(handle) else {
+            continue;
+        };
+
+        // Use generic Selectable if available; otherwise default policy
+        if let Some(sel) = kobj.as_selectable() {
+            // Remember first selectable for potential blocking
+            if first_selectable_fd.is_none() {
+                first_selectable_fd = Some(fd);
+            }
+
+            let interest = ReadyInterest {
+                read: want_read,
+                write: want_write,
+                except: want_except,
+            };
+            let rs: ReadySet = sel.current_ready(interest);
+            if rs.read {
+                out_read |= bit;
+                any_ready = true;
+            }
+            if rs.write {
+                out_write |= bit;
+                any_ready = true;
+            }
+            if rs.except {
+                out_except |= bit; /* any_ready unchanged */
+            }
+        } else {
+            // Default: treat as immediately ready (non-selectable path)
+            if want_read {
+                out_read |= bit;
+                any_ready = true;
+            }
+            if want_write {
+                out_write |= bit;
+                any_ready = true;
+            }
+            // except always false in this minimal implementation
+        }
+    }
+
+    // If nothing is ready and a non-zero timeout is provided, attempt to block
+    if !any_ready {
+        let zero_poll = matches!(timeout_ticks, Some(t) if t == 0);
+        if !zero_poll {
+            // Best-effort: wait on the first selectable fd's primary interest
+            if let Some(fd_wait) = first_selectable_fd {
+                let bit = 1u64 << fd_wait;
+                let want_read = (in_read & bit) != 0;
+                let want_write = (in_write & bit) != 0;
+                let want_except = (in_except & bit) != 0;
+                if let Some(handlew) = abi.get_handle(fd_wait) {
+                    if let Some(kobjw) = task.handle_table.get(handlew) {
+                        if let Some(sel) = kobjw.as_selectable() {
+                            let _ = sel.wait_until_ready(
+                                ReadyInterest {
+                                    read: want_read,
+                                    write: want_write,
+                                    except: want_except,
+                                },
+                                trapframe,
+                                timeout_ticks,
+                                0,
+                            );
+                            // After wake or timeout, recompute readiness for all fds properly
+                            out_read = 0;
+                            out_write = 0;
+                            out_except = 0;
+                            for fd2 in 0..max_fds {
+                                let bit2 = 1u64 << fd2;
+                                let want_r = (in_read & bit2) != 0;
+                                let want_w = (in_write & bit2) != 0;
+                                let want_x = (in_except & bit2) != 0;
+                                if !(want_r || want_w || want_x) {
+                                    continue;
+                                }
+                                if let Some(handle2) = abi.get_handle(fd2) {
+                                    if let Some(kobj2) = task.handle_table.get(handle2) {
+                                        if let Some(sel2) = kobj2.as_selectable() {
+                                            let rs2: ReadySet = sel2.current_ready(ReadyInterest {
+                                                read: want_r,
+                                                write: want_w,
+                                                except: want_x,
+                                            });
+                                            if rs2.read {
+                                                out_read |= bit2;
+                                            }
+                                            if rs2.write {
+                                                out_write |= bit2;
+                                            }
+                                            if rs2.except {
+                                                out_except |= bit2;
+                                            }
+                                        } else {
+                                            if want_r {
+                                                out_read |= bit2;
+                                            }
+                                            if want_w {
+                                                out_write |= bit2;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Write back fd_sets with results
+    if readfds_ptr != 0 {
+        let kptr = task.vm_manager.translate_to_kva(readfds_ptr).unwrap() as *mut u64;
+        unsafe { core::ptr::write_unaligned(kptr, out_read) };
+    }
+    if writefds_ptr != 0 {
+        let kptr = task.vm_manager.translate_to_kva(writefds_ptr).unwrap() as *mut u64;
+        unsafe { core::ptr::write_unaligned(kptr, out_write) };
+    }
+    if exceptfds_ptr != 0 {
+        let kptr = task.vm_manager.translate_to_kva(exceptfds_ptr).unwrap() as *mut u64;
+        unsafe { core::ptr::write_unaligned(kptr, out_except) };
+    }
+
+    // Return count of ready fds
+    let ready_count = out_read.count_ones() as usize
+        + out_write.count_ones() as usize
+        + out_except.count_ones() as usize;
+
+    trapframe.increment_pc_next(task);
+    ready_count
+}
+
+/// Minimal Linux ppoll implementation
+///
+/// Arguments
+///   arg0: fds_ptr (struct pollfd*)
+///   arg1: nfds (usize)
+///   arg2: timeout_ptr (timespec*) or NULL
+///   arg3: sigmask (ignored)
+///   arg4: sigsetsize (ignored)
+///
+/// Returns: number of fds with non-zero revents, or -1 (usize::MAX) on error.
+pub fn sys_ppoll(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    use crate::object::capability::selectable::{ReadyInterest, ReadySet};
+    use crate::timer::ns_to_ticks;
+
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    #[repr(C)]
+    struct PollFd {
+        fd: i32,
+        events: i16,
+        revents: i16,
+    }
+
+    const POLLIN: i16 = 0x0001;
+    const POLLPRI: i16 = 0x0002;
+    const POLLOUT: i16 = 0x0004;
+    const POLLERR: i16 = 0x0008;
+    const POLLHUP: i16 = 0x0010;
+    const POLLNVAL: i16 = 0x0020;
+
+    let fds_ptr = trapframe.get_arg(0);
+    let nfds = trapframe.get_arg(1) as usize;
+    let timeout_ptr = trapframe.get_arg(2);
+    let _sigmask = trapframe.get_arg(3);
+    let _sigsetsize = trapframe.get_arg(4);
+
+    trapframe.increment_pc_next(task);
+
+    if fds_ptr == 0 {
+        return usize::MAX;
+    }
+    let kptr = match task.vm_manager.translate_to_kva(fds_ptr) {
+        Some(p) => p as *mut PollFd,
+        None => return usize::MAX,
+    };
+    if kptr.is_null() {
+        return usize::MAX;
+    }
+    let fds: &mut [PollFd] = unsafe { core::slice::from_raw_parts_mut(kptr, nfds) };
+
+    #[repr(C)]
+    struct LinuxTimespec {
+        tv_sec: i64,
+        tv_nsec: i64,
+    }
+    let mut timeout_ticks: Option<u64> = None;
+    if timeout_ptr != 0 {
+        let tsp = match task.vm_manager.translate_to_kva(timeout_ptr) {
+            Some(p) => p as *const LinuxTimespec,
+            None => return usize::MAX,
+        };
+        let ts = unsafe { core::ptr::read_unaligned(tsp) };
+        if ts.tv_sec == 0 && ts.tv_nsec == 0 {
+            timeout_ticks = Some(0);
+        } else {
+            let ns = (ts.tv_sec as i128) * 1_000_000_000i128 + (ts.tv_nsec as i128);
+            let ns_u = if ns <= 0 { 0 } else { (ns as u128) as u64 };
+            timeout_ticks = Some(ns_to_ticks(ns_u));
+            // crate::println!(
+            //     "[sys_ppoll] timeout ts={}s {}ns -> ns={} ticks={:?}",
+            //     ts.tv_sec,
+            //     ts.tv_nsec,
+            //     ns_u,
+            //     timeout_ticks
+            // );
+        }
+    }
+
+    struct EvalResult {
+        ready: bool,
+        selectable: bool,
+    }
+
+    fn eval_pfd(pfd: &mut PollFd, abi_ref: &LinuxAbi, task_ref: &crate::task::Task) -> EvalResult {
+        pfd.revents = 0;
+        if pfd.fd < 0 {
+            pfd.revents |= POLLNVAL;
+            return EvalResult {
+                ready: true,
+                selectable: false,
+            };
+        }
+        let fd_usize = pfd.fd as usize;
+        let Some(handle) = abi_ref.get_handle(fd_usize) else {
+            pfd.revents |= POLLNVAL;
+            return EvalResult {
+                ready: true,
+                selectable: false,
+            };
+        };
+        let Some(kobj) = task_ref.handle_table.get(handle) else {
+            pfd.revents |= POLLNVAL;
+            return EvalResult {
+                ready: true,
+                selectable: false,
+            };
+        };
+
+        let want_read = (pfd.events & POLLIN) != 0;
+        let want_write = (pfd.events & POLLOUT) != 0;
+        let want_except = (pfd.events & POLLPRI) != 0;
+
+        let mut selectable = false;
+
+        if let Some(sel) = kobj.as_selectable() {
+            selectable = true;
+            let rs: ReadySet = sel.current_ready(ReadyInterest {
+                read: want_read,
+                write: want_write,
+                except: want_except,
+            });
+            if rs.read && want_read {
+                pfd.revents |= POLLIN;
+            }
+            if rs.write && want_write {
+                pfd.revents |= POLLOUT;
+            }
+            if rs.except && want_except {
+                pfd.revents |= POLLPRI;
+            }
+        } else {
+            if want_read {
+                pfd.revents |= POLLIN;
+            }
+            if want_write {
+                pfd.revents |= POLLOUT;
+            }
+        }
+
+        if let Some(pipe) = kobj.as_pipe() {
+            if pipe.is_readable() && !pipe.has_writers() {
+                pfd.revents |= POLLHUP;
+                if want_read && (pfd.revents & POLLIN) == 0 {
+                    pfd.revents |= POLLIN;
+                }
+            }
+            if pipe.is_writable() && !pipe.has_readers() {
+                pfd.revents |= POLLERR | POLLHUP;
+            }
+        }
+
+        EvalResult {
+            ready: pfd.revents != 0,
+            selectable,
+        }
+    }
+
+    let mut any_ready = false;
+    let mut first_selectable_index: Option<usize> = None;
+    let mut selectable_count = 0usize;
+    let mut ready_count = 0usize;
+    {
+        let abi_ref = &*abi;
+        let task_ref: &crate::task::Task = &*task;
+        for (idx, pfd) in fds.iter_mut().enumerate() {
+            let eval = eval_pfd(pfd, abi_ref, task_ref);
+            if eval.ready {
+                any_ready = true;
+                ready_count += 1;
+            }
+            if eval.selectable {
+                selectable_count += 1;
+            }
+            if first_selectable_index.is_none() && eval.selectable {
+                first_selectable_index = Some(idx);
+            }
+
+            let mut kind = "unknown";
+            let mut socket_state: Option<u32> = None;
+            let fd_usize = pfd.fd as usize;
+            if let Some(handle) = abi_ref.get_handle(fd_usize) {
+                if let Some(kobj) = task_ref.handle_table.get(handle) {
+                    match kobj {
+                        crate::object::KernelObject::File(_) => {
+                            kind = "file";
+                        }
+                        crate::object::KernelObject::Pipe(_) => {
+                            kind = "pipe";
+                        }
+                        crate::object::KernelObject::Counter(_) => {
+                            kind = "counter";
+                        }
+                        crate::object::KernelObject::EventChannel(_) => {
+                            kind = "event_channel";
+                        }
+                        crate::object::KernelObject::EventSubscription(_) => {
+                            kind = "event_sub";
+                        }
+                        #[cfg(feature = "network")]
+                        crate::object::KernelObject::Socket(socket) => {
+                            kind = "socket";
+                            socket_state = Some(socket.state() as u32);
+                        }
+                        crate::object::KernelObject::SharedMemory(_) => {
+                            kind = "shmem";
+                        }
+                        #[cfg(feature = "hypervisor")]
+                        crate::object::KernelObject::HypervisorVm(_) => {
+                            kind = "hypervisor_vm";
+                        }
+                        #[cfg(feature = "hypervisor")]
+                        crate::object::KernelObject::HypervisorVcpu(_) => {
+                            kind = "hypervisor_vcpu";
+                        }
+                    }
+                }
+            }
+
+            // crate::println!(
+            //     "[sys_ppoll] fd={} events=0x{:x} revents=0x{:x} selectable={} kind={} socket_state={:?}",
+            //     pfd.fd,
+            //     pfd.events as u16,
+            //     pfd.revents as u16,
+            //     eval.selectable,
+            //     kind,
+            //     socket_state
+            // );
+        }
+    }
+
+    {
+        let zero_poll = matches!(timeout_ticks, Some(t) if t == 0);
+        // crate::println!(
+        //     "[sys_ppoll] task={} nfds={} selectable={} ready={} any_ready={} zero_poll={} timeout_ticks={:?} first_selectable={:?}",
+        //     task.name,
+        //     nfds,
+        //     selectable_count,
+        //     ready_count,
+        //     any_ready,
+        //     zero_poll,
+        //     timeout_ticks,
+        //     first_selectable_index
+        // );
+    }
+
+    if !any_ready {
+        let zero_poll = matches!(timeout_ticks, Some(t) if t == 0);
+        if !zero_poll {
+            if selectable_count > 1 {
+                use crate::timer::get_tick;
+
+                let deadline = timeout_ticks.map(|ticks| get_tick().saturating_add(ticks));
+                loop {
+                    if let Some(deadline) = deadline {
+                        let now = get_tick();
+                        if now >= deadline {
+                            break;
+                        }
+                        let remaining = deadline.saturating_sub(now);
+                        if remaining == 0 {
+                            break;
+                        }
+                    }
+
+                    task.sleep(trapframe, 1);
+
+                    any_ready = false;
+                    ready_count = 0;
+                    {
+                        let abi_ref = &*abi;
+                        let task_ref: &crate::task::Task = &*task;
+                        for pfd in fds.iter_mut() {
+                            let eval = eval_pfd(pfd, abi_ref, task_ref);
+                            if eval.ready {
+                                any_ready = true;
+                                ready_count += 1;
+                            }
+                        }
+                    }
+
+                    if any_ready {
+                        break;
+                    }
+                }
+            } else if let Some(wait_idx) = first_selectable_index {
+                let pfd = &fds[wait_idx];
+                if pfd.fd >= 0 {
+                    let fd_usize = pfd.fd as usize;
+                    let abi_ref = &*abi;
+                    let task_ref: &crate::task::Task = &*task;
+                    if let Some(handle) = abi_ref.get_handle(fd_usize) {
+                        if let Some(kobj) = task_ref.handle_table.get(handle) {
+                            if let Some(sel) = kobj.as_selectable() {
+                                let want_read = (pfd.events & POLLIN) != 0;
+                                let want_write = (pfd.events & POLLOUT) != 0;
+                                let want_except = (pfd.events & POLLPRI) != 0;
+                                let _ = sel.wait_until_ready(
+                                    ReadyInterest {
+                                        read: want_read,
+                                        write: want_write,
+                                        except: want_except,
+                                    },
+                                    trapframe,
+                                    timeout_ticks,
+                                    0,
+                                );
+                            }
+                        }
+                    }
+                }
+
+                let abi_ref = &*abi;
+                let task_ref: &crate::task::Task = &*task;
+                for pfd in fds.iter_mut() {
+                    let _ = eval_pfd(pfd, abi_ref, task_ref);
+                }
+            }
+        }
+    }
+
+    let mut count = 0usize;
+    for pfd in fds.iter() {
+        if pfd.revents != 0 {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Linux sys_fchmod implementation (stub)
+///
+/// Changes the permissions of a file using its file descriptor.
+/// This is a stub implementation that simply validates the file descriptor
+/// and returns success without actually changing permissions.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: fd (file descriptor)
+///   - arg1: mode (new file permissions)
+///
+/// Returns:
+/// - 0 on success (if fd is valid)
+/// - usize::MAX (Linux -1) on error (if fd is invalid)
+pub fn sys_fchmod(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let fd = trapframe.get_arg(0) as i32;
+    let _mode = trapframe.get_arg(1) as u32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Validate the file descriptor
+    let handle = match abi.get_handle(fd as usize) {
+        Some(h) => h,
+        None => return usize::MAX, // Invalid file descriptor
+    };
+
+    // Check if the handle exists in the handle table
+    match task.handle_table.get(handle) {
+        Some(_) => {
+            // File descriptor is valid, return success
+            // In a real implementation, we would change the file permissions here
+            0 // Success
+        }
+        None => usize::MAX, // Handle not found
+    }
+}
+
+/// Linux sys_umask implementation (stub)
+///
+/// Sets the file mode creation mask (umask) and returns the previous value.
+/// This is a stub implementation that simply returns the provided mask
+/// without actually storing or using it for file creation permissions.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: mask (new file creation mask)
+///
+/// Returns:
+/// - The provided mask value (simulating the previous umask)
+pub fn sys_umask(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let mask = trapframe.get_arg(0) as u32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // In a real implementation, we would:
+    // 1. Store the current umask value to return it
+    // 2. Set the new umask value for future file creation operations
+    // 3. Return the previous umask value
+    //
+    // For this stub implementation, we simply return the provided mask
+    // This satisfies most applications that just want to set a umask
+    mask as usize // Return the provided mask as if it was the previous value
+}
+
+/// Linux sys_readlinkat implementation
+///
+/// Reads the target of a symbolic link relative to a directory file descriptor.
+/// Properly queries the VFS and does not append a null terminator.
+///
+/// Arguments:
+/// - abi: LinuxAbi context  
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: dirfd (directory file descriptor or AT_FDCWD)
+///   - arg1: pathname (pointer to path string)
+///   - arg2: buf (buffer to store link contents)
+///   - arg3: bufsiz (size of buffer)
+///
+/// Returns:
+/// - Number of bytes placed in buf on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_readlinkat(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::EIO),
+    };
+
+    let dirfd = trapframe.get_arg(0) as i32;
+    let pathname_ptr = trapframe.get_arg(1);
+    let buf_ptr = trapframe.get_arg(2);
+    let bufsiz = trapframe.get_arg(3) as usize;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Fast path: zero-sized buffer
+    if bufsiz == 0 {
+        return 0;
+    }
+
+    // Parse the pathname
+    let path_str = match parse_c_string_from_userspace(task, pathname_ptr, MAX_PATH_LENGTH) {
+        Ok(s) => s,
+        Err(_) => return errno::to_result(errno::EFAULT),
+    };
+
+    // Acquire VFS
+    let vfs = match task.vfs.read().clone() {
+        Some(v) => v,
+        None => return errno::to_result(errno::EIO),
+    };
+
+    // Determine base directory (entry and mount) for path resolution
+    use crate::fs::vfs_v2::core::VfsFileObject;
+    const AT_FDCWD: i32 = -100;
+
+    let (base_entry, base_mount) = if dirfd == AT_FDCWD {
+        vfs.get_cwd().unwrap_or_else(|| {
+            let root_mount = vfs.mount_tree.root_mount.read().clone();
+            (root_mount.root.clone(), root_mount)
+        })
+    } else {
+        // Resolve base from dirfd
+        let handle = match abi.get_handle(dirfd as usize) {
+            Some(h) => h,
+            None => return errno::to_result(errno::EBADF),
+        };
+        let kernel_obj = match task.handle_table.get(handle) {
+            Some(obj) => obj,
+            None => return errno::to_result(errno::EBADF),
+        };
+        let file_obj = match kernel_obj.as_file() {
+            Some(f) => f,
+            None => return errno::to_result(errno::ENOTDIR),
+        };
+        let vfs_file_obj = match file_obj.as_any().downcast_ref::<VfsFileObject>() {
+            Some(vfs_obj) => vfs_obj,
+            None => return errno::to_result(errno::ENOTDIR),
+        };
+        (
+            vfs_file_obj.get_vfs_entry().clone(),
+            vfs_file_obj.get_mount_point().clone(),
+        )
+    };
+
+    // Resolve the path from the base (do not follow the final link)
+    let (entry, _mp) = match vfs.resolve_path_from(&base_entry, &base_mount, &path_str) {
+        Ok(v) => v,
+        Err(e) => return errno::to_result(errno::from_fs_error(&e)),
+    };
+
+    // Ensure the target is a symlink and obtain its target
+    let node = entry.node();
+    let metadata = match node.metadata() {
+        Ok(m) => m,
+        Err(e) => return errno::to_result(errno::from_fs_error(&e)),
+    };
+
+    let target = match metadata.file_type {
+        FileType::SymbolicLink(ref t) => t.as_str(),
+        _ => return errno::to_result(errno::EINVAL), // Not a symlink
+    };
+
+    // Copy to user buffer (no null terminator), truncated if needed
+    let target_bytes = target.as_bytes();
+    let copy_len = core::cmp::min(target_bytes.len(), bufsiz);
+
+    let user_buf = match task.vm_manager.translate_to_kva(buf_ptr) {
+        Some(addr) => addr as *mut u8,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    if copy_len > 0 {
+        unsafe {
+            core::ptr::copy_nonoverlapping(target_bytes.as_ptr(), user_buf, copy_len);
+        }
+    }
+
+    copy_len
+}
+
+/// Linux sys_getrandom implementation
+///
+/// Fills the user buffer with random bytes from the kernel pool.
+pub fn sys_getrandom(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::EIO),
+    };
+
+    let buf_ptr = trapframe.get_arg(0);
+    let buflen = trapframe.get_arg(1) as usize;
+    let flags = trapframe.get_arg(2) as u32;
+
+    trapframe.increment_pc_next(task);
+
+    if buflen == 0 {
+        return 0;
+    }
+
+    let user_buf = match task.vm_manager.translate_to_kva(buf_ptr) {
+        Some(addr) => addr as *mut u8,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    if user_buf.is_null() {
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let buffer = unsafe { core::slice::from_raw_parts_mut(user_buf, buflen) };
+    let bytes_read = crate::random::RandomManager::get_random_bytes(buffer);
+
+    if bytes_read == 0 {
+        if (flags & GRND_NONBLOCK) != 0 {
+            return errno::to_result(errno::EAGAIN);
+        }
+        fill_pseudo_random(buffer);
+        return buflen;
+    }
+
+    if bytes_read < buflen && (flags & GRND_NONBLOCK) == 0 {
+        fill_pseudo_random(&mut buffer[bytes_read..]);
+        return buflen;
+    }
+
+    bytes_read
+}
+
+/// Linux sys_getcwd system call implementation
+/// Get current working directory
+///
+/// Arguments:
+/// - buf: Buffer to store the current working directory path
+/// - size: Size of the buffer
+///
+/// Returns:
+/// - Number of bytes written to buffer on success
+/// - usize::MAX on error
+pub fn sys_getcwd(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let buf_ptr = trapframe.get_arg(0);
+    let size = trapframe.get_arg(1);
+    trapframe.increment_pc_next(task);
+
+    // Check for invalid arguments
+    if buf_ptr == 0 || size == 0 {
+        return usize::MAX; // EFAULT or EINVAL
+    }
+
+    // Get current working directory from task context
+    let cwd = if let Some(vfs) = task.vfs.read().clone() {
+        vfs.get_cwd_path()
+    } else {
+        "/".to_string() // Default to root if no VFS manager
+    };
+    let cwd_bytes = cwd.as_bytes();
+
+    // Check if buffer is large enough (including null terminator)
+    if cwd_bytes.len() + 1 > size {
+        return usize::MAX; // ERANGE - buffer too small
+    }
+
+    // Translate user buffer address
+    let user_buf = match task.vm_manager.translate_to_kva(buf_ptr) {
+        Some(addr) => addr as *mut u8,
+        None => return usize::MAX, // EFAULT - invalid buffer address
+    };
+
+    // Copy current working directory to user buffer
+    unsafe {
+        core::ptr::copy_nonoverlapping(cwd_bytes.as_ptr(), user_buf, cwd_bytes.len());
+        // Add null terminator
+        *user_buf.add(cwd_bytes.len()) = 0;
+    }
+
+    // Return the number of bytes written (including null terminator)
+    cwd_bytes.len() + 1
+}
+
+/// Linux sys_chdir system call implementation (syscall 49)
+/// Change current working directory
+///
+/// Arguments:
+/// - path: Path to the new working directory
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX on error (path not found, not a directory, permission denied, etc.)
+pub fn sys_chdir(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let path_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(0)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Parse path from user space
+    let path_str = match cstring_to_string(path_ptr, MAX_PATH_LENGTH) {
+        Ok((path, _)) => path,
+        Err(_) => return usize::MAX, // Invalid UTF-8 or path too long
+    };
+
+    crate::println!("sys_chdir: Changing directory to '{}'", path_str);
+
+    // Convert to absolute path
+    let absolute_path = if path_str.starts_with('/') {
+        path_str
+    } else {
+        match to_absolute_path_v2(&task, &path_str) {
+            Ok(p) => p,
+            Err(_) => return usize::MAX,
+        }
+    };
+
+    let vfs = match task.vfs.read().clone() {
+        Some(v) => v,
+        None => return usize::MAX,
+    };
+
+    // Check if the path exists and is a directory
+    match vfs.resolve_path(&absolute_path) {
+        Ok((entry, _mount_point)) => {
+            match entry.node().file_type() {
+                Ok(file_type) => {
+                    if file_type == FileType::Directory {
+                        // Update the current working directory via VfsManager
+                        match vfs.set_cwd_by_path(&absolute_path) {
+                            Ok(()) => {
+                                crate::println!(
+                                    "sys_chdir: Successfully changed directory to '{}'",
+                                    absolute_path
+                                );
+                                0 // Success
+                            }
+                            Err(_) => {
+                                crate::println!(
+                                    "sys_chdir: Failed to set working directory to '{}'",
+                                    absolute_path
+                                );
+                                usize::MAX // Failed to set cwd
+                            }
+                        }
+                    } else {
+                        crate::println!("sys_chdir: '{}' is not a directory", absolute_path);
+                        usize::MAX // Not a directory (ENOTDIR)
+                    }
+                }
+                Err(_) => {
+                    crate::println!("sys_chdir: Failed to get file type for '{}'", absolute_path);
+                    usize::MAX // Failed to get file type
+                }
+            }
+        }
+        Err(_) => {
+            crate::println!("sys_chdir: Path '{}' not found", absolute_path);
+            usize::MAX // Path not found (ENOENT)
+        }
+    }
+}
+
+// renameat2 flags
+const RENAME_NOREPLACE: u32 = 1 << 0; // Don't overwrite target
+const RENAME_EXCHANGE: u32 = 1 << 1; // Exchange source and target
+#[allow(dead_code)]
+const RENAME_WHITEOUT: u32 = 1 << 2; // Create whiteout object
+
+/// Linux sys_renameat2 system call implementation (syscall 276)
+/// Rename/move a file or directory with additional flags
+///
+/// Arguments:
+/// - olddirfd: Old directory file descriptor (or AT_FDCWD)
+/// - oldpath: Pointer to old path string
+/// - newdirfd: New directory file descriptor (or AT_FDCWD)  
+/// - newpath: Pointer to new path string
+/// - flags: Rename operation flags
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX on error
+pub fn sys_renameat2(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let olddirfd = trapframe.get_arg(0) as i32;
+    let oldpath_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(1)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+    let newdirfd = trapframe.get_arg(2) as i32;
+    let newpath_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(3)) {
+        Some(ptr) => ptr as *const u8,
+        None => return usize::MAX,
+    };
+    let flags = trapframe.get_arg(4) as u32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Parse old path from user space
+    let oldpath_str = match cstring_to_string(oldpath_ptr, MAX_PATH_LENGTH) {
+        Ok((path, _)) => path,
+        Err(_) => return usize::MAX, // Invalid UTF-8 or path too long
+    };
+
+    // Parse new path from user space
+    let newpath_str = match cstring_to_string(newpath_ptr, MAX_PATH_LENGTH) {
+        Ok((path, _)) => path,
+        Err(_) => return usize::MAX, // Invalid UTF-8 or path too long
+    };
+
+    crate::println!(
+        "sys_renameat2: olddirfd={}, oldpath='{}', newdirfd={}, newpath='{}', flags={:#x}",
+        olddirfd,
+        oldpath_str,
+        newdirfd,
+        newpath_str,
+        flags
+    );
+
+    // Check for unsupported flags
+    const SUPPORTED_FLAGS: u32 = RENAME_NOREPLACE | RENAME_EXCHANGE;
+    if (flags & !SUPPORTED_FLAGS) != 0 {
+        crate::println!(
+            "sys_renameat2: Unsupported flags: {:#x}",
+            flags & !SUPPORTED_FLAGS
+        );
+        return usize::MAX; // EINVAL - unsupported flags
+    }
+
+    // RENAME_EXCHANGE and RENAME_NOREPLACE are mutually exclusive
+    if (flags & RENAME_EXCHANGE) != 0 && (flags & RENAME_NOREPLACE) != 0 {
+        crate::println!(
+            "sys_renameat2: RENAME_EXCHANGE and RENAME_NOREPLACE are mutually exclusive"
+        );
+        return usize::MAX; // EINVAL
+    }
+
+    let vfs = match task.vfs.read().clone() {
+        Some(v) => v,
+        None => return usize::MAX,
+    };
+
+    // Note: Current implementation ignores dirfd and only uses absolute path resolution
+    // TODO: Implement proper *at support for relative paths from directory file descriptors
+
+    // Resolve absolute paths using basic path resolution
+    let old_absolute_path = if oldpath_str.starts_with('/') {
+        oldpath_str
+    } else {
+        match to_absolute_path_v2(&task, &oldpath_str) {
+            Ok(p) => p,
+            Err(_) => return usize::MAX,
+        }
+    };
+
+    let new_absolute_path = if newpath_str.starts_with('/') {
+        newpath_str
+    } else {
+        match to_absolute_path_v2(&task, &newpath_str) {
+            Ok(p) => p,
+            Err(_) => return usize::MAX,
+        }
+    };
+
+    crate::println!(
+        "sys_renameat2: Resolved paths: '{}' -> '{}'",
+        old_absolute_path,
+        new_absolute_path
+    );
+
+    // Handle different rename operations based on flags
+    if (flags & RENAME_EXCHANGE) != 0 {
+        // Exchange operation: swap the two files/directories
+        crate::println!("sys_renameat2: Exchange operation not yet implemented");
+        return usize::MAX; // ENOSYS - not implemented
+    } else {
+        // Standard rename/move operation
+        let no_replace = (flags & RENAME_NOREPLACE) != 0;
+
+        // Check if target exists when RENAME_NOREPLACE is set
+        if no_replace {
+            match vfs.resolve_path(&new_absolute_path) {
+                Ok(_) => {
+                    crate::println!(
+                        "sys_renameat2: Target exists and RENAME_NOREPLACE flag is set"
+                    );
+                    return usize::MAX; // EEXIST - target exists
+                }
+                Err(_) => {
+                    // Target doesn't exist, which is what we want for RENAME_NOREPLACE
+                }
+            }
+        }
+
+        // Implement rename as a combination of copy and remove (simplified approach)
+        // This is not ideal for atomic operations but works with current VFS API
+        // TODO: Implement proper atomic rename operation in VfsManager
+
+        // For now, return not implemented for most cases
+        // In practice, this would need proper filesystem-level rename support
+        crate::println!("sys_renameat2: Full rename operation not yet implemented");
+        0 // Return success for basic compatibility (temporary)
+    }
+}
+
+/// eventfd2 - create file descriptor for event notification
+///
+/// # Arguments
+/// * `initval` - Initial value of the event counter (unsigned int)
+/// * `flags` - Flags (bitwise OR of EFD_CLOEXEC, EFD_NONBLOCK, EFD_SEMAPHORE)
+///
+/// # Returns
+/// * New file descriptor on success
+/// * Error code on failure
+pub fn sys_eventfd2(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::EIO),
+    };
+
+    let initval = trapframe.get_arg(0) as u32;
+    let flags = trapframe.get_arg(1) as u32;
+
+    trapframe.increment_pc_next(task);
+
+    // eventfd2 flags
+    const EFD_CLOEXEC: u32 = 0o02000000;
+    const EFD_NONBLOCK: u32 = 0o00004000;
+    const EFD_SEMAPHORE: u32 = 0x00000001;
+
+    // Validate flags (only allow EFD_CLOEXEC, EFD_NONBLOCK, EFD_SEMAPHORE)
+    let valid_flags = EFD_CLOEXEC | EFD_NONBLOCK | EFD_SEMAPHORE;
+    if flags & !valid_flags != 0 {
+        crate::println!("[sys_eventfd2] Invalid flags: 0x{:x}", flags);
+        return errno::to_result(errno::EINVAL);
+    }
+
+    // Create Counter object
+    let counter_obj = crate::ipc::counter::Counter::create_kernel_object(initval, flags);
+
+    // Insert into handle table
+    let handle = match task.handle_table.insert(counter_obj) {
+        Ok(h) => h,
+        Err(_) => return errno::to_result(errno::EMFILE),
+    };
+
+    // Allocate file descriptor for the handle
+    let fd = match abi.allocate_fd(handle as u32) {
+        Ok(fd) => fd,
+        Err(_) => {
+            let _ = task.handle_table.remove(handle);
+            return errno::to_result(errno::EMFILE);
+        }
+    };
+
+    // Set FD_CLOEXEC if requested
+    if (flags & EFD_CLOEXEC) != 0 {
+        let _ = abi.set_fd_flags(fd, FD_CLOEXEC);
+    }
+
+    // Set O_NONBLOCK if requested (already set in Counter, but also in ABI for consistency)
+    if (flags & EFD_NONBLOCK) != 0 {
+        let _ = abi.set_file_status_flags(fd, O_NONBLOCK as u32);
+    }
+
+    fd
+}

--- a/kernel/src/abi/linux/generic/futex.rs
+++ b/kernel/src/abi/linux/generic/futex.rs
@@ -1,0 +1,109 @@
+use crate::abi::linux::generic::LinuxAbi;
+use crate::arch::Trapframe;
+use crate::sync::waker::Waker;
+use alloc::collections::BTreeMap;
+use spin::{Mutex, Once};
+
+// Minimal FUTEX op codes (match Linux)
+const FUTEX_WAIT: u32 = 0;
+const FUTEX_WAKE: u32 = 1;
+// Extended ops commonly used by musl
+const FUTEX_WAIT_BITSET: u32 = 9;
+const FUTEX_WAKE_BITSET: u32 = 10;
+const FUTEX_CMD_MASK: u32 = 0x3f; // per Linux uapi
+
+// Global registry of futex wakers keyed by user address
+static FUTEX_WAKERS: Once<Mutex<BTreeMap<usize, Waker>>> = Once::new();
+
+fn init_futex_wakers() -> Mutex<BTreeMap<usize, Waker>> {
+    Mutex::new(BTreeMap::new())
+}
+
+fn get_futex_waker(uaddr: usize) -> &'static Waker {
+    let futex_map_mutex = FUTEX_WAKERS.call_once(init_futex_wakers);
+    let mut map = futex_map_mutex.lock();
+    if !map.contains_key(&uaddr) {
+        // Leak a static name for diagnostics
+        let name = alloc::format!("futex_{:#x}", uaddr);
+        let static_name = alloc::boxed::Box::leak(name.into_boxed_str());
+        map.insert(uaddr, Waker::new_interruptible(static_name));
+    }
+    unsafe {
+        let ptr = map.get(&uaddr).unwrap() as *const Waker;
+        &*ptr
+    }
+}
+
+/// Wake up to `max` waiters on a futex at `uaddr`.
+pub fn wake_address(uaddr: usize, max: usize) -> usize {
+    let waker = get_futex_waker(uaddr);
+    if max == 0 {
+        return 0;
+    }
+    let mut woken = 0;
+    if max == usize::MAX {
+        // treat as wake_all
+        woken = waker.wake_all();
+    } else {
+        for _ in 0..max {
+            if waker.wake_one() {
+                woken += 1;
+            } else {
+                break;
+            }
+        }
+    }
+    woken
+}
+
+/// Linux futex syscall (minimal implementation: WAIT/WAKE)
+pub fn sys_futex(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match crate::task::mytask() {
+        Some(t) => t,
+        None => return super::errno::to_result(super::errno::EPERM),
+    };
+
+    // args: uaddr, op, val, timeout, uaddr2, val3
+    let uaddr = trapframe.get_arg(0) as usize;
+    let op_raw = trapframe.get_arg(1) as u32;
+    let val = trapframe.get_arg(2) as i32;
+    let _timeout = trapframe.get_arg(3) as usize; // TODO: implement timeout
+    let _uaddr2 = trapframe.get_arg(4) as usize;
+    let _val3 = trapframe.get_arg(5) as u32; // e.g., bitset for *_BITSET ops
+
+    // Always advance PC to avoid re-executing syscall on resume
+    trapframe.increment_pc_next(task);
+
+    let cmd = op_raw & FUTEX_CMD_MASK; // strip PRIVATE/other flags
+    match cmd {
+        FUTEX_WAIT | FUTEX_WAIT_BITSET => {
+            // Validate user address and expected value
+            let paddr = match task.vm_manager.translate_to_kva(uaddr) {
+                Some(pa) => pa,
+                None => return super::errno::to_result(super::errno::EFAULT),
+            };
+            let cur_val = unsafe { *(paddr as *const i32) };
+            if cur_val != val {
+                // Expected value mismatch -> EAGAIN (common benign fast-path)
+                return super::errno::to_result(super::errno::EAGAIN);
+            }
+
+            // Block current task on futex queue
+            let waker = get_futex_waker(uaddr);
+            let tid = task.get_id();
+            waker.wait(tid, trapframe);
+            // When resumed, report success (Linux may report -EINTR if interrupted; TBD)
+            0
+        }
+        FUTEX_WAKE | FUTEX_WAKE_BITSET => {
+            let max = if val < 0 { 0 } else { val as usize };
+            let woken = wake_address(uaddr, max);
+            // Return number of woken tasks
+            woken
+        }
+        _ => {
+            // Not implemented ops
+            super::errno::to_result(super::errno::ENOSYS)
+        }
+    }
+}

--- a/kernel/src/abi/linux/generic/macros.rs
+++ b/kernel/src/abi/linux/generic/macros.rs
@@ -1,0 +1,24 @@
+/// Define a syscall dispatch table returning `Option<usize>`.
+///
+/// Returns `Some(result)` on match, `None` otherwise.
+/// Enables two-phase dispatch: common table first, then arch-specific fallback.
+macro_rules! syscall_table {
+    ( $handler_name:ident, $( $name:ident = $num:expr => $func:expr ),* $(,)? ) => {
+        #[allow(dead_code)]
+        #[derive(Debug)]
+        pub enum Syscall {
+            $(
+                $name = $num,
+            )*
+        }
+
+        pub fn $handler_name(abi: &mut crate::abi::linux::generic::LinuxAbi, trapframe: &mut crate::arch::Trapframe, syscall_number: usize) -> Option<usize> {
+            match syscall_number {
+                $(
+                    $num => Some($func(abi, trapframe)),
+                )*
+                _ => None,
+            }
+        }
+    };
+}

--- a/kernel/src/abi/linux/generic/mm.rs
+++ b/kernel/src/abi/linux/generic/mm.rs
@@ -1,0 +1,582 @@
+use crate::{
+    abi::linux::generic::{
+        LinuxAbi,
+        errno::{self, to_result},
+    },
+    arch::Trapframe,
+    environment::PAGE_SIZE,
+    object::capability::memory_mapping::syscall::reclaim_private_removed_mapping,
+    task::mytask,
+    vm::addr::{is_direct_mapped, virt_to_phys},
+    vm::vmem::{MemoryArea, VirtualMemoryMap},
+};
+use alloc::vec::Vec;
+
+pub fn sys_mmap(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    // Linux mmap constants
+    const MAP_ANONYMOUS: usize = 0x20;
+    #[allow(dead_code)]
+    const MAP_FIXED: usize = 0x10;
+    #[allow(dead_code)]
+    const MAP_SHARED: usize = 0x01;
+
+    // Linux protection flags
+    const PROT_READ: usize = 0x1;
+    const PROT_WRITE: usize = 0x2;
+    const PROT_EXEC: usize = 0x4;
+
+    let task = match mytask() {
+        Some(task) => task,
+        None => return usize::MAX,
+    };
+
+    let addr = trapframe.get_arg(0);
+    let length = trapframe.get_arg(1);
+    let prot = trapframe.get_arg(2);
+    let flags = trapframe.get_arg(3);
+    let fd = trapframe.get_arg(4) as isize;
+    let offset = trapframe.get_arg(5);
+
+    trapframe.increment_pc_next(task);
+
+    // Input validation
+    if length == 0 {
+        return usize::MAX; // -EINVAL
+    }
+
+    // Round up length to page boundary
+    let aligned_length = (length + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+    let num_pages = aligned_length / PAGE_SIZE;
+
+    // Handle ANONYMOUS mappings specially
+    if (flags & MAP_ANONYMOUS) != 0 {
+        if fd != -1 {
+            return to_result(errno::EINVAL);
+        }
+        let result = handle_anonymous_mapping(task, addr, aligned_length, num_pages, prot, flags);
+        return result;
+    }
+
+    // Handle file-backed mappings
+    if fd == -1 {
+        return to_result(errno::EINVAL);
+    }
+
+    // Get handle from Linux fd
+    let handle = match abi.get_handle(fd as usize) {
+        Some(h) => h,
+        None => return to_result(errno::EBADF),
+    };
+
+    // Get kernel object from handle
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => return to_result(errno::EBADF),
+    };
+
+    // Special case: KVM vCPU mmap (shared kvm_run page).
+    // kvmtool calls mmap(vcpu_fd, ...) to map the per-vCPU kvm_run structure.
+    // This bypasses the generic MemoryMappingOps path because HypervisorVcpu
+    // doesn't implement that trait — the kvm_run page is managed by the KVM
+    // compat layer instead.
+    #[cfg(feature = "hypervisor")]
+    if let crate::object::KernelObject::HypervisorVcpu(vcpu) = &kernel_obj {
+        return handle_kvm_vcpu_mmap(task, &vcpu, addr, aligned_length, prot, flags);
+    }
+
+    // Check if object supports MemoryMappingOps
+    let memory_mappable = match kernel_obj.as_memory_mappable() {
+        Some(mappable) => mappable,
+        None => return to_result(errno::ENODEV),
+    };
+
+    // Check if the object supports mmap
+    if !memory_mappable.supports_mmap() {
+        return to_result(errno::ENODEV);
+    }
+
+    // Decide sharing semantics from flags (MAP_SHARED controls sharing)
+    let is_shared = (flags & MAP_SHARED) != 0;
+    let is_fixed = (flags & MAP_FIXED) != 0;
+    const MAP_PRIVATE: usize = 0x02;
+    let is_map_private_flag = (flags & MAP_PRIVATE) != 0;
+
+    // Determine final address
+    let final_vaddr = if addr == 0 {
+        match task
+            .vm_manager
+            .find_unmapped_area(aligned_length, PAGE_SIZE)
+        {
+            Some(vaddr) => vaddr,
+            None => return to_result(errno::ENOMEM),
+        }
+    } else {
+        if addr % PAGE_SIZE != 0 {
+            return to_result(errno::EINVAL);
+        }
+
+        if !is_fixed {
+            let requested_end = addr + aligned_length - 1;
+            let has_overlap = task.vm_manager.with_memmaps(|mm| {
+                mm.values()
+                    .any(|map| !(requested_end < map.vmarea.start || addr > map.vmarea.end))
+            });
+
+            if has_overlap {
+                match task
+                    .vm_manager
+                    .find_unmapped_area(aligned_length, PAGE_SIZE)
+                {
+                    Some(vaddr) => vaddr,
+                    None => return to_result(errno::ENOMEM),
+                }
+            } else {
+                addr
+            }
+        } else {
+            addr
+        }
+    };
+
+    // Convert protection flags to kernel permissions
+    let mut prot_mask = 0;
+    if (prot & PROT_READ) != 0 {
+        prot_mask |= 0x1;
+    }
+    if (prot & PROT_WRITE) != 0 {
+        prot_mask |= 0x2;
+    }
+    if (prot & PROT_EXEC) != 0 {
+        prot_mask |= 0x4;
+    }
+
+    let mut final_permissions = if is_map_private_flag {
+        prot_mask
+    } else {
+        prot_mask
+    };
+
+    if prot != 0 {
+        final_permissions |= 0x08;
+    }
+
+    if is_map_private_flag && !is_shared {
+        let owner = match kernel_obj.as_memory_mappable_arc() {
+            Some(owner) => owner,
+            None => return to_result(errno::ENODEV),
+        };
+        let vm_map = VirtualMemoryMap {
+            pmarea: MemoryArea { start: 0, end: 0 },
+            vmarea: MemoryArea::new(final_vaddr, final_vaddr + aligned_length - 1),
+            vm_start: final_vaddr,
+            permissions: final_permissions,
+            is_shared: false,
+            owner: Some(owner),
+        };
+
+        let removed_mappings = if is_fixed {
+            task.vm_manager
+                .add_memory_map_fixed(vm_map)
+                .map_err(|_| to_result(errno::ENOMEM))
+        } else {
+            task.vm_manager
+                .add_memory_map(vm_map)
+                .map(|_| Vec::new())
+                .map_err(|_| to_result(errno::ENOMEM))
+        };
+
+        let removed_mappings = match removed_mappings {
+            Ok(rm) => rm,
+            Err(e) => return e,
+        };
+
+        for removed_map in &removed_mappings {
+            if let Some(owner) = &removed_map.owner {
+                owner.on_unmapped(removed_map.vmarea.start, removed_map.vmarea.size());
+            }
+        }
+        for removed_map in removed_mappings {
+            reclaim_private_removed_mapping(task, &removed_map);
+        }
+
+        memory_mappable.on_mapped(final_vaddr, 0, aligned_length, offset);
+        return final_vaddr;
+    }
+
+    // Shared path: need get_mapping_info_with for pmarea and permissions
+    let mut ok_len = aligned_length;
+    let (mapping_base, obj_permissions, _obj_is_shared) = loop {
+        match memory_mappable.get_mapping_info_with(offset, ok_len, is_shared) {
+            Ok(info) => break info,
+            Err(_e) => {
+                if ok_len >= PAGE_SIZE {
+                    ok_len -= PAGE_SIZE;
+                } else {
+                    ok_len = 0;
+                }
+                if ok_len == 0 {
+                    break (0, 0, false);
+                }
+            }
+        }
+    };
+    let paddr = if mapping_base != 0 && is_direct_mapped(mapping_base) {
+        virt_to_phys(mapping_base)
+    } else {
+        mapping_base
+    };
+
+    final_permissions = obj_permissions & prot_mask;
+    if prot != 0 {
+        final_permissions |= 0x08;
+    }
+
+    if paddr == 0 && ok_len == 0 {
+        return to_result(errno::EINVAL);
+    }
+
+    let ok_len_aligned = (ok_len / PAGE_SIZE) * PAGE_SIZE;
+    if ok_len_aligned == 0 {
+        return to_result(errno::EINVAL);
+    }
+
+    let vmarea = MemoryArea::new(final_vaddr, final_vaddr + ok_len_aligned - 1);
+    let pmarea = MemoryArea::new(paddr, paddr + ok_len_aligned - 1);
+
+    let owner = kernel_obj.as_memory_mappable_arc();
+    let vm_map = VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner);
+
+    let map_result = if is_fixed {
+        task.vm_manager
+            .add_memory_map_fixed(vm_map)
+            .map(|removed| Some(removed))
+    } else {
+        task.vm_manager.add_memory_map(vm_map).map(|_| None)
+    };
+
+    match map_result {
+        Ok(removed_mappings_opt) => {
+            memory_mappable.on_mapped(final_vaddr, paddr, ok_len_aligned, offset);
+
+            if let Some(removed_mappings) = &removed_mappings_opt {
+                for removed_map in removed_mappings {
+                    if removed_map.is_shared {
+                        if let Some(owner) = &removed_map.owner {
+                            owner.on_unmapped(removed_map.vmarea.start, removed_map.vmarea.size());
+                        }
+                    }
+                }
+            }
+
+            if let Some(removed_mappings) = removed_mappings_opt {
+                for removed_map in removed_mappings {
+                    reclaim_private_removed_mapping(task, &removed_map);
+                }
+            }
+
+            final_vaddr
+        }
+        Err(_) => to_result(errno::ENOMEM),
+    }
+}
+
+/// Handle anonymous memory mapping based on scarlet's implementation
+fn handle_anonymous_mapping(
+    task: &crate::task::Task,
+    vaddr: usize,
+    aligned_length: usize,
+    _num_pages: usize,
+    prot: usize,
+    flags: usize,
+) -> usize {
+    // Linux protection flags
+    const PROT_READ: usize = 0x1;
+    const PROT_WRITE: usize = 0x2;
+    const PROT_EXEC: usize = 0x4;
+    const MAP_FIXED: usize = 0x10;
+
+    // For anonymous mappings, decide shareable based on flags
+    const MAP_SHARED: usize = 0x01;
+    let is_shared = (flags & MAP_SHARED) != 0;
+
+    // Determine final address - if vaddr is 0, find an unmapped area
+    let final_vaddr = if vaddr == 0 {
+        match task
+            .vm_manager
+            .find_unmapped_area(aligned_length, PAGE_SIZE)
+        {
+            Some(addr) => addr,
+            None => return to_result(errno::ENOMEM),
+        }
+    } else {
+        let is_fixed = (flags & MAP_FIXED) != 0;
+        if !is_fixed {
+            let requested_end = vaddr + aligned_length - 1;
+            let has_overlap = task.vm_manager.with_memmaps(|mm| {
+                mm.values()
+                    .any(|map| !(requested_end < map.vmarea.start || vaddr > map.vmarea.end))
+            });
+
+            if has_overlap {
+                match task
+                    .vm_manager
+                    .find_unmapped_area(aligned_length, PAGE_SIZE)
+                {
+                    Some(addr) => addr,
+                    None => return to_result(errno::ENOMEM),
+                }
+            } else {
+                vaddr
+            }
+        } else {
+            vaddr
+        }
+    };
+
+    // Convert protection flags to kernel permissions
+    let mut permissions = 0;
+    if prot != 0 {
+        permissions |= 0x08;
+        if (prot & PROT_READ) != 0 {
+            permissions |= 0x1;
+        }
+        if (prot & PROT_WRITE) != 0 {
+            permissions |= 0x2;
+        }
+        if (prot & PROT_EXEC) != 0 {
+            permissions |= 0x4;
+        }
+    }
+
+    let owner: alloc::sync::Arc<dyn crate::object::capability::memory_mapping::MemoryMappingOps> =
+        alloc::sync::Arc::new(
+            crate::object::capability::memory_mapping::anon_owner::AnonymousPageOwner::new(),
+        );
+
+    let vmarea = MemoryArea::new(final_vaddr, final_vaddr + aligned_length - 1);
+    let vm_map = VirtualMemoryMap {
+        pmarea: MemoryArea { start: 0, end: 0 },
+        vmarea,
+        vm_start: final_vaddr,
+        permissions,
+        is_shared,
+        owner: Some(owner),
+    };
+
+    let removed_mappings = match task.vm_manager.add_memory_map_fixed(vm_map) {
+        Ok(removed) => removed,
+        Err(_) => return to_result(errno::ENOMEM),
+    };
+
+    for removed_map in &removed_mappings {
+        if removed_map.is_shared {
+            if let Some(owner) = &removed_map.owner {
+                owner.on_unmapped(removed_map.vmarea.start, removed_map.vmarea.size());
+            }
+        }
+    }
+    for removed_map in removed_mappings {
+        reclaim_private_removed_mapping(task, &removed_map);
+    }
+    final_vaddr
+}
+
+pub fn sys_mprotect(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    // Linux protection flags
+    const PROT_READ: usize = 0x1;
+    const PROT_WRITE: usize = 0x2;
+    const PROT_EXEC: usize = 0x4;
+
+    let task = match mytask() {
+        Some(task) => task,
+        None => return usize::MAX,
+    };
+
+    let addr = trapframe.get_arg(0);
+    let length = trapframe.get_arg(1);
+    let prot = trapframe.get_arg(2);
+
+    trapframe.increment_pc_next(task);
+
+    // Input validation
+    if length == 0 || addr % PAGE_SIZE != 0 {
+        return usize::MAX; // -EINVAL
+    }
+
+    // Round up length to page boundary
+    let aligned_length = (length + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+    let num_pages = aligned_length / PAGE_SIZE;
+
+    // Check if all pages in the range are mapped
+    for i in 0..num_pages {
+        let page_addr = addr + i * PAGE_SIZE;
+        if task.vm_manager.translate_to_kva(page_addr).is_none() {
+            return usize::MAX; // -ENOMEM
+        }
+    }
+
+    // Convert Linux protection flags to kernel permissions
+    let mut new_permissions = 0;
+    if prot != 0 {
+        new_permissions |= 0x08; // Access from user space (only if not PROT_NONE)
+        if (prot & PROT_READ) != 0 {
+            new_permissions |= 0x1; // Readable
+        }
+        if (prot & PROT_WRITE) != 0 {
+            new_permissions |= 0x2; // Writable
+        }
+        if (prot & PROT_EXEC) != 0 {
+            new_permissions |= 0x4; // Executable
+        }
+    }
+
+    for i in 0..num_pages {
+        let page_addr = addr + i * PAGE_SIZE;
+        let original_mapping = match task.vm_manager.search_memory_map(page_addr) {
+            Some(map) => map,
+            None => return usize::MAX,
+        };
+
+        if let Some(owner) = &original_mapping.owner {
+            let offset = page_addr - original_mapping.vmarea.start;
+            if let Ok((_, obj_permissions, _)) = owner.get_mapping_info(offset, PAGE_SIZE) {
+                if (new_permissions & obj_permissions) != (new_permissions & 0x7) {
+                    return usize::MAX;
+                }
+            }
+        }
+
+        let offset_in_mapping = page_addr - original_mapping.vmarea.start;
+        let new_paddr = original_mapping.pmarea.start + offset_in_mapping;
+        let new_map = VirtualMemoryMap::new(
+            MemoryArea::new(new_paddr, new_paddr + PAGE_SIZE - 1),
+            MemoryArea::new(page_addr, page_addr + PAGE_SIZE - 1),
+            new_permissions,
+            original_mapping.is_shared,
+            original_mapping.owner.clone(),
+        );
+
+        if task.vm_manager.add_memory_map_fixed(new_map).is_err() {
+            return usize::MAX;
+        }
+    }
+
+    0
+}
+
+pub fn sys_munmap(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(task) => task,
+        None => return usize::MAX,
+    };
+
+    let vaddr = trapframe.get_arg(0);
+    let length = trapframe.get_arg(1);
+
+    trapframe.increment_pc_next(task);
+
+    // Input validation
+    if length == 0 || vaddr % PAGE_SIZE != 0 {
+        return usize::MAX; // -EINVAL
+    }
+
+    if vaddr == 0 {
+        return usize::MAX; // -EINVAL
+    }
+
+    // Remove the mapping range, splitting existing mappings if necessary
+    let removed_maps = task.vm_manager.remove_memory_map_range(vaddr, length);
+
+    if removed_maps.is_empty() {
+        return usize::MAX; // No mappings found in the specified range
+    }
+
+    // Notify the object owners and clean up page allocations
+    for removed_map in &removed_maps {
+        if let Some(owner) = &removed_map.owner {
+            owner.on_unmapped(removed_map.vmarea.start, removed_map.vmarea.size());
+        }
+
+        reclaim_private_removed_mapping(task, removed_map);
+    }
+
+    0
+}
+
+/// Handle mmap for a KVM vCPU fd — maps the shared kvm_run page.
+#[cfg(feature = "hypervisor")]
+fn handle_kvm_vcpu_mmap(
+    task: &crate::task::Task,
+    vcpu: &crate::hypervisor::VcpuRef,
+    addr: usize,
+    aligned_length: usize,
+    prot: usize,
+    flags: usize,
+) -> usize {
+    crate::println!(
+        "[KVM-VCPU-MMAP] addr={:#x} len={:#x} prot={:#x} flags={:#x}",
+        addr,
+        aligned_length,
+        prot,
+        flags
+    );
+    const PROT_READ: usize = 0x1;
+    const PROT_WRITE: usize = 0x2;
+    const MAP_SHARED: usize = 0x01;
+    const MAP_FIXED: usize = 0x10;
+
+    let paddr = match crate::abi::linux::device::kvm::get_vcpu_run_paddr(vcpu) {
+        Some(p) => p,
+        None => return to_result(errno::ENODEV),
+    };
+
+    // The kvm_run backing is exactly one page. Clamp the mapping length to
+    // PAGE_SIZE regardless of what the caller requested to avoid mapping
+    // beyond the allocated page.
+    let map_length = PAGE_SIZE;
+
+    let is_fixed = (flags & MAP_FIXED) != 0;
+    let is_shared = (flags & MAP_SHARED) != 0;
+
+    let final_vaddr = if addr == 0 {
+        match task.vm_manager.find_unmapped_area(map_length, PAGE_SIZE) {
+            Some(vaddr) => vaddr,
+            None => return to_result(errno::ENOMEM),
+        }
+    } else if is_fixed {
+        addr
+    } else {
+        addr
+    };
+
+    let mut prot_mask = 0;
+    if (prot & PROT_READ) != 0 {
+        prot_mask |= 0x1;
+    }
+    if (prot & PROT_WRITE) != 0 {
+        prot_mask |= 0x2;
+    }
+    if prot != 0 {
+        prot_mask |= 0x08;
+    }
+
+    let pmarea = MemoryArea::new(paddr, paddr + map_length - 1);
+    let vmarea = MemoryArea::new(final_vaddr, final_vaddr + map_length - 1);
+    let vm_map = VirtualMemoryMap::new(pmarea, vmarea, prot_mask, is_shared, None);
+
+    let map_result = if is_fixed {
+        task.vm_manager
+            .add_memory_map_fixed(vm_map)
+            .map(|removed| Some(removed))
+    } else {
+        task.vm_manager.add_memory_map(vm_map).map(|_| None)
+    };
+
+    match map_result {
+        Ok(_removed_mappings_opt) => final_vaddr,
+        Err(_) => to_result(errno::ENOMEM),
+    }
+}
+
+// TODO: Migrate object-backed MAP_PRIVATE mappings to delayed Copy-On-Write (COW).
+// (omitted for brevity)

--- a/kernel/src/abi/linux/generic/mod.rs
+++ b/kernel/src/abi/linux/generic/mod.rs
@@ -1,0 +1,352 @@
+#[macro_use]
+mod macros;
+pub mod errno;
+pub mod fs;
+pub mod futex;
+pub mod mm;
+pub mod pipe;
+pub mod proc;
+pub mod signal;
+pub mod socket;
+pub mod time;
+
+use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
+
+use self::time::PosixTimer;
+use crate::arch::Trapframe;
+
+const MAX_FDS: usize = 1024;
+
+#[derive(Clone, Default)]
+pub struct LinuxThreadState {
+    pub parent_tid_ptr: Option<usize>,
+    pub child_tid_ptr: Option<usize>,
+    pub clear_child_tid_ptr: Option<usize>,
+    pub robust_list_head: Option<usize>,
+    pub robust_list_len: usize,
+    pub tls_pointer: Option<usize>,
+    pub tgid: usize,
+    pub pending_clone_is_thread: bool,
+}
+
+#[derive(Clone)]
+pub struct LinuxAbi {
+    pub namespace: Arc<crate::task::namespace::TaskNamespace>,
+    pub fd_to_handle: Vec<Option<u32>>,
+    pub fd_flags: Vec<u32>,
+    pub file_status_flags: Vec<u32>,
+    pub free_fds: Vec<usize>,
+    pub signal_state: Arc<spin::Mutex<signal::SignalState>>,
+    pub thread_state: LinuxThreadState,
+    pub posix_timers: BTreeMap<u64, PosixTimer>,
+    pub next_timer_id: u64,
+}
+
+impl Default for LinuxAbi {
+    fn default() -> Self {
+        let mut free_fds: Vec<usize> = (0..MAX_FDS).collect();
+        free_fds.reverse();
+
+        let namespace = crate::task::namespace::get_root_namespace().clone();
+
+        Self {
+            namespace,
+            fd_to_handle: vec![None; MAX_FDS],
+            fd_flags: vec![0; MAX_FDS],
+            file_status_flags: vec![0; MAX_FDS],
+            free_fds,
+            signal_state: Arc::new(spin::Mutex::new(signal::SignalState::new())),
+            thread_state: LinuxThreadState::default(),
+            posix_timers: BTreeMap::new(),
+            next_timer_id: 1,
+        }
+    }
+}
+
+impl LinuxAbi {
+    pub fn thread_state(&self) -> &LinuxThreadState {
+        &self.thread_state
+    }
+    pub fn thread_state_mut(&mut self) -> &mut LinuxThreadState {
+        &mut self.thread_state
+    }
+
+    pub fn allocate_fd(&mut self, handle: u32) -> Result<usize, &'static str> {
+        let fd = if let Some(freed_fd) = self.free_fds.pop() {
+            freed_fd
+        } else {
+            return Err("Too many open files");
+        };
+        self.fd_to_handle[fd] = Some(handle);
+        Ok(fd)
+    }
+
+    pub fn allocate_specific_fd(&mut self, fd: usize, handle: u32) -> Result<(), &'static str> {
+        if fd >= MAX_FDS {
+            return Err("File descriptor out of range");
+        }
+        if self.fd_to_handle[fd].is_some() {
+            return Err("File descriptor already in use");
+        }
+        if let Some(pos) = self.free_fds.iter().position(|&x| x == fd) {
+            self.free_fds.remove(pos);
+        }
+        self.fd_to_handle[fd] = Some(handle);
+        Ok(())
+    }
+
+    pub fn get_handle(&self, fd: usize) -> Option<u32> {
+        if fd < MAX_FDS {
+            self.fd_to_handle[fd]
+        } else {
+            None
+        }
+    }
+
+    pub fn remove_fd(&mut self, fd: usize) -> Option<u32> {
+        if fd < MAX_FDS {
+            if let Some(handle) = self.fd_to_handle[fd].take() {
+                self.fd_flags[fd] = 0;
+                self.file_status_flags[fd] = 0;
+                self.free_fds.push(fd);
+                Some(handle)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn find_fd_by_handle(&self, handle: u32) -> Option<usize> {
+        for (fd, &mapped_handle) in self.fd_to_handle.iter().enumerate() {
+            if let Some(h) = mapped_handle {
+                if h == handle {
+                    return Some(fd);
+                }
+            }
+        }
+        None
+    }
+
+    pub fn init_std_fds(&mut self, stdin_handle: u32, stdout_handle: u32, stderr_handle: u32) {
+        self.fd_to_handle[0] = Some(stdin_handle);
+        self.fd_to_handle[1] = Some(stdout_handle);
+        self.fd_to_handle[2] = Some(stderr_handle);
+        self.free_fds.retain(|&fd| fd != 0 && fd != 1 && fd != 2);
+    }
+
+    pub fn get_fd_flags(&self, fd: usize) -> Option<u32> {
+        if fd < MAX_FDS && self.fd_to_handle[fd].is_some() {
+            Some(self.fd_flags[fd])
+        } else {
+            None
+        }
+    }
+
+    pub fn set_fd_flags(&mut self, fd: usize, flags: u32) -> Result<(), &'static str> {
+        use crate::{object::handle::SpecialSemantics, task::mytask};
+
+        if fd < MAX_FDS && self.fd_to_handle[fd].is_some() {
+            let handle = self.fd_to_handle[fd].unwrap();
+            self.fd_flags[fd] = flags;
+
+            if let Some(task) = mytask() {
+                if let Some(current_metadata) = task.handle_table.get_metadata(handle) {
+                    let mut new_metadata = current_metadata.clone();
+
+                    if flags & fs::FD_CLOEXEC != 0 {
+                        new_metadata.special_semantics = Some(SpecialSemantics::CloseOnExec);
+                    } else {
+                        if matches!(
+                            new_metadata.special_semantics,
+                            Some(SpecialSemantics::CloseOnExec)
+                        ) {
+                            new_metadata.special_semantics = None;
+                        }
+                    }
+
+                    let _ = task.handle_table.update_metadata(handle, new_metadata);
+                }
+            }
+
+            Ok(())
+        } else {
+            Err("Invalid file descriptor")
+        }
+    }
+
+    pub fn get_file_status_flags(&self, fd: usize) -> Option<u32> {
+        if fd < MAX_FDS && self.fd_to_handle[fd].is_some() {
+            Some(self.file_status_flags[fd])
+        } else {
+            None
+        }
+    }
+
+    pub fn set_file_status_flags(&mut self, fd: usize, flags: u32) -> Result<(), &'static str> {
+        if fd < MAX_FDS && self.fd_to_handle[fd].is_some() {
+            self.file_status_flags[fd] = flags;
+            Ok(())
+        } else {
+            Err("Invalid file descriptor")
+        }
+    }
+
+    pub fn fd_count(&self) -> usize {
+        self.fd_to_handle.iter().filter(|&&h| h.is_some()).count()
+    }
+
+    pub fn allocated_fds(&self) -> Vec<usize> {
+        self.fd_to_handle
+            .iter()
+            .enumerate()
+            .filter_map(|(fd, &handle)| if handle.is_some() { Some(fd) } else { None })
+            .collect()
+    }
+
+    pub fn process_signals(&self, trapframe: &mut Trapframe) -> bool {
+        let mut signal_state = self.signal_state.lock();
+        signal::process_pending_signals_with_state(&mut *signal_state, trapframe)
+    }
+
+    pub fn handle_event_direct(&self, event: &crate::ipc::event::Event) {
+        if let Some(signal) = signal::handle_event_to_signal(event) {
+            let mut signal_state = self.signal_state.lock();
+            signal_state.add_pending(signal);
+        }
+    }
+
+    pub fn has_pending_signals(&self) -> bool {
+        let signal_state = self.signal_state.lock();
+        signal_state.next_deliverable_signal().is_some()
+    }
+
+    pub fn allocate_posix_timer_id(&mut self) -> u64 {
+        let mut id = self.next_timer_id;
+        if id == 0 {
+            id = 1;
+        }
+        self.next_timer_id = id.wrapping_add(1);
+        if self.next_timer_id == 0 {
+            self.next_timer_id = 1;
+        }
+        id
+    }
+
+    pub fn store_posix_timer(&mut self, timer: PosixTimer) {
+        self.posix_timers.insert(timer.id, timer);
+    }
+
+    pub fn get_posix_timer(&self, id: u64) -> Option<&PosixTimer> {
+        self.posix_timers.get(&id)
+    }
+
+    pub fn remove_posix_timer(&mut self, id: u64) -> Option<PosixTimer> {
+        self.posix_timers.remove(&id)
+    }
+}
+
+syscall_table! {
+    dispatch_common_syscall,
+    Invalid = 0 => |_abi: &mut crate::abi::linux::generic::LinuxAbi, _trapframe: &mut crate::arch::Trapframe| {
+        0
+    },
+    Getcwd = 17 => fs::sys_getcwd,
+    Eventfd2 = 19 => fs::sys_eventfd2,
+    EpollCtl = 21 => fs::sys_epoll_ctl,
+    EpollPwait = 22 => fs::sys_epoll_pwait,
+    EpollCreate1 = 20 => fs::sys_epoll_create1,
+    Flock = 32 => fs::sys_flock,
+    Dup = 23 => fs::sys_dup,
+    Dup3 = 24 => fs::sys_dup3,
+    Fcntl = 25 => fs::sys_fcntl,
+    Ioctl = 29 => fs::sys_ioctl,
+    MkdirAt = 34 => fs::sys_mkdirat,
+    UnlinkAt = 35 => fs::sys_unlinkat,
+    Ftruncate = 46 => fs::sys_ftruncate,
+    Fallocate = 47 => fs::sys_fallocate,
+    LinkAt = 37 => fs::sys_linkat,
+    FaccessAt = 48 => fs::sys_faccessat,
+    Chdir = 49 => fs::sys_chdir,
+    Fchmod = 52 => fs::sys_fchmod,
+    OpenAt = 56 => fs::sys_openat,
+    Close = 57 => fs::sys_close,
+    Pipe2 = 59 => pipe::sys_pipe2,
+    GetDents64 = 61 => fs::sys_getdents64,
+    Lseek = 62 => fs::sys_lseek,
+    Read = 63 => fs::sys_read,
+    Write = 64 => fs::sys_write,
+    Readv = 65 => fs::sys_readv,
+    Writev = 66 => fs::sys_writev,
+    Pread64 = 67 => fs::sys_pread64,
+    Pwrite64 = 68 => fs::sys_pwrite64,
+    Pselect6 = 72 => fs::sys_pselect6,
+    Ppoll = 73 => fs::sys_ppoll,
+    NewFstAtAt = 79 => fs::sys_newfstatat,
+    NewFstat = 80 => fs::sys_newfstat,
+    ReadLinkAt = 78 => fs::sys_readlinkat,
+    Fsync = 82 => fs::sys_fsync,
+    Exit = 93 => proc::sys_exit,
+    ExitGroup = 94 => proc::sys_exit_group,
+    SetTidAddress = 96 => proc::sys_set_tid_address,
+    Futex = 98 => futex::sys_futex,
+    SetRobustList = 99 => proc::sys_set_robust_list,
+    Nanosleep = 101 => time::sys_nanosleep,
+    TimerCreate = 107 => time::sys_timer_create,
+    TimerGettime = 108 => time::sys_timer_gettime,
+    TimerGetoverrun = 109 => time::sys_timer_getoverrun,
+    TimerSettime = 110 => time::sys_timer_settime,
+    TimerDelete = 111 => time::sys_timer_delete,
+    ClockGettime = 113 => time::sys_clock_gettime,
+    ClockGetres = 114 => time::sys_clock_getres,
+    RtSigaction = 134 => signal::sys_rt_sigaction,
+    RtSigprocmask = 135 => signal::sys_rt_sigprocmask,
+    RtSigreturn = 139 => signal::sys_rt_sigreturn,
+    SetGid = 144 => proc::sys_setgid,
+    SetUid = 146 => proc::sys_setuid,
+    SetPgid = 154 => proc::sys_setpgid,
+    GetPgid = 155 => proc::sys_getpgid,
+    Uname = 160 => proc::sys_uname,
+    Umask = 166 => fs::sys_umask,
+    Prctl = 167 => proc::sys_prctl,
+    GetPid = 172 => proc::sys_getpid,
+    GetPpid = 173 => proc::sys_getppid,
+    GetUid = 174 => proc::sys_getuid,
+    GetEuid = 175 => proc::sys_geteuid,
+    GetGid = 176 => proc::sys_getgid,
+    GetEgid = 177 => proc::sys_getegid,
+    GetTid = 178 => proc::sys_gettid,
+    Kill = 129 => signal::sys_tkill,
+    Tkill = 130 => signal::sys_tkill,
+    Brk = 214 => proc::sys_brk,
+    Munmap = 215 => mm::sys_munmap,
+    Clone = 220 => proc::sys_clone,
+    Execve = 221 => fs::sys_execve,
+    Mmap = 222 => mm::sys_mmap,
+    Mprotect = 226 => mm::sys_mprotect,
+    EpollWait = 232 => fs::sys_epoll_wait,
+    Getrandom = 278 => fs::sys_getrandom,
+    MemfdCreate = 279 => proc::sys_memfd_create,
+    Wait4 = 260 => proc::sys_wait4,
+    Prlimit64 = 261 => proc::sys_prlimit64,
+    Socket = 198 => socket::sys_socket,
+    Socketpair = 199 => socket::sys_socketpair,
+    Bind = 200 => socket::sys_bind,
+    Listen = 201 => socket::sys_listen,
+    Accept = 202 => socket::sys_accept,
+    Connect = 203 => socket::sys_connect,
+    GetSockname = 204 => socket::sys_getsockname,
+    GetPeerName = 205 => socket::sys_getpeername,
+    Sendto = 206 => socket::sys_sendto,
+    Recvfrom = 207 => socket::sys_recvfrom,
+    SetSockopt = 208 => socket::sys_setsockopt,
+    GetSockopt = 209 => socket::sys_getsockopt,
+    Shutdown = 210 => socket::sys_shutdown,
+    Sendmsg = 211 => socket::sys_sendmsg,
+    Recvmsg = 212 => socket::sys_recvmsg,
+    Statx = 291 => fs::sys_statx,
+    RenameAt2 = 276 => fs::sys_renameat2,
+    Membarrier = 283 => proc::sys_membarrier,
+    FaccessAt2 = 439 => fs::sys_faccessat2,
+}

--- a/kernel/src/abi/linux/generic/mod.rs
+++ b/kernel/src/abi/linux/generic/mod.rs
@@ -302,7 +302,6 @@ syscall_table! {
     ClockGetres = 114 => time::sys_clock_getres,
     RtSigaction = 134 => signal::sys_rt_sigaction,
     RtSigprocmask = 135 => signal::sys_rt_sigprocmask,
-    RtSigreturn = 139 => signal::sys_rt_sigreturn,
     SetGid = 144 => proc::sys_setgid,
     SetUid = 146 => proc::sys_setuid,
     SetPgid = 154 => proc::sys_setpgid,

--- a/kernel/src/abi/linux/generic/pipe.rs
+++ b/kernel/src/abi/linux/generic/pipe.rs
@@ -1,0 +1,112 @@
+//! Linux pipe syscalls (minimum implementation)
+//!
+
+use crate::{
+    abi::linux::generic::{
+        LinuxAbi, errno,
+        fs::{FD_CLOEXEC, O_CLOEXEC, O_NONBLOCK},
+    },
+    arch::Trapframe,
+    ipc::UnidirectionalPipe,
+    object::capability::selectable::Selectable,
+    task::mytask,
+};
+
+/// Minimal sys_pipe2 implementation for Linux ABI (returns 0 on success, -1 on error)
+pub fn sys_pipe2(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::EIO),
+    };
+
+    let pipefd_user = trapframe.get_arg(0);
+    let flags = trapframe.get_arg(1) as i32;
+
+    trapframe.increment_pc_next(task);
+
+    // Validate flags: Linux pipe2 only accepts O_CLOEXEC and O_NONBLOCK.
+    let allowed = O_CLOEXEC | O_NONBLOCK;
+    if flags & !allowed != 0 {
+        return errno::to_result(errno::EINVAL);
+    }
+
+    let pipefd_ptr = match task.vm_manager.translate_to_kva(pipefd_user) {
+        Some(ptr) => ptr as *mut u32,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let (read_end, write_end) = UnidirectionalPipe::create_pair(4096);
+
+    let read_handle = match task.handle_table.insert(read_end) {
+        Ok(h) => h,
+        Err(_) => return errno::to_result(errno::ENFILE),
+    };
+    let write_handle = match task.handle_table.insert(write_end) {
+        Ok(h) => h,
+        Err(_) => {
+            let _ = task.handle_table.remove(read_handle);
+            return errno::to_result(errno::ENFILE);
+        }
+    };
+
+    let read_fd = match abi.allocate_fd(read_handle as u32) {
+        Ok(fd) => fd,
+        Err(_) => {
+            let _ = task.handle_table.remove(read_handle);
+            let _ = task.handle_table.remove(write_handle);
+            return errno::to_result(errno::EMFILE);
+        }
+    };
+    let write_fd = match abi.allocate_fd(write_handle as u32) {
+        Ok(fd) => fd,
+        Err(_) => {
+            let _ = abi.remove_fd(read_fd);
+            let _ = task.handle_table.remove(read_handle);
+            let _ = task.handle_table.remove(write_handle);
+            return errno::to_result(errno::EMFILE);
+        }
+    };
+
+    let mut status_flags: u32 = 0;
+    if (flags & O_NONBLOCK) != 0 {
+        status_flags |= O_NONBLOCK as u32;
+    }
+
+    if abi.set_file_status_flags(read_fd, status_flags).is_err() {
+        let _ = abi.remove_fd(write_fd);
+        let _ = abi.remove_fd(read_fd);
+        let _ = task.handle_table.remove(write_handle);
+        let _ = task.handle_table.remove(read_handle);
+        return errno::to_result(errno::EMFILE);
+    }
+    if abi.set_file_status_flags(write_fd, status_flags).is_err() {
+        let _ = abi.remove_fd(write_fd);
+        let _ = abi.remove_fd(read_fd);
+        let _ = task.handle_table.remove(write_handle);
+        let _ = task.handle_table.remove(read_handle);
+        return errno::to_result(errno::EMFILE);
+    }
+
+    if (flags & O_CLOEXEC) != 0 {
+        let _ = abi.set_fd_flags(read_fd, FD_CLOEXEC);
+        let _ = abi.set_fd_flags(write_fd, FD_CLOEXEC);
+    }
+
+    if let Some(obj) = task.handle_table.get(read_handle) {
+        if let Some(sel) = obj.as_selectable() {
+            sel.set_nonblocking((flags & O_NONBLOCK) != 0);
+        }
+    }
+    if let Some(obj) = task.handle_table.get(write_handle) {
+        if let Some(sel) = obj.as_selectable() {
+            sel.set_nonblocking((flags & O_NONBLOCK) != 0);
+        }
+    }
+
+    unsafe {
+        core::ptr::write_unaligned(pipefd_ptr, read_fd as u32);
+        core::ptr::write_unaligned(pipefd_ptr.add(1), write_fd as u32);
+    }
+
+    0
+}

--- a/kernel/src/abi/linux/generic/proc.rs
+++ b/kernel/src/abi/linux/generic/proc.rs
@@ -1,0 +1,957 @@
+use crate::{
+    abi::linux::generic::LinuxAbi,
+    arch::{Trapframe, get_cpu},
+    sched::scheduler::get_scheduler,
+    task::{CloneFlags, mytask},
+};
+
+// /// VFS v2 helper function for path absolutization
+// /// TODO: Move this to a shared helper module when VFS v2 provides public API
+// fn to_absolute_path_v2(task: &crate::task::Task, path: &str) -> Result<String, ()> {
+//     if path.starts_with('/') {
+//         Ok(path.to_string())
+//     } else {
+//         let cwd = task.cwd.clone().ok_or(())?;
+//         let mut absolute_path = cwd;
+//         if !absolute_path.ends_with('/') {
+//             absolute_path.push('/');
+//         }
+//         absolute_path.push_str(path);
+//         // Simple normalization (removes "//", ".", etc.)
+//         let mut components = alloc::vec::Vec::new();
+//         for comp in absolute_path.split('/') {
+//             match comp {
+//                 "" | "." => {},
+//                 ".." => { components.pop(); },
+//                 _ => components.push(comp),
+//             }
+//         }
+//         Ok("/".to_string() + &components.join("/"))
+//     }
+// }
+
+// /// Helper function to replace the missing get_path_str function
+// /// TODO: This should be moved to a shared helper when VFS v2 provides public API
+// fn get_path_str_v2(ptr: *const u8) -> Result<String, ()> {
+//     const MAX_PATH_LENGTH: usize = 128;
+//     cstring_to_string(ptr, MAX_PATH_LENGTH).map(|(s, _)| s).map_err(|_| ())
+// }
+
+// pub fn sys_fork(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+//     let parent_task = mytask().unwrap();
+
+//     trapframe.increment_pc_next(parent_task); /* Increment the program counter */
+//     /* Save the trapframe to the task before cloning */
+//     parent_task.vcpu.lock().store(trapframe);
+
+//     /* Clone the task */
+//     match parent_task.clone_task(CloneFlags::default()) {
+//         Ok(mut child_task) => {
+//             let child_id = child_task.get_id();
+//             child_task.vcpu.regs.reg[10] = 0; /* Set the return value (a0) to 0 in the child proc */
+//             get_scheduler().add_task(child_task, get_cpu().get_cpuid());
+//             /* Return the child task ID as pid to the parent proc */
+//             child_id
+//         },
+//         Err(_) => {
+//             usize::MAX /* Return -1 on error */
+//         }
+//     }
+// }
+
+pub fn sys_set_tid_address(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let tid_ptr = trapframe.get_arg(0);
+
+    let tid_opt = (tid_ptr != 0).then_some(tid_ptr);
+    abi.thread_state_mut().clear_child_tid_ptr = tid_opt;
+
+    trapframe.increment_pc_next(task);
+
+    // Return current task namespace ID (Linux TID visible to user space)
+    task.get_namespace_id()
+}
+
+pub fn sys_exit(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    task.vcpu.lock().store(trapframe);
+    let exit_code = trapframe.get_arg(0) as i32;
+
+    task.exit(exit_code);
+    get_scheduler().schedule(trapframe);
+    usize::MAX
+}
+
+pub fn sys_exit_group(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    task.vcpu.lock().store(trapframe);
+    let exit_code = trapframe.get_arg(0) as i32;
+    task.exit(exit_code);
+    get_scheduler().schedule(trapframe);
+    usize::MAX
+}
+
+pub fn sys_set_robust_list(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let head = trapframe.get_arg(0);
+    let len = trapframe.get_arg(1);
+
+    let head_opt = (head != 0).then_some(head);
+    let state = abi.thread_state_mut();
+    state.robust_list_head = head_opt;
+    state.robust_list_len = len as usize;
+
+    trapframe.increment_pc_next(task);
+
+    0
+}
+
+// pub fn sys_wait(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+//     let task = mytask().unwrap();
+//     let status_ptr = trapframe.get_arg(0) as *mut i32;
+
+//     for pid in task.get_children().clone() {
+//         match task.wait(pid) {
+//             Ok(status) => {
+//                 // If the child proc is exited, we can return the status
+//                 if status_ptr != core::ptr::null_mut() {
+//                     let status_ptr = task.vm_manager.translate_vaddr(status_ptr as usize).unwrap() as *mut i32;
+//                     unsafe {
+//                         *status_ptr = status;
+//                     }
+//                 }
+//                 trapframe.increment_pc_next(task);
+//                 return pid;
+//             },
+//             Err(error) => {
+//                 match error {
+//                     WaitError::ChildNotExited(_) => continue,
+//                     _ => {
+//                         return trapframe.get_return_value();
+//                     },
+//                 }
+//             }
+//         }
+//     }
+
+//     // No child has exited yet, block until one does
+//     // xv6's wait() is equivalent to waitpid(-1), so we use the parent waker
+//     let parent_waker = get_parent_waker(task.get_id());
+//     parent_waker.wait(task, trapframe);
+// }
+
+#[allow(dead_code)]
+pub fn sys_kill(_abi: &mut LinuxAbi, _trapframe: &mut Trapframe) -> usize {
+    // Implement the kill syscall
+    // This syscall is not yet implemented. Returning ENOSYS error code (-1).
+    usize::MAX
+}
+
+#[allow(dead_code)]
+pub fn sys_sbrk(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let increment = trapframe.get_arg(0) as isize; // Treat as signed increment
+    let current_brk = task.get_brk();
+    trapframe.increment_pc_next(task);
+
+    // Handle increment of 0 (query current brk)
+    if increment == 0 {
+        return current_brk;
+    }
+
+    let new_brk = if increment > 0 {
+        current_brk.checked_add(increment as usize)
+    } else {
+        // Handle negative increment (decrease brk)
+        current_brk.checked_sub((-increment) as usize)
+    };
+
+    let new_brk = match new_brk {
+        Some(brk) => brk,
+        None => {
+            // Overflow/underflow
+            use super::errno;
+            return errno::to_result(errno::ENOMEM);
+        }
+    };
+
+    match task.set_brk(new_brk) {
+        Ok(_) => {
+            let new_actual = task.get_brk();
+            // crate::println!("[brk] sbrk inc={} old={:#x} new={:#x}", increment, current_brk, new_actual);
+            new_actual
+        }
+        Err(_) => {
+            use super::errno;
+            // crate::println!("[brk] sbrk fail inc={} old={:#x}", increment, current_brk);
+            errno::to_result(errno::ENOMEM)
+        }
+    }
+}
+
+pub fn sys_brk(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let new_brk = trapframe.get_arg(0);
+    trapframe.increment_pc_next(task);
+
+    // If new_brk is 0, just return current brk (query current brk)
+    if new_brk == 0 {
+        return task.get_brk();
+    }
+
+    let _old = task.get_brk();
+    match task.set_brk(new_brk) {
+        Ok(_) => {
+            let actual = task.get_brk();
+            // crate::println!("[brk] brk req={:#x} old={:#x} -> {:#x}", new_brk, old, actual);
+            actual
+        }
+        Err(_) => {
+            let cur = task.get_brk();
+            // crate::println!("[brk] brk fail req={:#x} keep={:#x}", new_brk, cur);
+            cur
+        }
+    }
+}
+
+// pub fn sys_chdir(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+//     let task = mytask().unwrap();
+//     trapframe.increment_pc_next(task);
+
+//     let path_ptr = task.vm_manager.translate_vaddr(trapframe.get_arg(0) as usize).unwrap() as *const u8;
+//     let path = match get_path_str_v2(path_ptr) {
+//         Ok(p) => match to_absolute_path_v2(&task, &p) {
+//             Ok(abs_path) => abs_path,
+//             Err(_) => return usize::MAX,
+//         },
+//         Err(_) => return usize::MAX, /* -1 */
+//     };
+
+//     // Try to open the file
+//     let file = match task.vfs.read().clone() {
+//         Some(vfs) => vfs.open(&path, 0),
+//         None => return usize::MAX, // VFS not initialized
+//     };
+//     if file.is_err() {
+//         return usize::MAX; // -1
+//     }
+//     let kernel_obj = file.unwrap();
+//     let file_handle = kernel_obj.as_file().unwrap();
+//     // Check if the file is a directory
+//     if file_handle.metadata().unwrap().file_type != FileType::Directory {
+//         return usize::MAX; // -1
+//     }
+
+//     task.cwd = Some(path); // Update the current working directory
+
+//     0
+// }
+
+pub fn sys_getpid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    // Return TGID for Linux semantics; fallback to Task ID if unset
+    let tgid = _abi.thread_state().tgid;
+    trapframe.increment_pc_next(task);
+    if tgid != 0 { tgid } else { task.get_id() }
+}
+
+pub fn sys_getppid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+    task.get_parent_id().unwrap_or(1) // Return parent PID or 1 if none
+}
+
+/// Linux gettid system call implementation
+/// Returns the calling thread ID (TID). For now, this equals Scarlet Task ID.
+pub fn sys_gettid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+    task.get_id()
+}
+
+/// Linux prctl system call (syscall 167)
+///
+/// Operations on a process or thread. This is a stub implementation
+/// that returns success for common operations.
+///
+/// Arguments:
+///   - arg0: option (PR_* operation)
+///   - arg1-arg4: operation-specific arguments
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) for unsupported operations
+pub fn sys_prctl(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let option = trapframe.get_arg(0) as i32;
+    let _arg2 = trapframe.get_arg(1);
+    let _arg3 = trapframe.get_arg(2);
+    let _arg4 = trapframe.get_arg(3);
+    let _arg5 = trapframe.get_arg(4);
+
+    trapframe.increment_pc_next(task);
+
+    crate::println!(
+        "[stub] sys_prctl: option={}, arg2={:#x}, arg3={:#x}, arg4={:#x}, arg5={:#x}",
+        option,
+        _arg2,
+        _arg3,
+        _arg4,
+        _arg5
+    );
+
+    // Common PR_* operations (from include/uapi/linux/prctl.h)
+    // For now, just return success for all operations
+    // Specific operations can be implemented as needed
+    0
+}
+
+pub fn sys_setpgid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let _pid = trapframe.get_arg(0);
+    let _pgid = trapframe.get_arg(1);
+    trapframe.increment_pc_next(task);
+    0 // Always succeed
+}
+
+pub fn sys_getpgid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let _pid = trapframe.get_arg(0);
+    trapframe.increment_pc_next(task);
+    task.get_id() // Return current task ID as process group ID
+}
+
+pub fn sys_prlimit64(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let _pid = trapframe.get_arg(0) as i32;
+    let _resource = trapframe.get_arg(1);
+    let _new_rlim_ptr = trapframe.get_arg(2);
+    let old_rlim_ptr = trapframe.get_arg(3);
+
+    trapframe.increment_pc_next(task);
+
+    // If old_rlim is requested, write some reasonable default values
+    if old_rlim_ptr != 0 {
+        if let Some(old_rlim_paddr) = task.vm_manager.translate_to_kva(old_rlim_ptr) {
+            unsafe {
+                // Write a simple rlimit structure with high limits
+                // struct rlimit { rlim_t rlim_cur; rlim_t rlim_max; }
+                let rlimit = old_rlim_paddr as *mut [u64; 2];
+                *rlimit = [
+                    0xFFFFFFFF, // rlim_cur - current limit (high value)
+                    0xFFFFFFFF, // rlim_max - maximum limit (high value)
+                ];
+            }
+        }
+    }
+
+    0 // Always succeed
+}
+
+pub fn sys_getuid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    0 // Return 0 for the root user (UID 0)
+}
+
+pub fn sys_geteuid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    0 // Return 0 for the root user (EUID 0)
+}
+
+pub fn sys_getgid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    0 // Return 0 for the root group (GID 0)
+}
+
+pub fn sys_getegid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    0 // Return 0 for the root group (EGID 0)
+}
+
+/// Linux utsname structure for uname system call
+/// This structure must match Linux's struct utsname layout
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct UtsName {
+    /// System name (e.g., "Linux")
+    pub sysname: [u8; 65],
+    /// Node name (hostname)
+    pub nodename: [u8; 65],
+    /// Release (kernel version)
+    pub release: [u8; 65],
+    /// Version (kernel build info)
+    pub version: [u8; 65],
+    /// Machine (hardware architecture)
+    pub machine: [u8; 65],
+    /// Domain name (GNU extension)
+    pub domainname: [u8; 65],
+}
+
+impl UtsName {
+    /// Create a new UtsName with Scarlet system information
+    pub fn new() -> Self {
+        let mut uts = UtsName {
+            sysname: [0; 65],
+            nodename: [0; 65],
+            release: [0; 65],
+            version: [0; 65],
+            machine: [0; 65],
+            domainname: [0; 65],
+        };
+
+        // System name - identify as Linux for compatibility
+        let sysname = b"Linux";
+        uts.sysname[..sysname.len()].copy_from_slice(sysname);
+
+        // Node name (hostname)
+        let nodename = b"scarlet";
+        uts.nodename[..nodename.len()].copy_from_slice(nodename);
+
+        // Release (kernel version)
+        let release = b"6.1.0-scarlet_linux_abi_module";
+        uts.release[..release.len()].copy_from_slice(release);
+
+        // Version (build info)
+        let version = b"#1 SMP Scarlet";
+        uts.version[..version.len()].copy_from_slice(version);
+
+        let machine = if cfg!(target_arch = "riscv64") {
+            b"riscv64"
+        } else if cfg!(target_arch = "aarch64") {
+            b"aarch64"
+        } else {
+            b"unknown"
+        };
+        uts.machine[..machine.len()].copy_from_slice(machine);
+
+        // Domain name
+        let domainname = b"(none)";
+        uts.domainname[..domainname.len()].copy_from_slice(domainname);
+
+        uts
+    }
+}
+
+/// Linux uname system call implementation
+///
+/// Returns system information including system name, hostname, kernel version,
+/// and hardware architecture. This provides compatibility with Linux applications
+/// that query system information.
+///
+/// # Arguments
+/// - buf: Pointer to utsname structure to fill
+///
+/// # Returns
+/// - 0 on success
+/// - usize::MAX on error (-1 in Linux)
+pub fn sys_uname(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    let buf_ptr = trapframe.get_arg(0);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Translate user space pointer
+    let buf_vaddr = match task.vm_manager.translate_to_kva(buf_ptr) {
+        Some(addr) => addr as *mut UtsName,
+        None => return usize::MAX, // Invalid address
+    };
+
+    if buf_vaddr.is_null() {
+        return usize::MAX; // NULL pointer
+    }
+
+    // Create and copy system information
+    let uts = UtsName::new();
+    unsafe {
+        *buf_vaddr = uts;
+    }
+
+    0 // Success
+}
+
+/// Linux sys_clone implementation
+///
+/// clone argument order (Linux ABI):
+/// long clone(unsigned long flags, void *stack, int *parent_tid, unsigned long tls, int *child_tid);
+///
+/// Arguments:
+/// - flags: clone flags (CLONE_VM, CLONE_FS, etc.)
+/// - stack: child stack pointer (NULL to duplicate parent stack)
+/// - parent_tid: pointer to store parent TID (for CLONE_PARENT_SETTID)
+/// - child_tid: pointer to store child TID (for CLONE_CHILD_SETTID/CLONE_CHILD_CLEARTID)
+/// - tls: TLS (Thread Local Storage) pointer
+pub fn sys_clone(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let parent_task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let flags = trapframe.get_arg(0);
+    let child_stack = trapframe.get_arg(1);
+    let parent_tid_ptr = trapframe.get_arg(2) as *mut i32; // a2
+    let tls = trapframe.get_arg(3); //a3 (TLS)
+    let child_tid_ptr = trapframe.get_arg(4) as *mut i32; // a4
+
+    let parent_tid_opt = (!parent_tid_ptr.is_null()).then_some(parent_tid_ptr as usize);
+    let child_tid_opt = (!child_tid_ptr.is_null()).then_some(child_tid_ptr as usize);
+    {
+        let state = abi.thread_state_mut();
+        state.parent_tid_ptr = parent_tid_opt;
+        state.child_tid_ptr = child_tid_opt;
+        if (flags & CLONE_CHILD_CLEARTID) != 0 {
+            state.clear_child_tid_ptr = child_tid_opt;
+        }
+        if (flags & CLONE_SETTLS) != 0 {
+            state.tls_pointer = Some(tls);
+        }
+    }
+
+    // Linux clone flags
+    const CLONE_VM: usize = 0x00000100;
+    const CLONE_FS: usize = 0x00000200;
+    const CLONE_FILES: usize = 0x00000400;
+    // Thread-related flags (accepted but not fully implemented yet)
+    #[allow(dead_code)]
+    const CLONE_SIGHAND: usize = 0x00000800;
+    const CLONE_THREAD: usize = 0x00010000;
+    #[allow(dead_code)]
+    const CLONE_SETTLS: usize = 0x00080000;
+    /// Set child's TID at child_tid_ptr in child's memory
+    #[allow(dead_code)]
+    const CLONE_CHILD_SETTID: usize = 0x01000000;
+    #[allow(dead_code)]
+    const CLONE_PARENT_SETTID: usize = 0x00100000;
+    #[allow(dead_code)]
+    const CLONE_CHILD_CLEARTID: usize = 0x00200000;
+
+    // Accept CLONE_THREAD/CLONE_SIGHAND for minimal thread support.
+    // Note: signal handler sharing and full thread group semantics are partial.
+    // Stash CLONE_THREAD intent so on_task_cloned can initialize child's TGID.
+    {
+        let state = abi.thread_state_mut();
+        state.pending_clone_is_thread = (flags & CLONE_THREAD) != 0;
+    }
+
+    trapframe.increment_pc_next(parent_task);
+    parent_task.vcpu.lock().store(trapframe);
+
+    // Map Linux clone flags to Scarlet CloneFlags
+    let mut cflags = CloneFlags::new();
+    if (flags & CLONE_VM) != 0 {
+        cflags.set(crate::task::CloneFlagsDef::Vm);
+    }
+    if (flags & CLONE_FS) != 0 {
+        cflags.set(crate::task::CloneFlagsDef::Fs);
+    }
+    if (flags & CLONE_FILES) != 0 {
+        cflags.set(crate::task::CloneFlagsDef::Files);
+    }
+    if (flags & CLONE_THREAD) != 0 {
+        cflags.set(crate::task::CloneFlagsDef::Thread);
+    }
+
+    let ret = match parent_task.clone_task(cflags) {
+        Ok(mut child_task) => {
+            child_task.vcpu.lock().iregs.reg[10] = 0; // a0 = 0 in child
+            // If child_stack is provided, set child's user SP
+            if child_stack != 0 {
+                child_task.vcpu.lock().set_sp(child_stack);
+            }
+            // If CLONE_SETTLS requested, set tp (x4) to tls for child
+            #[allow(non_snake_case)]
+            const CLONE_SETTLS: usize = 0x00080000;
+            if (flags & CLONE_SETTLS) != 0 {
+                child_task.vcpu.lock().iregs.reg[4] = tls; // x4 = tp
+            }
+
+            let scheduler = get_scheduler();
+            let cpu_id = get_cpu().get_cpuid();
+            let parent_id = parent_task.get_id();
+
+            // Add child and get allocated ID
+            let child_id = scheduler.add_task(child_task, cpu_id);
+
+            // Establish parent-child relationship now that both have valid IDs
+            if let Some(child) = scheduler.get_task_by_id(child_id) {
+                child.set_parent_id(parent_id);
+            }
+            if let Some(parent) = scheduler.get_task_by_id(parent_id) {
+                parent.add_child(child_id);
+            }
+
+            // Do not modify user pthread list; musl manages linkage. No safety-net writes.
+            // Handle parent TID store when CLONE_PARENT_SETTID is requested
+            if (flags & CLONE_PARENT_SETTID) != 0 && !parent_tid_ptr.is_null() {
+                if let Some(paddr) = parent_task
+                    .vm_manager
+                    .translate_to_kva(parent_tid_ptr as usize)
+                {
+                    unsafe {
+                        *(paddr as *mut i32) = child_id as i32;
+                    }
+                }
+            }
+            // IMPORTANT: Only write child TID when CLONE_CHILD_SETTID is set.
+            // For CLONE_CHILD_CLEARTID, the pointer is a futex lock to clear on exit.
+            if (flags & CLONE_CHILD_SETTID) != 0 && !child_tid_ptr.is_null() {
+                if let Some(paddr) = get_scheduler()
+                    .get_task_by_id(child_id)
+                    .unwrap()
+                    .vm_manager
+                    .translate_to_kva(child_tid_ptr as usize)
+                {
+                    unsafe {
+                        *(paddr as *mut i32) = child_id as i32;
+                    }
+                }
+            }
+            child_id
+        }
+        Err(_) => usize::MAX,
+    };
+
+    // Clear pending flag in parent after clone completes
+    abi.thread_state_mut().pending_clone_is_thread = false;
+    ret
+}
+
+/// Linux sys_setgid implementation (syscall 144)
+///
+/// Set group ID. This is a stub implementation that always succeeds.
+///
+/// Arguments:
+/// - gid: group ID to set
+///
+/// Returns:
+/// - 0 on success
+pub fn sys_setgid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX - 1, // -EPERM
+    };
+
+    let _gid = trapframe.get_arg(0);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Always succeed - group ID is ignored in this stub
+    0
+}
+
+/// Linux sys_setuid implementation (syscall 146)
+///
+/// Set user ID. This is a stub implementation that always succeeds.
+///
+/// Arguments:
+/// - uid: user ID to set
+///
+/// Returns:
+/// - 0 on success
+pub fn sys_setuid(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX - 1, // -EPERM
+    };
+
+    let _uid = trapframe.get_arg(0);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Always succeed - user ID is ignored in this stub
+    0
+}
+
+///
+/// Wait for process to change state (wait4 system call).
+/// This is a stub implementation that returns immediately.
+///
+/// Arguments:
+/// Wait for process to change state (wait4 system call).
+///
+/// This is a Linux-compatible implementation that waits for child processes
+/// to exit and returns their process ID and exit status.
+///
+/// # Arguments
+/// - pid: process ID to wait for
+///   * -1: wait for any child process
+///   * >0: wait for specific child process
+///   * 0 or <-1: wait for process group (not implemented)
+/// - wstatus: pointer to store status information (can be null)
+/// - options: wait options (currently ignored - TODO: implement WNOHANG, WUNTRACED)
+/// - rusage: pointer to resource usage structure (can be null, currently ignored)
+///
+/// # Returns
+/// - On success: process ID of child that changed state
+/// - On error: negated error code (e.g., usize::MAX - 9 for -ECHILD)
+///
+/// # Errors
+/// - ECHILD: no child processes or specified child is not our child
+/// - EFAULT: invalid address for wstatus pointer
+/// - ENOSYS: unsupported operation (process groups)
+/// - EPERM: no current task context
+pub fn sys_wait4(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    use crate::task::{WaitError, get_parent_waitpid_waker};
+
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX - 1, // -EPERM
+    };
+
+    let pid = trapframe.get_arg(0) as isize;
+    let wstatus = trapframe.get_arg(1) as *mut i32;
+    let _options = trapframe.get_arg(2); // TODO: Handle WNOHANG, WUNTRACED, etc.
+    let _rusage = trapframe.get_arg(3); // TODO: Implement resource usage tracking
+
+    // Check if the task has any children
+    if task.get_children().is_empty() {
+        trapframe.increment_pc_next(task);
+        return usize::MAX - 9; // -ECHILD (no child processes)
+    }
+
+    // Minimal implementation; no verbose logging.
+
+    // Loop until a child exits or an error occurs
+    loop {
+        if pid == -1 {
+            // Wait for any child process
+            for child_pid in task.get_children().clone() {
+                match task.wait(child_pid) {
+                    Ok(status) => {
+                        // Child has exited, return the status
+                        if wstatus != core::ptr::null_mut() {
+                            match task.vm_manager.translate_to_kva(wstatus as usize) {
+                                Some(phys_addr) => {
+                                    let status_ptr = phys_addr as *mut i32;
+                                    unsafe {
+                                        *status_ptr = status;
+                                    }
+                                }
+                                None => {
+                                    // Invalid address, return EFAULT
+                                    trapframe.increment_pc_next(task);
+                                    return usize::MAX - 13; // -EFAULT
+                                }
+                            }
+                        }
+                        trapframe.increment_pc_next(task);
+                        return child_pid;
+                    }
+                    Err(error) => {
+                        match error {
+                            WaitError::NoSuchChild(_) => {
+                                // This child is not our child
+                                continue;
+                            }
+                            WaitError::ChildTaskNotFound(_) => {
+                                // Child task not found in scheduler, continue with other children
+                                continue;
+                            }
+                            WaitError::ChildNotExited(_) => {
+                                // Child not exited yet, continue with other children
+                                continue;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // No child has exited yet, block until one does
+            // Use parent waker for waitpid(-1) semantics
+            let parent_waker = get_parent_waitpid_waker(task.get_id());
+            parent_waker.wait(task.get_id(), task.get_trapframe());
+            // Woken by child exit; re-check children.
+            // Continue the loop to re-check after waking up
+            continue;
+        } else if pid > 0 {
+            // Wait for specific child process
+            let child_pid = pid as usize;
+
+            // Check if this is actually our child
+            if !task.get_children().contains(&child_pid) {
+                trapframe.increment_pc_next(task);
+                return usize::MAX - 9; // -ECHILD (not our child)
+            }
+
+            match task.wait(child_pid) {
+                Ok(status) => {
+                    // Child has exited, return the status
+                    if wstatus != core::ptr::null_mut() {
+                        match task.vm_manager.translate_to_kva(wstatus as usize) {
+                            Some(phys_addr) => {
+                                let status_ptr = phys_addr as *mut i32;
+                                unsafe {
+                                    *status_ptr = status;
+                                }
+                            }
+                            None => {
+                                // Invalid address, return EFAULT
+                                trapframe.increment_pc_next(task);
+                                return usize::MAX - 13; // -EFAULT
+                            }
+                        }
+                    }
+                    trapframe.increment_pc_next(task);
+                    return child_pid;
+                }
+                Err(error) => {
+                    match error {
+                        WaitError::NoSuchChild(_) => {
+                            trapframe.increment_pc_next(task);
+                            return usize::MAX - 9; // -ECHILD
+                        }
+                        WaitError::ChildTaskNotFound(_) => {
+                            trapframe.increment_pc_next(task);
+                            return usize::MAX - 9; // -ECHILD
+                        }
+                        WaitError::ChildNotExited(_) => {
+                            // Child not exited yet, wait for it
+                            use crate::task::get_waitpid_waker;
+                            let child_waker = get_waitpid_waker(child_pid);
+                            child_waker.wait(task.get_id(), task.get_trapframe());
+                            // Woken by specific child exit; re-check.
+                            // Continue the loop to re-check after waking up
+                            continue;
+                        }
+                    }
+                }
+            }
+        } else {
+            // pid <= 0 && pid != -1: wait for process group (not implemented)
+            trapframe.increment_pc_next(task);
+            return usize::MAX - 37; // -ENOSYS (function not implemented)
+        }
+    }
+}
+
+/// Linux sys_membarrier implementation (syscall 283)
+///
+/// Memory barrier system call for ensuring memory ordering between threads.
+/// This is a stub implementation that always succeeds.
+///
+/// Arguments:
+/// - cmd: membarrier command (various MEMBARRIER_CMD_* constants)
+/// - flags: flags for the command (usually 0)
+/// - cpu_id: CPU ID for per-CPU barriers (usually unused)
+///
+/// Returns:
+/// - 0 on success
+/// - Negative error code on failure
+///
+/// Note: This is a no-op stub. On a real system with multiple cores,
+/// this would issue appropriate memory barrier instructions to ensure
+/// memory ordering visibility across CPUs. For single-core or simple
+/// multi-core systems without complex memory reordering, this stub
+/// should be sufficient for most applications.
+pub fn sys_membarrier(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX - 1, // -EPERM
+    };
+
+    let _cmd = trapframe.get_arg(0);
+    let _flags = trapframe.get_arg(1);
+    let _cpu_id = trapframe.get_arg(2);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Issue a memory fence to ensure all memory operations are visible
+    // This is a basic implementation - real membarrier has multiple modes
+    core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+
+    // Always succeed - stub implementation
+    0
+}
+
+/// Linux sys_memfd_create - Create an anonymous file descriptor for memory mapping
+///
+/// Creates a new anonymous file descriptor that can be used for memory mapping.
+/// This is primarily used by Wayland clients for shared memory.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: uname (name for the memfd - can be NULL)
+///   - arg1: flags (MFD_CLOEXEC, MFD_ALLOW_SEALING, etc.)
+///
+/// Returns:
+/// - New file descriptor on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_memfd_create(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    use crate::ipc::SharedMemory;
+    use crate::object::KernelObject;
+
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let _uname_ptr = trapframe.get_arg(0);
+    let flags = trapframe.get_arg(1) as u32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Parse flags (Linux memfd_create flags)
+    const MFD_CLOEXEC: u32 = 0x0001;
+    const MFD_ALLOW_SEALING: u32 = 0x0002;
+    const MFD_SEAL_SEAL: u32 = 0x0004;
+
+    let _cloexec = (flags & MFD_CLOEXEC) != 0;
+    let _allow_sealing = (flags & MFD_ALLOW_SEALING) != 0;
+    let _seal = (flags & MFD_SEAL_SEAL) != 0;
+
+    // Create shared memory object (size 0 initially, will be resized by ftruncate)
+    // Default size for Wayland SHM pools
+    const DEFAULT_SHM_SIZE: usize = crate::environment::PAGE_SIZE; // one page as starting point
+
+    let shm = match SharedMemory::new(DEFAULT_SHM_SIZE, 0x3 /* READ | WRITE */) {
+        Ok(shm) => shm,
+        Err(e) => {
+            crate::early_println!("[sys_memfd_create] Failed to create shared memory: {:?}", e);
+            return usize::MAX;
+        }
+    };
+
+    // Insert into handle table
+    let handle = match task
+        .handle_table
+        .insert(KernelObject::SharedMemory(alloc::sync::Arc::new(shm)))
+    {
+        Ok(h) => h,
+        Err(_) => {
+            crate::early_println!("[sys_memfd_create] Failed to insert handle into table");
+            return usize::MAX;
+        }
+    };
+
+    // Allocate fd for the shared memory
+    let fd = match abi.allocate_fd(handle) {
+        Ok(fd) => fd,
+        Err(_) => {
+            // Clean up on error
+            let _ = task.handle_table.remove(handle);
+            crate::early_println!("[sys_memfd_create] Failed to allocate fd");
+            return usize::MAX;
+        }
+    };
+
+    // crate::early_println!(
+    //     "[sys_memfd_create] Created memfd: fd={}, handle={}",
+    //     fd,
+    //     handle
+    // );
+
+    fd
+}

--- a/kernel/src/abi/linux/generic/signal.rs
+++ b/kernel/src/abi/linux/generic/signal.rs
@@ -1,0 +1,670 @@
+//! Linux signal syscalls and signal handling
+//!
+//! Implements POSIX signals with Linux-compatible semantics, integrated with Scarlet's
+//! event system for cross-ABI signal delivery.
+
+use crate::abi::linux::generic::LinuxAbi;
+use crate::arch::Trapframe;
+use crate::ipc::event::{Event, EventContent, ProcessControlType};
+use crate::task::mytask;
+use alloc::collections::BTreeMap;
+
+/// Linux signal numbers (POSIX standard)
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LinuxSignal {
+    SIGHUP = 1,
+    SIGINT = 2,
+    SIGQUIT = 3,
+    SIGILL = 4,
+    SIGTRAP = 5,
+    SIGABRT = 6,
+    SIGBUS = 7,
+    SIGFPE = 8,
+    SIGKILL = 9,
+    SIGUSR1 = 10,
+    SIGSEGV = 11,
+    SIGUSR2 = 12,
+    SIGPIPE = 13,
+    SIGALRM = 14,
+    SIGTERM = 15,
+    SIGSTKFLT = 16,
+    SIGCHLD = 17,
+    SIGCONT = 18,
+    SIGSTOP = 19,
+    SIGTSTP = 20,
+    SIGTTIN = 21,
+    SIGTTOU = 22,
+    SIGURG = 23,
+    SIGXCPU = 24,
+    SIGXFSZ = 25,
+    SIGVTALRM = 26,
+    SIGPROF = 27,
+    SIGWINCH = 28,
+    SIGIO = 29,
+    SIGPWR = 30,
+    SIGSYS = 31,
+}
+
+impl LinuxSignal {
+    /// Convert from u32 to LinuxSignal
+    pub fn from_u32(signal: u32) -> Option<Self> {
+        match signal {
+            1 => Some(Self::SIGHUP),
+            2 => Some(Self::SIGINT),
+            3 => Some(Self::SIGQUIT),
+            4 => Some(Self::SIGILL),
+            5 => Some(Self::SIGTRAP),
+            6 => Some(Self::SIGABRT),
+            7 => Some(Self::SIGBUS),
+            8 => Some(Self::SIGFPE),
+            9 => Some(Self::SIGKILL),
+            10 => Some(Self::SIGUSR1),
+            11 => Some(Self::SIGSEGV),
+            12 => Some(Self::SIGUSR2),
+            13 => Some(Self::SIGPIPE),
+            14 => Some(Self::SIGALRM),
+            15 => Some(Self::SIGTERM),
+            16 => Some(Self::SIGSTKFLT),
+            17 => Some(Self::SIGCHLD),
+            18 => Some(Self::SIGCONT),
+            19 => Some(Self::SIGSTOP),
+            20 => Some(Self::SIGTSTP),
+            21 => Some(Self::SIGTTIN),
+            22 => Some(Self::SIGTTOU),
+            23 => Some(Self::SIGURG),
+            24 => Some(Self::SIGXCPU),
+            25 => Some(Self::SIGXFSZ),
+            26 => Some(Self::SIGVTALRM),
+            27 => Some(Self::SIGPROF),
+            28 => Some(Self::SIGWINCH),
+            29 => Some(Self::SIGIO),
+            30 => Some(Self::SIGPWR),
+            31 => Some(Self::SIGSYS),
+            _ => None,
+        }
+    }
+
+    /// Get default action for this signal
+    pub fn default_action(&self) -> SignalAction {
+        match self {
+            Self::SIGKILL | Self::SIGSTOP => SignalAction::ForceTerminate,
+            Self::SIGCHLD | Self::SIGURG | Self::SIGWINCH => SignalAction::Ignore,
+            Self::SIGCONT => SignalAction::Continue,
+            Self::SIGTSTP | Self::SIGTTIN | Self::SIGTTOU => SignalAction::Stop,
+            _ => SignalAction::Terminate,
+        }
+    }
+}
+
+/// Signal action types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalAction {
+    /// Default action: terminate process
+    Terminate,
+    /// Force terminate (cannot be caught/ignored)
+    ForceTerminate,
+    /// Ignore signal
+    Ignore,
+    /// Stop process
+    Stop,
+    /// Continue process
+    Continue,
+    /// Custom handler
+    Custom(usize), // Handler function address
+}
+
+/// Signal mask for blocking signals
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SignalMask {
+    mask: u64, // Bit mask for signals 1-64
+}
+
+impl SignalMask {
+    pub fn new() -> Self {
+        Self { mask: 0 }
+    }
+
+    pub fn block_signal(&mut self, signal: LinuxSignal) {
+        self.mask |= 1u64 << (signal as u32 - 1);
+    }
+
+    pub fn unblock_signal(&mut self, signal: LinuxSignal) {
+        self.mask &= !(1u64 << (signal as u32 - 1));
+    }
+
+    pub fn is_blocked(&self, signal: LinuxSignal) -> bool {
+        (self.mask & (1u64 << (signal as u32 - 1))) != 0
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.mask
+    }
+
+    pub fn set_raw(&mut self, mask: u64) {
+        self.mask = mask;
+    }
+}
+
+/// Signal handler state for a task
+#[derive(Debug, Clone)]
+pub struct SignalState {
+    /// Signal handlers (signal number -> handler action)
+    pub handlers: BTreeMap<LinuxSignal, SignalAction>,
+    /// Blocked signals mask
+    pub blocked: SignalMask,
+    /// Pending signals that are blocked
+    pub pending: SignalMask,
+}
+
+impl Default for SignalState {
+    fn default() -> Self {
+        let mut handlers = BTreeMap::new();
+        // Set default actions for all signals
+        for signal_num in 1..=31 {
+            if let Some(signal) = LinuxSignal::from_u32(signal_num) {
+                handlers.insert(signal, signal.default_action());
+            }
+        }
+
+        Self {
+            handlers,
+            blocked: SignalMask::new(),
+            pending: SignalMask::new(),
+        }
+    }
+}
+
+impl SignalState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set signal handler
+    pub fn set_handler(&mut self, signal: LinuxSignal, action: SignalAction) {
+        // SIGKILL and SIGSTOP cannot be caught or ignored
+        if signal != LinuxSignal::SIGKILL && signal != LinuxSignal::SIGSTOP {
+            self.handlers.insert(signal, action);
+        }
+    }
+
+    /// Get signal handler
+    pub fn get_handler(&self, signal: LinuxSignal) -> SignalAction {
+        self.handlers
+            .get(&signal)
+            .copied()
+            .unwrap_or(signal.default_action())
+    }
+
+    /// Add pending signal
+    pub fn add_pending(&mut self, signal: LinuxSignal) {
+        self.pending.block_signal(signal);
+    }
+
+    /// Remove pending signal
+    pub fn remove_pending(&mut self, signal: LinuxSignal) {
+        self.pending.unblock_signal(signal);
+    }
+
+    /// Check if signal is pending
+    pub fn is_pending(&self, signal: LinuxSignal) -> bool {
+        self.pending.is_blocked(signal)
+    }
+
+    /// Get next deliverable signal (not blocked and pending)
+    pub fn next_deliverable_signal(&self) -> Option<LinuxSignal> {
+        for signal_num in 1..=31 {
+            if let Some(signal) = LinuxSignal::from_u32(signal_num) {
+                if self.is_pending(signal) && !self.blocked.is_blocked(signal) {
+                    return Some(signal);
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Linux sigaction structure (simplified)
+/// This matches the Linux sigaction layout
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Sigaction {
+    /// Signal handler address (or SIG_DFL, SIG_IGN)
+    pub handler: usize,
+    /// Signal flags
+    pub flags: u64,
+    /// Signal mask to apply during handler execution
+    pub mask: u64,
+}
+
+/// Special handler values
+pub const SIG_DFL: usize = 0; // Default action
+pub const SIG_IGN: usize = 1; // Ignore signal
+
+/// Linux rt_sigaction system call implementation
+///
+/// int rt_sigaction(int signum, const struct sigaction *act, struct sigaction *oldact, size_t sigsetsize);
+pub fn sys_rt_sigaction(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+
+    let signum = trapframe.get_arg(0) as u32;
+    let act_ptr = trapframe.get_arg(1);
+    let oldact_ptr = trapframe.get_arg(2);
+    let _sigsetsize = trapframe.get_arg(3);
+
+    // Convert signal number to LinuxSignal
+    let signal = match LinuxSignal::from_u32(signum) {
+        Some(sig) => sig,
+        None => {
+            trapframe.set_return_value(!0usize); // -1 (EINVAL)
+            trapframe.increment_pc_next(task);
+            return !0usize;
+        }
+    };
+
+    let mut signal_state = abi.signal_state.lock();
+
+    // Get old action if requested
+    if oldact_ptr != 0 {
+        let Some(paddr) = task.vm_manager.translate_to_kva(oldact_ptr) else {
+            // Invalid user pointer for oldact: return EFAULT
+            trapframe.set_return_value(!0usize);
+            trapframe.increment_pc_next(task);
+            return !0usize; // -EFAULT
+        };
+        let old_action = signal_state.get_handler(signal);
+        let old_sigaction = sigaction_to_linux(old_action);
+        unsafe {
+            core::ptr::write(paddr as *mut Sigaction, old_sigaction);
+        }
+    }
+
+    // Set new action if provided
+    if act_ptr != 0 {
+        let Some(paddr) = task.vm_manager.translate_to_kva(act_ptr) else {
+            // Invalid user pointer for act: return EFAULT
+            trapframe.set_return_value(!0usize);
+            trapframe.increment_pc_next(task);
+            return !0usize; // -EFAULT
+        };
+        let new_sigaction = unsafe { core::ptr::read(paddr as *const Sigaction) };
+        let new_action = linux_to_sigaction(new_sigaction, signal);
+        signal_state.set_handler(signal, new_action);
+    }
+
+    trapframe.set_return_value(0);
+    trapframe.increment_pc_next(task);
+    0
+}
+
+/// Convert internal SignalAction to Linux sigaction
+fn sigaction_to_linux(action: SignalAction) -> Sigaction {
+    match action {
+        SignalAction::Ignore => Sigaction {
+            handler: SIG_IGN,
+            flags: 0,
+            mask: 0,
+        },
+        SignalAction::Custom(addr) => Sigaction {
+            handler: addr,
+            flags: 0,
+            mask: 0,
+        },
+        _ => Sigaction {
+            handler: SIG_DFL,
+            flags: 0,
+            mask: 0,
+        },
+    }
+}
+
+/// Convert Linux sigaction to internal SignalAction
+fn linux_to_sigaction(sigaction: Sigaction, signal: LinuxSignal) -> SignalAction {
+    match sigaction.handler {
+        SIG_DFL => signal.default_action(), // Restore per-signal default action
+        SIG_IGN => SignalAction::Ignore,
+        addr => SignalAction::Custom(addr),
+    }
+}
+
+/// Linux rt_sigprocmask system call implementation
+///
+/// int rt_sigprocmask(int how, const sigset_t *set, sigset_t *oldset, size_t sigsetsize);
+pub fn sys_rt_sigprocmask(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+
+    let how = trapframe.get_arg(0);
+    let set_ptr = trapframe.get_arg(1);
+    let oldset_ptr = trapframe.get_arg(2);
+    let _sigsetsize = trapframe.get_arg(3);
+
+    let mut signal_state = abi.signal_state.lock();
+
+    // Save old mask if requested
+    if oldset_ptr != 0 {
+        let Some(paddr) = task.vm_manager.translate_to_kva(oldset_ptr) else {
+            // Invalid user pointer for oldset: return EFAULT
+            trapframe.set_return_value(!0usize);
+            trapframe.increment_pc_next(task);
+            return !0usize; // -EFAULT
+        };
+        let old_mask = signal_state.blocked.raw();
+        unsafe {
+            core::ptr::write(paddr as *mut u64, old_mask);
+        }
+    }
+
+    // Modify mask if new set is provided
+    if set_ptr != 0 {
+        let Some(paddr) = task.vm_manager.translate_to_kva(set_ptr) else {
+            // Invalid user pointer for set: return EFAULT
+            trapframe.set_return_value(!0usize);
+            trapframe.increment_pc_next(task);
+            return !0usize; // -EFAULT
+        };
+        let new_mask = unsafe { core::ptr::read(paddr as *const u64) };
+        let mut new_signal_mask = SignalMask::new();
+        new_signal_mask.set_raw(new_mask);
+
+        // SIG_BLOCK = 0, SIG_UNBLOCK = 1, SIG_SETMASK = 2
+        match how {
+            0 => {
+                // SIG_BLOCK: Add new_mask to current blocked signals
+                let current = signal_state.blocked.raw();
+                signal_state.blocked.set_raw(current | new_mask);
+            }
+            1 => {
+                // SIG_UNBLOCK: Remove new_mask from current blocked signals
+                let current = signal_state.blocked.raw();
+                signal_state.blocked.set_raw(current & !new_mask);
+            }
+            2 => {
+                // SIG_SETMASK: Replace blocked signals with new_mask
+                signal_state.blocked = new_signal_mask;
+            }
+            _ => {
+                trapframe.set_return_value(!0usize); // -1 (EINVAL)
+                trapframe.increment_pc_next(task);
+                return !0usize;
+            }
+        }
+    }
+
+    trapframe.set_return_value(0);
+    trapframe.increment_pc_next(task);
+    0
+}
+
+/// Convert Scarlet ProcessControlType to Linux signal
+pub fn process_control_to_signal(control_type: ProcessControlType) -> Option<LinuxSignal> {
+    match control_type {
+        ProcessControlType::Terminate => Some(LinuxSignal::SIGTERM),
+        ProcessControlType::Kill => Some(LinuxSignal::SIGKILL),
+        ProcessControlType::Stop => Some(LinuxSignal::SIGSTOP),
+        ProcessControlType::Continue => Some(LinuxSignal::SIGCONT),
+        ProcessControlType::Interrupt => Some(LinuxSignal::SIGINT),
+        ProcessControlType::Quit => Some(LinuxSignal::SIGQUIT),
+        ProcessControlType::Hangup => Some(LinuxSignal::SIGHUP),
+        ProcessControlType::ChildExit => Some(LinuxSignal::SIGCHLD),
+        ProcessControlType::PipeBroken => Some(LinuxSignal::SIGPIPE),
+        ProcessControlType::Alarm => Some(LinuxSignal::SIGALRM),
+        ProcessControlType::IoReady => Some(LinuxSignal::SIGIO),
+        ProcessControlType::User(sig) => LinuxSignal::from_u32(sig + 32), // Map to RT signals
+    }
+}
+
+/// Handle incoming event and convert to signal if needed
+pub fn handle_event_to_signal(event: &Event) -> Option<LinuxSignal> {
+    match &event.content {
+        EventContent::ProcessControl(control_type) => process_control_to_signal(*control_type),
+        _ => None, // Non-signal events are ignored in Linux ABI
+    }
+}
+
+/// Deliver a signal to a task's signal state
+pub fn deliver_signal_to_task(abi: &LinuxAbi, signal: LinuxSignal) {
+    // Add signal to pending if it's not already pending
+    let mut signal_state = abi.signal_state.lock();
+    if !signal_state.is_pending(signal) {
+        signal_state.add_pending(signal);
+    }
+}
+
+/// Check if task has pending signals and return the next one to handle
+pub fn get_next_pending_signal(abi: &LinuxAbi) -> Option<LinuxSignal> {
+    let signal_state = abi.signal_state.lock();
+    signal_state.next_deliverable_signal()
+}
+
+/// Process pending signals for a task with explicit signal state
+/// Returns true if a signal was handled and execution should be interrupted
+pub fn process_pending_signals_with_state(
+    signal_state: &mut SignalState,
+    trapframe: &mut Trapframe,
+) -> bool {
+    if let Some(signal) = signal_state.next_deliverable_signal() {
+        let action = signal_state.get_handler(signal);
+
+        // Remove signal from pending
+        signal_state.remove_pending(signal);
+
+        match action {
+            SignalAction::Terminate | SignalAction::ForceTerminate => {
+                // TODO: Implement actual task termination
+                // This should call task.set_state(TaskState::Terminated)
+                // and set exit code based on signal
+                crate::early_println!("Signal {}: Terminating task", signal as u32);
+                true
+            }
+            SignalAction::Ignore => {
+                // Signal ignored, continue execution
+                false
+            }
+            SignalAction::Stop => {
+                // TODO: Implement actual task stopping
+                // This should call task.set_state(TaskState::Stopped)
+                crate::early_println!("Signal {}: Stopping task", signal as u32);
+                true
+            }
+            SignalAction::Continue => {
+                // TODO: Implement actual task continuation
+                // This should call task.set_state(TaskState::Ready) if stopped
+                crate::early_println!("Signal {}: Continuing task", signal as u32);
+                false
+            }
+            SignalAction::Custom(handler_addr) => {
+                // Set up user-space signal handler execution
+                crate::early_println!(
+                    "Signal {}: Calling custom handler at {:#x}",
+                    signal as u32,
+                    handler_addr
+                );
+                setup_signal_handler(trapframe, handler_addr, signal);
+                true
+            }
+        }
+    } else {
+        false
+    }
+}
+
+/// Set up user-space signal handler execution with context save/restore.
+///
+/// Signal frame layout on user stack (simplified rt_sigframe):
+/// ```text
+///   [frame_base + 0]:   trampoline (li a7, 139; ecall) — rt_sigreturn
+///   [frame_base + 8]:   signal number
+///   [frame_base + 16]:  saved regs[0..31] (256 bytes)
+///   [frame_base + 272]: saved epc (8 bytes)
+/// ```
+pub fn setup_signal_handler(trapframe: &mut Trapframe, handler_addr: usize, signal: LinuxSignal) {
+    let mut sp = trapframe.regs.reg[2];
+
+    // trampoline(8) + signo(8) + regs(32×8) + epc(8) = 280
+    const SIGNAL_FRAME_SIZE: usize = 8 + 8 + (32 * 8) + 8;
+    sp -= SIGNAL_FRAME_SIZE;
+    sp &= !0xF;
+
+    let frame_base = sp;
+
+    let task = match mytask() {
+        Some(t) => t,
+        None => return,
+    };
+
+    unsafe {
+        // Trampoline: addi a7, x0, 139 (0x08b00893) + ecall (0x00000073)
+        let paddr = match task.vm_manager.translate_to_kva(frame_base) {
+            Some(p) => p,
+            None => return,
+        };
+        *(paddr as *mut u32) = 0x08b00893; // addi a7, x0, 139
+        *((paddr as *mut u32).add(1)) = 0x00000073; // ecall
+
+        let paddr = match task.vm_manager.translate_to_kva(frame_base + 8) {
+            Some(p) => p,
+            None => return,
+        };
+        *(paddr as *mut usize) = signal as usize;
+
+        for i in 0..32 {
+            let paddr = match task.vm_manager.translate_to_kva(frame_base + 16 + i * 8) {
+                Some(p) => p,
+                None => return,
+            };
+            *(paddr as *mut usize) = trapframe.regs.reg[i];
+        }
+
+        let paddr = match task.vm_manager.translate_to_kva(frame_base + 272) {
+            Some(p) => p,
+            None => return,
+        };
+        *(paddr as *mut u64) = trapframe.epc;
+    }
+
+    trapframe.epc = handler_addr as u64;
+    trapframe.regs.reg[2] = sp;
+    trapframe.regs.reg[10] = signal as usize; // a0 = signal number
+    trapframe.regs.reg[1] = frame_base; // ra = trampoline (rt_sigreturn)
+}
+
+/// Handle fatal signals that should terminate immediately
+/// This is a simplified implementation for basic signal handling
+pub fn handle_fatal_signal_immediately(signal: LinuxSignal) -> Result<(), &'static str> {
+    if let Some(task) = crate::task::mytask() {
+        let exit_code = match signal {
+            LinuxSignal::SIGKILL => 128 + 9,  // Standard SIGKILL exit code
+            LinuxSignal::SIGTERM => 128 + 15, // Standard SIGTERM exit code
+            LinuxSignal::SIGINT => 128 + 2,   // Standard SIGINT exit code
+            _ => return Err("Not a fatal signal"),
+        };
+
+        crate::early_println!(
+            "Signal {}: Immediately terminating task {} with exit code {}",
+            signal as u32,
+            task.get_id(),
+            exit_code
+        );
+
+        // Set task state to terminated and exit
+        task.exit(exit_code);
+        Ok(())
+    } else {
+        Err("No current task to terminate")
+    }
+}
+
+/// Check if a signal should be handled immediately (cannot be blocked/ignored)
+pub fn is_fatal_signal(signal: LinuxSignal) -> bool {
+    matches!(
+        signal,
+        LinuxSignal::SIGKILL | LinuxSignal::SIGTERM | LinuxSignal::SIGINT
+    )
+}
+
+/// Linux sys_rt_sigreturn — Restore context saved by `setup_signal_handler`.
+///
+/// Reads the signal frame from the current user stack pointer and restores
+/// all 32 general-purpose registers plus `epc`.  The frame layout matches
+/// what `setup_signal_handler` wrote:
+///
+/// ```text
+///   [sp + 0]:   trampoline (8 bytes, ignored here)
+///   [sp + 8]:   signal number (8 bytes, ignored here)
+///   [sp + 16]:  saved regs[0..31] (256 bytes)
+///   [sp + 272]: saved epc (8 bytes)
+/// ```
+///
+/// After restoration the task resumes at the instruction that was
+/// interrupted by the signal.
+pub fn sys_rt_sigreturn(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let frame_base = trapframe.regs.reg[2]; // SP points to signal frame
+
+    unsafe {
+        // Restore all 32 general-purpose registers
+        for i in 0..32 {
+            let paddr = match task.vm_manager.translate_to_kva(frame_base + 16 + i * 8) {
+                Some(p) => p,
+                None => return usize::MAX,
+            };
+            trapframe.regs.reg[i] = *(paddr as *const usize);
+        }
+
+        // Restore epc (program counter at time of signal)
+        let paddr = match task.vm_manager.translate_to_kva(frame_base + 272) {
+            Some(p) => p,
+            None => return usize::MAX,
+        };
+        trapframe.epc = *(paddr as *const u64);
+    }
+
+    // Return value is irrelevant — a0 was already restored from the frame.
+    0
+}
+
+/// Linux sys_tkill - Send a signal to a specific thread
+///
+/// tkill() sends a signal to a specific thread within the same thread group.
+/// This is a simplified implementation that mainly prevents crashes.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: tid (thread ID)
+///   - arg1: sig (signal number)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_tkill(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let tid = trapframe.get_arg(0) as i32;
+    let sig = trapframe.get_arg(1) as i32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // For now, just log and return success
+    // A proper implementation would:
+    // 1. Find the target task by TID
+    // 2. Add the signal to its pending signal queue
+    // 3. Wake the task if it's sleeping
+    crate::early_println!(
+        "[sys_tkill] tid={} sig={} - NOOP (signal delivery not implemented)",
+        tid,
+        sig
+    );
+
+    // Return success to avoid crashing applications
+    // Many applications use tkill for thread management
+    0
+}

--- a/kernel/src/abi/linux/generic/signal.rs
+++ b/kernel/src/abi/linux/generic/signal.rs
@@ -436,50 +436,38 @@ pub fn get_next_pending_signal(abi: &LinuxAbi) -> Option<LinuxSignal> {
     signal_state.next_deliverable_signal()
 }
 
-/// Process pending signals for a task with explicit signal state
-/// Returns true if a signal was handled and execution should be interrupted
+/// Process pending signals and dispatch to arch-specific handler.
+/// Returns true if execution should be interrupted.
+/// Arch modules must provide `arch_setup_signal_handler`.
 pub fn process_pending_signals_with_state(
     signal_state: &mut SignalState,
     trapframe: &mut Trapframe,
 ) -> bool {
     if let Some(signal) = signal_state.next_deliverable_signal() {
         let action = signal_state.get_handler(signal);
-
-        // Remove signal from pending
         signal_state.remove_pending(signal);
 
         match action {
             SignalAction::Terminate | SignalAction::ForceTerminate => {
-                // TODO: Implement actual task termination
-                // This should call task.set_state(TaskState::Terminated)
-                // and set exit code based on signal
                 crate::early_println!("Signal {}: Terminating task", signal as u32);
                 true
             }
-            SignalAction::Ignore => {
-                // Signal ignored, continue execution
-                false
-            }
+            SignalAction::Ignore => false,
             SignalAction::Stop => {
-                // TODO: Implement actual task stopping
-                // This should call task.set_state(TaskState::Stopped)
                 crate::early_println!("Signal {}: Stopping task", signal as u32);
                 true
             }
             SignalAction::Continue => {
-                // TODO: Implement actual task continuation
-                // This should call task.set_state(TaskState::Ready) if stopped
                 crate::early_println!("Signal {}: Continuing task", signal as u32);
                 false
             }
             SignalAction::Custom(handler_addr) => {
-                // Set up user-space signal handler execution
                 crate::early_println!(
                     "Signal {}: Calling custom handler at {:#x}",
                     signal as u32,
                     handler_addr
                 );
-                setup_signal_handler(trapframe, handler_addr, signal);
+                arch_setup_signal_handler(trapframe, handler_addr, signal);
                 true
             }
         }
@@ -488,74 +476,26 @@ pub fn process_pending_signals_with_state(
     }
 }
 
-/// Set up user-space signal handler execution with context save/restore.
-///
-/// Signal frame layout on user stack (simplified rt_sigframe):
-/// ```text
-///   [frame_base + 0]:   trampoline (li a7, 139; ecall) — rt_sigreturn
-///   [frame_base + 8]:   signal number
-///   [frame_base + 16]:  saved regs[0..31] (256 bytes)
-///   [frame_base + 272]: saved epc (8 bytes)
-/// ```
-pub fn setup_signal_handler(trapframe: &mut Trapframe, handler_addr: usize, signal: LinuxSignal) {
-    let mut sp = trapframe.regs.reg[2];
-
-    // trampoline(8) + signo(8) + regs(32×8) + epc(8) = 280
-    const SIGNAL_FRAME_SIZE: usize = 8 + 8 + (32 * 8) + 8;
-    sp -= SIGNAL_FRAME_SIZE;
-    sp &= !0xF;
-
-    let frame_base = sp;
-
-    let task = match mytask() {
-        Some(t) => t,
-        None => return,
-    };
-
-    unsafe {
-        // Trampoline: addi a7, x0, 139 (0x08b00893) + ecall (0x00000073)
-        let paddr = match task.vm_manager.translate_to_kva(frame_base) {
-            Some(p) => p,
-            None => return,
-        };
-        *(paddr as *mut u32) = 0x08b00893; // addi a7, x0, 139
-        *((paddr as *mut u32).add(1)) = 0x00000073; // ecall
-
-        let paddr = match task.vm_manager.translate_to_kva(frame_base + 8) {
-            Some(p) => p,
-            None => return,
-        };
-        *(paddr as *mut usize) = signal as usize;
-
-        for i in 0..32 {
-            let paddr = match task.vm_manager.translate_to_kva(frame_base + 16 + i * 8) {
-                Some(p) => p,
-                None => return,
-            };
-            *(paddr as *mut usize) = trapframe.regs.reg[i];
-        }
-
-        let paddr = match task.vm_manager.translate_to_kva(frame_base + 272) {
-            Some(p) => p,
-            None => return,
-        };
-        *(paddr as *mut u64) = trapframe.epc;
-    }
-
-    trapframe.epc = handler_addr as u64;
-    trapframe.regs.reg[2] = sp;
-    trapframe.regs.reg[10] = signal as usize; // a0 = signal number
-    trapframe.regs.reg[1] = frame_base; // ra = trampoline (rt_sigreturn)
+/// Arch-specific signal handler setup. Must be implemented by each arch module.
+pub fn arch_setup_signal_handler(
+    _trapframe: &mut Trapframe,
+    _handler_addr: usize,
+    _signal: LinuxSignal,
+) {
+    // Default: no-op. Arch modules should override via cfg.
+    #[cfg(target_arch = "riscv64")]
+    crate::abi::linux::riscv64::signal::setup_signal_handler(_trapframe, _handler_addr, _signal);
+    #[cfg(target_arch = "aarch64")]
+    crate::abi::linux::aarch64::signal::setup_signal_handler(_trapframe, _handler_addr, _signal);
 }
 
 /// Handle fatal signals that should terminate immediately
-/// This is a simplified implementation for basic signal handling
 pub fn handle_fatal_signal_immediately(signal: LinuxSignal) -> Result<(), &'static str> {
     if let Some(task) = crate::task::mytask() {
         let exit_code = match signal {
-            LinuxSignal::SIGKILL => 128 + 9,  // Standard SIGKILL exit code
-            LinuxSignal::SIGTERM => 128 + 15, // Standard SIGTERM exit code
-            LinuxSignal::SIGINT => 128 + 2,   // Standard SIGINT exit code
+            LinuxSignal::SIGKILL => 128 + 9,
+            LinuxSignal::SIGTERM => 128 + 15,
+            LinuxSignal::SIGINT => 128 + 2,
             _ => return Err("Not a fatal signal"),
         };
 
@@ -566,7 +506,6 @@ pub fn handle_fatal_signal_immediately(signal: LinuxSignal) -> Result<(), &'stat
             exit_code
         );
 
-        // Set task state to terminated and exit
         task.exit(exit_code);
         Ok(())
     } else {
@@ -574,57 +513,11 @@ pub fn handle_fatal_signal_immediately(signal: LinuxSignal) -> Result<(), &'stat
     }
 }
 
-/// Check if a signal should be handled immediately (cannot be blocked/ignored)
 pub fn is_fatal_signal(signal: LinuxSignal) -> bool {
     matches!(
         signal,
         LinuxSignal::SIGKILL | LinuxSignal::SIGTERM | LinuxSignal::SIGINT
     )
-}
-
-/// Linux sys_rt_sigreturn — Restore context saved by `setup_signal_handler`.
-///
-/// Reads the signal frame from the current user stack pointer and restores
-/// all 32 general-purpose registers plus `epc`.  The frame layout matches
-/// what `setup_signal_handler` wrote:
-///
-/// ```text
-///   [sp + 0]:   trampoline (8 bytes, ignored here)
-///   [sp + 8]:   signal number (8 bytes, ignored here)
-///   [sp + 16]:  saved regs[0..31] (256 bytes)
-///   [sp + 272]: saved epc (8 bytes)
-/// ```
-///
-/// After restoration the task resumes at the instruction that was
-/// interrupted by the signal.
-pub fn sys_rt_sigreturn(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
-    let task = match mytask() {
-        Some(t) => t,
-        None => return usize::MAX,
-    };
-
-    let frame_base = trapframe.regs.reg[2]; // SP points to signal frame
-
-    unsafe {
-        // Restore all 32 general-purpose registers
-        for i in 0..32 {
-            let paddr = match task.vm_manager.translate_to_kva(frame_base + 16 + i * 8) {
-                Some(p) => p,
-                None => return usize::MAX,
-            };
-            trapframe.regs.reg[i] = *(paddr as *const usize);
-        }
-
-        // Restore epc (program counter at time of signal)
-        let paddr = match task.vm_manager.translate_to_kva(frame_base + 272) {
-            Some(p) => p,
-            None => return usize::MAX,
-        };
-        trapframe.epc = *(paddr as *const u64);
-    }
-
-    // Return value is irrelevant — a0 was already restored from the frame.
-    0
 }
 
 /// Linux sys_tkill - Send a signal to a specific thread

--- a/kernel/src/abi/linux/generic/socket.rs
+++ b/kernel/src/abi/linux/generic/socket.rs
@@ -1,0 +1,1848 @@
+use crate::ipc::IpcError;
+use crate::object::capability::StreamError;
+use crate::{
+    abi::linux::generic::LinuxAbi,
+    abi::linux::generic::errno,
+    abi::linux::generic::fs::{FD_CLOEXEC, IoVec, O_NONBLOCK},
+    arch::Trapframe,
+    network::{NetworkManager, SocketDomain, SocketProtocol, SocketType, local::LocalSocket},
+    object::KernelObject,
+    object::capability::selectable::Selectable,
+    sched::scheduler::get_scheduler,
+    task::mytask,
+};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::mem::size_of;
+
+/// Linux socket domains
+pub const AF_UNIX: i32 = 1; // Unix domain sockets
+pub const AF_INET: i32 = 2; // Internet IP Protocol
+pub const AF_INET6: i32 = 10; // IP version 6
+
+/// Linux socket domain as u16 constants for pattern matching
+const AF_UNIX_U16: u16 = AF_UNIX as u16;
+const AF_INET_U16: u16 = AF_INET as u16;
+
+/// IPv4 socket address structure
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SockaddrIn {
+    pub sin_family: u16,
+    pub sin_port: u16,
+    pub sin_addr: u32,
+    pub sin_zero: [u8; 8],
+}
+
+impl SockaddrIn {
+    pub fn new() -> Self {
+        Self {
+            sin_family: AF_INET as u16,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0; 8],
+        }
+    }
+}
+
+/// Linux socket types
+pub const SOCK_STREAM: i32 = 1; // Stream socket
+pub const SOCK_DGRAM: i32 = 2; // Datagram socket
+pub const SOCK_RAW: i32 = 3; // Raw socket
+pub const SOCK_SEQPACKET: i32 = 5; // Sequenced packet socket
+pub const SOCK_NONBLOCK: i32 = 0x800;
+pub const SOCK_CLOEXEC: i32 = 0x80000;
+pub const SOCK_TYPE_MASK: i32 = 0xF;
+
+pub const SOL_SOCKET: i32 = 1;
+pub const SCM_RIGHTS: i32 = 1;
+pub const MSG_DONTWAIT: i32 = 0x40;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct LinuxMsghdr {
+    msg_name: u64,
+    msg_namelen: u32,
+    __pad1: u32,
+    msg_iov: u64,
+    msg_iovlen: u64,
+    msg_control: u64,
+    msg_controllen: u64,
+    msg_flags: u32,
+    __pad2: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct LinuxCmsghdr {
+    cmsg_len: usize,
+    cmsg_level: i32,
+    cmsg_type: i32,
+}
+
+/// Linux sys_socket implementation
+///
+/// Creates a socket endpoint for communication. Now properly integrated with
+/// NetworkManager and VFS for Unix domain socket support.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: domain (communication domain, e.g., AF_UNIX, AF_INET)
+///   - arg1: type (socket type, e.g., SOCK_STREAM, SOCK_DGRAM)
+///   - arg2: protocol (protocol to use, usually 0)
+///
+/// Returns:
+/// - file descriptor on success
+/// - usize::MAX (Linux -1) on error
+pub fn sys_socket(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let domain = trapframe.get_arg(0) as i32;
+    let socket_type = trapframe.get_arg(1) as i32;
+    let _protocol = trapframe.get_arg(2) as i32;
+    let socket_base_type = socket_type & SOCK_TYPE_MASK;
+    let socket_flags = socket_type & !SOCK_TYPE_MASK;
+    let set_nonblock = (socket_flags & SOCK_NONBLOCK) != 0;
+    let set_cloexec = (socket_flags & SOCK_CLOEXEC) != 0;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Map Linux socket domain to Scarlet domain
+    let scarlet_domain = match domain {
+        AF_UNIX => SocketDomain::Local,
+        AF_INET => SocketDomain::Inet4,
+        AF_INET6 => SocketDomain::Inet6,
+        _ => {
+            crate::early_println!("[linux socket] unsupported domain {}", domain);
+            return usize::MAX;
+        }
+    };
+
+    // Map Linux socket type to Scarlet type
+    let scarlet_type = match socket_base_type {
+        SOCK_STREAM => SocketType::Stream,
+        SOCK_DGRAM => SocketType::Datagram,
+        SOCK_RAW => SocketType::Raw,
+        SOCK_SEQPACKET => SocketType::SeqPacket,
+        _ => {
+            crate::early_println!("[linux socket] unsupported type {}", socket_type);
+            return usize::MAX;
+        }
+    };
+
+    // Map protocol
+    let scarlet_protocol = match scarlet_domain {
+        SocketDomain::Local => SocketProtocol::Default,
+        SocketDomain::Inet4 | SocketDomain::Inet6 => match (_protocol, socket_base_type) {
+            (0, SOCK_STREAM) => SocketProtocol::Tcp,
+            (0, SOCK_DGRAM) => SocketProtocol::Udp,
+            (6, _) => SocketProtocol::Tcp,
+            (17, _) => SocketProtocol::Udp,
+            (1, _) => SocketProtocol::Icmp,
+            _ => SocketProtocol::Default,
+        },
+        _ => SocketProtocol::Default,
+    };
+
+    let socket_obj: Arc<dyn crate::network::SocketObject> = match scarlet_domain {
+        SocketDomain::Local => {
+            let local_socket = Arc::new(LocalSocket::new(scarlet_type, SocketProtocol::Default));
+            LocalSocket::init_self_weak(&local_socket);
+            local_socket as Arc<dyn crate::network::SocketObject>
+        }
+        SocketDomain::Inet4 | SocketDomain::Inet6 => {
+            let socket = match scarlet_protocol {
+                SocketProtocol::Tcp => {
+                    NetworkManager::get_manager().get_layer("tcp").map(|layer| {
+                        let tcp = layer
+                            .as_any()
+                            .downcast_ref::<crate::network::tcp::TcpLayer>()
+                            .expect("tcp layer type mismatch");
+                        tcp.create_socket() as Arc<dyn crate::network::SocketObject>
+                    })
+                }
+                SocketProtocol::Udp => {
+                    NetworkManager::get_manager().get_layer("udp").map(|layer| {
+                        let udp = layer
+                            .as_any()
+                            .downcast_ref::<crate::network::udp::UdpLayer>()
+                            .expect("udp layer type mismatch");
+                        udp.create_socket() as Arc<dyn crate::network::SocketObject>
+                    })
+                }
+                SocketProtocol::Icmp => {
+                    NetworkManager::get_manager()
+                        .get_layer("icmp")
+                        .map(|layer| {
+                            let icmp = layer
+                                .as_any()
+                                .downcast_ref::<crate::network::icmp::IcmpLayer>()
+                                .expect("icmp layer type mismatch");
+                            icmp.create_socket() as Arc<dyn crate::network::SocketObject>
+                        })
+                }
+                _ => None,
+            };
+
+            match socket {
+                Some(socket) => socket,
+                None => {
+                    crate::early_println!(
+                        "[linux socket] failed to create INET socket protocol={:?}",
+                        scarlet_protocol
+                    );
+                    return usize::MAX;
+                }
+            }
+        }
+        _ => {
+            crate::early_println!("[linux socket] unsupported domain {:?}", scarlet_domain);
+            return usize::MAX;
+        }
+    };
+    if NetworkManager::get_manager()
+        .allocate_socket_id(Arc::clone(&socket_obj))
+        .is_err()
+    {
+        crate::early_println!("[linux socket] allocate_socket_id failed");
+    }
+
+    if set_nonblock {
+        if let Some(local_socket) = LocalSocket::from_socket_object(&socket_obj) {
+            local_socket.set_nonblocking(true);
+        }
+    }
+
+    // Wrap in KernelObject
+    let kernel_obj = KernelObject::Socket(socket_obj);
+
+    // Insert into handle table
+    match task.handle_table.insert(kernel_obj) {
+        Ok(handle) => {
+            // Allocate a file descriptor for the socket
+            match abi.allocate_fd(handle) {
+                Ok(fd) => {
+                    if set_cloexec {
+                        let _ = abi.set_fd_flags(fd, FD_CLOEXEC);
+                    }
+                    fd
+                }
+                Err(_) => {
+                    // Clean up on error
+                    let _ = task.handle_table.remove(handle);
+                    usize::MAX
+                }
+            }
+        }
+        Err(_) => {
+            crate::early_println!("[linux socket] handle table insert failed");
+            usize::MAX
+        }
+    }
+}
+
+/// Linux sys_bind implementation
+///
+/// Binds a socket to an address. For AF_UNIX sockets, this creates a socket file
+/// in the VFS at the specified path.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: addr (pointer to socket address structure)
+///   - arg2: addrlen (size of address structure)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) indicating failure
+pub fn sys_bind(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let sockfd = trapframe.get_arg(0) as i32;
+    let addr_ptr = trapframe.get_arg(1);
+    let addrlen = trapframe.get_arg(2) as u32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Get the file descriptor handle
+    let handle_id = match abi.get_handle(sockfd as usize) {
+        Some(h) => h,
+        None => {
+            crate::early_println!("[linux socket] bind invalid fd {}", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    // Get the socket object from handle table
+    let socket_arc = match task.handle_table.get(handle_id) {
+        Some(KernelObject::Socket(socket)) => socket.clone(),
+        _ => {
+            crate::early_println!("[linux socket] bind fd {} not socket", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    // Translate address pointer to physical
+    let addr_paddr = match task.vm_manager.translate_to_kva(addr_ptr) {
+        Some(addr) => addr,
+        None => {
+            crate::early_println!("[linux socket] bind bad addr {:x}", addr_ptr);
+            return usize::MAX;
+        }
+    };
+
+    // Read sockaddr structure from userspace
+    // sockaddr_un structure: { sa_family: u16, sun_path: [u8; 108] }
+    if addrlen < 2 {
+        return usize::MAX; // Too small
+    }
+
+    unsafe {
+        let sa_family = *(addr_paddr as *const u16);
+
+        match sa_family {
+            AF_UNIX_U16 => {
+                // Read the socket path (starts at offset 2)
+                let path_start = (addr_paddr + 2) as *const u8;
+                let max_path_len = (addrlen - 2) as usize;
+
+                // Find the null terminator or max length
+                let mut path_len = 0;
+                while path_len < max_path_len && *path_start.add(path_len) != 0 {
+                    path_len += 1;
+                }
+
+                if path_len == 0 || path_len > 108 {
+                    crate::early_println!("[linux socket] bind invalid path length {}", path_len);
+                    return usize::MAX;
+                }
+
+                // Convert to string
+                let path_bytes = core::slice::from_raw_parts(path_start, path_len);
+                let path = match core::str::from_utf8(path_bytes) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        crate::early_println!("[linux socket] bind path utf8 error");
+                        return usize::MAX;
+                    }
+                };
+
+                // Bind the socket to the address
+                let socket_addr = match crate::network::LocalSocketAddress::from_path(path) {
+                    Ok(addr) => crate::network::SocketAddress::Local(addr),
+                    Err(_) => return usize::MAX,
+                };
+
+                if socket_arc.bind(&socket_addr).is_err() {
+                    crate::early_println!("[linux socket] bind failed for {}", path);
+                    return usize::MAX;
+                }
+
+                if NetworkManager::get_manager()
+                    .register_named_socket(path, socket_arc.clone())
+                    .is_err()
+                {
+                    crate::early_println!("[linux socket] register_named_socket failed {}", path);
+                    return usize::MAX;
+                }
+
+                // Get the socket ID from NetworkManager
+                let socket_id = match NetworkManager::get_manager().get_socket_id(&socket_arc) {
+                    Some(id) => id,
+                    None => {
+                        crate::early_println!("[linux socket] get_socket_id failed {}", path);
+                        return usize::MAX;
+                    }
+                };
+
+                // Create socket file in VFS on a best-effort basis
+                // The socket has already been successfully bound, so VFS file creation
+                // is optional - the socket remains functional even if this fails
+                let vfs = match task.vfs.read().clone() {
+                    Some(vfs) => vfs.clone(),
+                    None => {
+                        // Use global VFS if task doesn't have its own
+                        crate::fs::vfs_v2::manager::get_global_vfs_manager()
+                    }
+                };
+
+                let socket_file_type =
+                    crate::fs::FileType::Socket(crate::fs::SocketFileInfo { socket_id });
+
+                // Attempt to create the socket file - log on failure but don't fail the bind
+                if let Err(e) = vfs.create_file(path, socket_file_type) {
+                    crate::early_println!(
+                        "[sys_bind] Warning: Failed to create VFS socket file at '{}': {:?}",
+                        path,
+                        e
+                    );
+                }
+
+                0 // Success
+            }
+            AF_INET_U16 => {
+                let addr_struct = &*(addr_paddr as *const SockaddrIn);
+                let port = u16::from_be(addr_struct.sin_port);
+                let addr_bytes = u32::to_be(addr_struct.sin_addr).to_be_bytes();
+                let socket_addr = crate::network::SocketAddress::Inet(
+                    crate::network::Inet4SocketAddress::new(addr_bytes, port),
+                );
+
+                if socket_arc.bind(&socket_addr).is_err() {
+                    crate::early_println!("[linux socket] bind failed for INET address");
+                    return usize::MAX;
+                }
+
+                0
+            }
+            _ => {
+                crate::early_println!("[linux socket] bind unsupported family {}", sa_family);
+                usize::MAX
+            }
+        }
+    }
+}
+
+/// Linux sys_listen implementation (mock)
+///
+/// Marks a socket as passive, ready to accept connections. This is a mock
+/// implementation that always succeeds to allow applications to proceed.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: backlog (maximum queue length for pending connections)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) indicating failure
+pub fn sys_listen(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let sockfd = trapframe.get_arg(0) as i32;
+    let backlog = trapframe.get_arg(1) as i32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    let handle_id = match abi.get_handle(sockfd as usize) {
+        Some(h) => h,
+        None => {
+            crate::early_println!("[linux socket] listen invalid fd {}", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    let socket_arc = match task.handle_table.get(handle_id) {
+        Some(KernelObject::Socket(socket)) => socket.clone(),
+        _ => {
+            crate::early_println!("[linux socket] listen fd {} not socket", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    if socket_arc.listen(backlog.max(0) as usize).is_err() {
+        crate::early_println!("[linux socket] listen failed fd {}", sockfd);
+        return usize::MAX;
+    }
+
+    0
+}
+
+/// Linux sys_accept implementation (mock)
+///
+/// Accepts a connection on a socket. This is a mock implementation that
+/// creates a new pipe and returns it as a "connected" socket fd.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: addr (pointer to socket address structure for peer)
+///   - arg2: addrlen (pointer to size of address structure)
+///
+/// Returns:
+/// - new socket file descriptor on success
+/// - usize::MAX (Linux -1) indicating failure
+pub fn sys_accept(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let sockfd = trapframe.get_arg(0) as i32;
+    let _addr_ptr = trapframe.get_arg(1);
+    let _addrlen_ptr = trapframe.get_arg(2);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    let handle_id = match abi.get_handle(sockfd as usize) {
+        Some(h) => h,
+        None => {
+            crate::early_println!("[linux socket] accept invalid fd {}", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    let socket_obj = match task.handle_table.get(handle_id) {
+        Some(KernelObject::Socket(socket)) => socket.clone(),
+        _ => {
+            crate::early_println!("[linux socket] accept fd {} not socket", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    // Try LocalSocket first, then TcpSocket
+    let accepted_socket = if let Some(local_socket) = LocalSocket::from_socket_object(&socket_obj) {
+        local_socket.accept_blocking(task.get_id(), trapframe)
+    } else if let Some(tcp_socket) = crate::network::tcp::TcpSocket::from_socket_object(&socket_obj)
+    {
+        tcp_socket.accept_blocking(task.get_id(), trapframe)
+    } else {
+        crate::early_println!("[linux socket] accept not supported socket type");
+        return usize::MAX;
+    };
+
+    let accepted_socket = match accepted_socket {
+        Ok(socket) => socket,
+        Err(_) => {
+            crate::early_println!("[linux socket] accept_blocking failed");
+            return usize::MAX;
+        }
+    };
+
+    let kernel_obj = KernelObject::Socket(accepted_socket);
+    match task.handle_table.insert(kernel_obj) {
+        Ok(handle) => match abi.allocate_fd(handle) {
+            Ok(fd) => fd,
+            Err(_) => {
+                let _ = task.handle_table.remove(handle);
+                usize::MAX
+            }
+        },
+        Err(_) => usize::MAX,
+    }
+}
+
+/// Linux sys_connect implementation (mock)
+///
+/// Connects a socket to an address. This is a mock implementation that
+/// always succeeds to allow applications to proceed.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: addr (pointer to socket address structure)
+///   - arg2: addrlen (size of address structure)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) indicating failure
+pub fn sys_connect(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let sockfd = trapframe.get_arg(0) as i32;
+    let addr_ptr = trapframe.get_arg(1);
+    let addrlen = trapframe.get_arg(2) as u32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    let handle_id = match abi.get_handle(sockfd as usize) {
+        Some(h) => h,
+        None => {
+            crate::early_println!("[linux socket] connect invalid fd {}", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    let socket_arc = match task.handle_table.get(handle_id) {
+        Some(KernelObject::Socket(socket)) => socket.clone(),
+        _ => {
+            crate::early_println!("[linux socket] connect fd {} not socket", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    let addr_paddr = match task.vm_manager.translate_to_kva(addr_ptr) {
+        Some(addr) => addr,
+        None => {
+            crate::early_println!("[linux socket] connect bad addr {:x}", addr_ptr);
+            return usize::MAX;
+        }
+    };
+
+    if addrlen < 2 {
+        return usize::MAX;
+    }
+
+    unsafe {
+        let sa_family = *(addr_paddr as *const u16);
+        match sa_family {
+            AF_UNIX_U16 => {
+                let path_start = (addr_paddr + 2) as *const u8;
+                let max_path_len = (addrlen - 2) as usize;
+                let mut path_len = 0;
+                while path_len < max_path_len && *path_start.add(path_len) != 0 {
+                    path_len += 1;
+                }
+
+                if path_len == 0 || path_len > 108 {
+                    crate::early_println!(
+                        "[linux socket] connect invalid path length {}",
+                        path_len
+                    );
+                    return usize::MAX;
+                }
+
+                let path_bytes = core::slice::from_raw_parts(path_start, path_len);
+                let path = match core::str::from_utf8(path_bytes) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        crate::early_println!("[linux socket] connect path utf8 error");
+                        return usize::MAX;
+                    }
+                };
+
+                let socket_addr = match crate::network::LocalSocketAddress::from_path(path) {
+                    Ok(addr) => crate::network::SocketAddress::Local(addr),
+                    Err(_) => return usize::MAX,
+                };
+
+                if socket_arc.connect(&socket_addr).is_err() {
+                    crate::early_println!("[linux socket] connect failed {}", path);
+                    return usize::MAX;
+                }
+            }
+            AF_INET_U16 => {
+                let addr_struct = &*(addr_paddr as *const SockaddrIn);
+                let port = u16::from_be(addr_struct.sin_port);
+                let addr_bytes = u32::to_be(addr_struct.sin_addr).to_be_bytes();
+                let socket_addr = crate::network::SocketAddress::Inet(
+                    crate::network::Inet4SocketAddress::new(addr_bytes, port),
+                );
+
+                if socket_arc.connect(&socket_addr).is_err() {
+                    crate::early_println!("[linux socket] connect failed for INET address");
+                    return usize::MAX;
+                }
+            }
+            _ => {
+                crate::early_println!("[linux socket] connect unsupported family {}", sa_family);
+                return usize::MAX;
+            }
+        }
+    }
+
+    0
+}
+
+/// Linux sys_getsockname implementation
+///
+/// Gets the current address of a socket.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: addr (pointer to socket address structure)
+///   - arg2: addrlen (pointer to size of address structure)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) indicating failure
+pub fn sys_getsockname(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let sockfd = trapframe.get_arg(0) as i32;
+    let addr_ptr = trapframe.get_arg(1);
+    let addrlen_ptr = trapframe.get_arg(2);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    let handle_id = match abi.get_handle(sockfd as usize) {
+        Some(h) => h,
+        None => {
+            crate::early_println!("[linux socket] getsockname invalid fd {}", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    let socket_arc = match task.handle_table.get(handle_id) {
+        Some(KernelObject::Socket(socket)) => socket.clone(),
+        _ => {
+            crate::early_println!("[linux socket] getsockname fd {} not socket", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    let (addr_paddr, addrlen_paddr) = match (
+        task.vm_manager.translate_to_kva(addr_ptr),
+        task.vm_manager.translate_to_kva(addrlen_ptr),
+    ) {
+        (Some(addr), Some(len)) => (addr, len),
+        _ => {
+            crate::early_println!("[linux socket] getsockname invalid pointers");
+            return usize::MAX;
+        }
+    };
+
+    let socket_addr = match socket_arc.getsockname() {
+        Ok(addr) => addr,
+        Err(_) => {
+            crate::early_println!("[linux socket] getsockname failed");
+            return usize::MAX;
+        }
+    };
+
+    unsafe {
+        let addrlen = *(addrlen_paddr as *const u32);
+
+        match socket_addr {
+            crate::network::SocketAddress::Local(addr) => {
+                if addrlen >= 2 {
+                    let sockaddr = addr_paddr as *mut u16;
+                    *sockaddr = AF_UNIX_U16;
+
+                    let path_start = (addr_paddr + 2) as *mut u8;
+                    let path = addr.path().as_bytes();
+                    let path_len = path.len().min((addrlen - 2) as usize);
+                    core::ptr::copy_nonoverlapping(path.as_ptr(), path_start, path_len);
+                    if path_len < (addrlen - 2) as usize {
+                        *(path_start.add(path_len)) = 0;
+                    }
+
+                    *(addrlen_paddr as *mut u32) = (2 + path_len as u32).min(addrlen);
+                    0
+                } else {
+                    usize::MAX
+                }
+            }
+            crate::network::SocketAddress::Inet(inet) => {
+                if addrlen >= size_of::<SockaddrIn>() as u32 {
+                    let sockaddr = addr_paddr as *mut SockaddrIn;
+                    (*sockaddr).sin_family = AF_INET_U16;
+                    (*sockaddr).sin_port = u16::to_be(inet.port);
+                    (*sockaddr).sin_addr = u32::from_be_bytes(inet.addr);
+
+                    *(addrlen_paddr as *mut u32) = size_of::<SockaddrIn>() as u32;
+                    0
+                } else {
+                    usize::MAX
+                }
+            }
+            _ => usize::MAX,
+        }
+    }
+}
+
+/// Linux sys_getpeername implementation
+///
+/// Gets the address of the peer connected to the socket.
+///
+/// Arguments:
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: addr (pointer to socket address structure)
+///   - arg2: addrlen (pointer to size of address structure)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) indicating failure
+pub fn sys_getpeername(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let sockfd = trapframe.get_arg(0) as i32;
+    let addr_ptr = trapframe.get_arg(1);
+    let addrlen_ptr = trapframe.get_arg(2);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    let handle_id = match abi.get_handle(sockfd as usize) {
+        Some(h) => h,
+        None => {
+            crate::early_println!("[linux socket] getpeername invalid fd {}", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    let socket_arc = match task.handle_table.get(handle_id) {
+        Some(KernelObject::Socket(socket)) => socket.clone(),
+        _ => {
+            crate::early_println!("[linux socket] getpeername fd {} not socket", sockfd);
+            return usize::MAX;
+        }
+    };
+
+    let (addr_paddr, addrlen_paddr) = match (
+        task.vm_manager.translate_to_kva(addr_ptr),
+        task.vm_manager.translate_to_kva(addrlen_ptr),
+    ) {
+        (Some(addr), Some(len)) => (addr, len),
+        _ => {
+            crate::early_println!("[linux socket] getpeername invalid pointers");
+            return usize::MAX;
+        }
+    };
+
+    let socket_addr = match socket_arc.getpeername() {
+        Ok(addr) => addr,
+        Err(_) => {
+            crate::early_println!("[linux socket] getpeername failed");
+            return usize::MAX;
+        }
+    };
+
+    unsafe {
+        let addrlen = *(addrlen_paddr as *const u32);
+
+        match socket_addr {
+            crate::network::SocketAddress::Local(addr) => {
+                if addrlen >= 2 {
+                    let sockaddr = addr_paddr as *mut u16;
+                    *sockaddr = AF_UNIX_U16;
+
+                    let path_start = (addr_paddr + 2) as *mut u8;
+                    let path = addr.path().as_bytes();
+                    let path_len = path.len().min((addrlen - 2) as usize);
+                    core::ptr::copy_nonoverlapping(path.as_ptr(), path_start, path_len);
+                    if path_len < (addrlen - 2) as usize {
+                        *(path_start.add(path_len)) = 0;
+                    }
+
+                    *(addrlen_paddr as *mut u32) = (2 + path_len as u32).min(addrlen);
+                    0
+                } else {
+                    usize::MAX
+                }
+            }
+            crate::network::SocketAddress::Inet(inet) => {
+                if addrlen >= size_of::<SockaddrIn>() as u32 {
+                    let sockaddr = addr_paddr as *mut SockaddrIn;
+                    (*sockaddr).sin_family = AF_INET_U16;
+                    (*sockaddr).sin_port = u16::to_be(inet.port);
+                    (*sockaddr).sin_addr = u32::from_be_bytes(inet.addr);
+
+                    *(addrlen_paddr as *mut u32) = size_of::<SockaddrIn>() as u32;
+                    0
+                } else {
+                    usize::MAX
+                }
+            }
+            _ => usize::MAX,
+        }
+    }
+}
+
+/// Linux sys_getsockopt implementation (mock)
+///
+/// Gets socket options. This is a mock implementation that
+/// writes dummy data and succeeds to allow applications to proceed.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: level (protocol level)
+///   - arg2: optname (option name)
+///   - arg3: optval (pointer to option value buffer)
+///   - arg4: optlen (pointer to option length)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) indicating failure
+pub fn sys_getsockopt(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let _sockfd = trapframe.get_arg(0) as i32;
+    let _level = trapframe.get_arg(1) as i32;
+    let _optname = trapframe.get_arg(2) as i32;
+    let optval_ptr = trapframe.get_arg(3);
+    let optlen_ptr = trapframe.get_arg(4);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Mock implementation - write minimal valid data and return success
+    if let (Some(optval_paddr), Some(optlen_paddr)) = (
+        task.vm_manager.translate_to_kva(optval_ptr),
+        task.vm_manager.translate_to_kva(optlen_ptr),
+    ) {
+        unsafe {
+            // Read the provided length
+            let optlen = *(optlen_paddr as *const u32);
+
+            // Write dummy option value (typically an integer)
+            if optlen >= 4 && optval_ptr != 0 {
+                let optval = optval_paddr as *mut u32;
+                *optval = 1; // Generic "enabled" value
+
+                // Update the actual length used
+                *(optlen_paddr as *mut u32) = 4;
+            }
+        }
+        0 // Success
+    } else {
+        usize::MAX // Invalid pointers
+    }
+}
+
+/// Linux sys_setsockopt implementation (mock)
+///
+/// Sets socket options. This is a mock implementation that
+/// always succeeds to allow applications to proceed.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: level (protocol level)
+///   - arg2: optname (option name)
+///   - arg3: optval (pointer to option value)
+///   - arg4: optlen (option length)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX (Linux -1) indicating failure
+pub fn sys_setsockopt(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let _sockfd = trapframe.get_arg(0) as i32;
+    let _level = trapframe.get_arg(1) as i32;
+    let _optname = trapframe.get_arg(2) as i32;
+    let _optval_ptr = trapframe.get_arg(3);
+    let _optlen = trapframe.get_arg(4) as u32;
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // Mock implementation - always succeed
+    0
+}
+
+/// Linux sys_sendmsg implementation (minimal)
+pub fn sys_sendmsg(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let sockfd = trapframe.get_arg(0);
+    let msg_ptr = trapframe.get_arg(1);
+    let flags = trapframe.get_arg(2) as i32;
+
+    trapframe.increment_pc_next(task);
+
+    let handle = match abi.get_handle(sockfd) {
+        Some(h) => h,
+        None => {
+            crate::early_println!("[linux socket] sendmsg bad fd {}", sockfd);
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => {
+            crate::early_println!("[linux socket] sendmsg missing handle {}", sockfd);
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let stream = match kernel_obj.as_stream() {
+        Some(stream) => stream,
+        None => {
+            crate::early_println!("[linux socket] sendmsg not a stream");
+            return errno::to_result(errno::ENOTSOCK);
+        }
+    };
+
+    let nonblocking = (flags & MSG_DONTWAIT) != 0
+        || abi
+            .get_file_status_flags(sockfd)
+            .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+            .unwrap_or(false);
+
+    let msg_addr = match task.vm_manager.translate_to_kva(msg_ptr) {
+        Some(addr) => addr as *const LinuxMsghdr,
+        None => {
+            crate::early_println!("[linux socket] sendmsg bad msg ptr {:x}", msg_ptr);
+            return errno::to_result(errno::EFAULT);
+        }
+    };
+
+    if msg_addr.is_null() {
+        crate::early_println!("[linux socket] sendmsg null msg ptr");
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let msg = unsafe { *msg_addr };
+    let iovcnt = msg.msg_iovlen as usize;
+    if iovcnt == 0 {
+        return 0;
+    }
+
+    const IOV_MAX: usize = 1024;
+    if iovcnt > IOV_MAX {
+        return errno::to_result(errno::EINVAL);
+    }
+
+    let iovec_addr = match task.vm_manager.translate_to_kva(msg.msg_iov as usize) {
+        Some(addr) => addr as *const IoVec,
+        None => {
+            crate::early_println!("[linux socket] sendmsg bad iov ptr {:x}", msg.msg_iov);
+            return errno::to_result(errno::EFAULT);
+        }
+    };
+
+    if iovec_addr.is_null() {
+        crate::early_println!("[linux socket] sendmsg null iov ptr");
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let iovecs = unsafe { core::slice::from_raw_parts(iovec_addr, iovcnt) };
+
+    if msg.msg_control != 0 && msg.msg_controllen as usize >= size_of::<LinuxCmsghdr>() {
+        let socket_arc = match &kernel_obj {
+            KernelObject::Socket(socket) => Arc::clone(socket),
+            _ => return errno::to_result(errno::ENOTSOCK),
+        };
+
+        if let Some(local_socket) = LocalSocket::from_socket_object(&socket_arc) {
+            let cmsg_addr = match task.vm_manager.translate_to_kva(msg.msg_control as usize) {
+                Some(addr) => addr as *const LinuxCmsghdr,
+                None => {
+                    crate::early_println!(
+                        "[linux socket] sendmsg bad cmsg ptr {:x}",
+                        msg.msg_control
+                    );
+                    return errno::to_result(errno::EFAULT);
+                }
+            };
+
+            if !cmsg_addr.is_null() {
+                let cmsg = unsafe { *cmsg_addr };
+                if cmsg.cmsg_level == SOL_SOCKET && cmsg.cmsg_type == SCM_RIGHTS {
+                    let data_len = cmsg.cmsg_len.saturating_sub(size_of::<LinuxCmsghdr>());
+                    let fd_count = data_len / size_of::<i32>();
+                    let data_ptr = unsafe { cmsg_addr.add(1) } as *const i32;
+
+                    for index in 0..fd_count {
+                        let fd = unsafe { *data_ptr.add(index) };
+                        if fd < 0 {
+                            return errno::to_result(errno::EBADF);
+                        }
+                        let send_handle = match abi.get_handle(fd as usize) {
+                            Some(h) => h,
+                            None => {
+                                crate::early_println!(
+                                    "[linux socket] sendmsg bad fd in cmsg {}",
+                                    fd
+                                );
+                                return errno::to_result(errno::EBADF);
+                            }
+                        };
+                        let dup_obj = match task.handle_table.clone_for_dup(send_handle) {
+                            Some(obj) => obj,
+                            None => {
+                                crate::early_println!(
+                                    "[linux socket] sendmsg clone_for_dup failed"
+                                );
+                                return errno::to_result(errno::EBADF);
+                            }
+                        };
+                        if local_socket.send_handle(dup_obj).is_err() {
+                            crate::early_println!("[linux socket] sendmsg send_handle failed");
+                            return errno::to_result(errno::EIO);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut total_written = 0usize;
+    struct NonblockGuard<'a> {
+        sel: Option<&'a dyn Selectable>,
+        prev: bool,
+    }
+
+    impl<'a> Drop for NonblockGuard<'a> {
+        fn drop(&mut self) {
+            if let Some(sel) = self.sel {
+                sel.set_nonblocking(self.prev);
+            }
+        }
+    }
+
+    let _nonblock_guard = if nonblocking {
+        if let Some(sel) = kernel_obj.as_selectable() {
+            let prev = sel.is_nonblocking();
+            if !prev {
+                sel.set_nonblocking(true);
+                Some(NonblockGuard {
+                    sel: Some(sel),
+                    prev,
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    for iovec in iovecs {
+        if iovec.iov_len == 0 {
+            continue;
+        }
+
+        let buf_addr = match task.vm_manager.translate_to_kva(iovec.iov_base as usize) {
+            Some(addr) => addr as *const u8,
+            None => {
+                crate::early_println!(
+                    "[linux socket] sendmsg bad buf ptr {:x}",
+                    iovec.iov_base as usize
+                );
+                return errno::to_result(errno::EFAULT);
+            }
+        };
+
+        if buf_addr.is_null() {
+            crate::early_println!("[linux socket] sendmsg null buf ptr");
+            return errno::to_result(errno::EFAULT);
+        }
+
+        let buffer = unsafe { core::slice::from_raw_parts(buf_addr, iovec.iov_len) };
+
+        match stream.write(buffer) {
+            Ok(n) => {
+                total_written = total_written.saturating_add(n);
+                if n < iovec.iov_len {
+                    break;
+                }
+            }
+            Err(StreamError::WouldBlock) => {
+                if nonblocking {
+                    crate::early_println!("[linux socket] sendmsg would block");
+                    return if total_written == 0 {
+                        errno::to_result(errno::EAGAIN)
+                    } else {
+                        total_written
+                    };
+                }
+                get_scheduler().schedule(trapframe);
+                return usize::MAX;
+            }
+            Err(_) => {
+                crate::early_println!("[linux socket] sendmsg write error");
+                return errno::to_result(errno::EIO);
+            }
+        }
+    }
+
+    total_written
+}
+
+/// Linux sys_recvmsg implementation (minimal)
+pub fn sys_recvmsg(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let sockfd = trapframe.get_arg(0);
+    let msg_ptr = trapframe.get_arg(1);
+    let flags = trapframe.get_arg(2) as i32;
+    // crate::early_println!(
+    //     "[linux recvmsg] fd={} msg_ptr={:#x} flags={:#x}",
+    //     sockfd,
+    //     msg_ptr,
+    //     flags
+    // );
+
+    trapframe.increment_pc_next(task);
+
+    let handle = match abi.get_handle(sockfd) {
+        Some(h) => h,
+        None => {
+            crate::early_println!("[linux socket] recvmsg bad fd {}", sockfd);
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    // crate::early_println!("[linux recvmsg] handle={}", handle);
+
+    let kernel_obj = match task.handle_table.get(handle) {
+        Some(obj) => obj,
+        None => {
+            crate::early_println!("[linux socket] recvmsg missing handle {}", sockfd);
+            return errno::to_result(errno::EBADF);
+        }
+    };
+
+    let stream = match kernel_obj.as_stream() {
+        Some(stream) => stream,
+        None => {
+            crate::early_println!("[linux socket] recvmsg not a stream");
+            return errno::to_result(errno::ENOTSOCK);
+        }
+    };
+
+    let nonblocking = (flags & MSG_DONTWAIT) != 0
+        || abi
+            .get_file_status_flags(sockfd)
+            .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+            .unwrap_or(false);
+
+    let msg_addr = match task.vm_manager.translate_to_kva(msg_ptr) {
+        Some(addr) => addr as *mut LinuxMsghdr,
+        None => {
+            crate::early_println!("[linux socket] recvmsg bad msg ptr {:x}", msg_ptr);
+            return errno::to_result(errno::EFAULT);
+        }
+    };
+
+    if msg_addr.is_null() {
+        crate::early_println!("[linux socket] recvmsg null msg ptr");
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let msg = unsafe { *msg_addr };
+    // crate::early_println!(
+    //     "[linux recvmsg] iov_ptr={:#x} iovlen={} control_ptr={:#x} controllen={}",
+    //     msg.msg_iov,
+    //     msg.msg_iovlen,
+    //     msg.msg_control,
+    //     msg.msg_controllen
+    // );
+    let iovcnt = msg.msg_iovlen as usize;
+    if iovcnt == 0 {
+        return 0;
+    }
+
+    const IOV_MAX: usize = 1024;
+    if iovcnt > IOV_MAX {
+        return errno::to_result(errno::EINVAL);
+    }
+
+    let iovec_addr = match task.vm_manager.translate_to_kva(msg.msg_iov as usize) {
+        Some(addr) => addr as *const IoVec,
+        None => {
+            crate::early_println!("[linux socket] recvmsg bad iov ptr {:x}", msg.msg_iov);
+            return errno::to_result(errno::EFAULT);
+        }
+    };
+
+    if iovec_addr.is_null() {
+        crate::early_println!("[linux socket] recvmsg null iov ptr");
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let iovecs = unsafe { core::slice::from_raw_parts(iovec_addr, iovcnt) };
+    // crate::early_println!("[linux recvmsg] iovcnt={}", iovecs.len());
+    let mut total_read = 0usize;
+    let mut pending_fd: Option<i32> = None;
+    let mut msg_controllen = 0usize;
+    struct NonblockGuard<'a> {
+        sel: Option<&'a dyn Selectable>,
+        prev: bool,
+    }
+
+    impl<'a> Drop for NonblockGuard<'a> {
+        fn drop(&mut self) {
+            if let Some(sel) = self.sel {
+                sel.set_nonblocking(self.prev);
+            }
+        }
+    }
+
+    let _nonblock_guard = if nonblocking {
+        if let Some(sel) = kernel_obj.as_selectable() {
+            let prev = sel.is_nonblocking();
+            if !prev {
+                sel.set_nonblocking(true);
+                Some(NonblockGuard {
+                    sel: Some(sel),
+                    prev,
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Calculate total buffer size for potential handle+data receive
+    let total_buffer_size: usize = iovecs.iter().map(|i| i.iov_len).sum();
+    let mut atomic_data: Option<Vec<u8>> = None;
+
+    // Try atomic handle+data receive if control buffer is provided
+    if msg.msg_control != 0
+        && (msg.msg_controllen as usize) >= size_of::<LinuxCmsghdr>() + size_of::<i32>()
+    {
+        let socket_arc = match &kernel_obj {
+            KernelObject::Socket(socket) => Arc::clone(socket),
+            _ => {
+                return errno::to_result(errno::ENOTSOCK);
+            }
+        };
+
+        if let Some(local_socket) = LocalSocket::from_socket_object(&socket_arc) {
+            match local_socket.recv_handle_and_data(total_buffer_size) {
+                Ok((obj, data)) => {
+                    let new_handle = match task.handle_table.insert(obj) {
+                        Ok(h) => h,
+                        Err(_) => return errno::to_result(errno::EMFILE),
+                    };
+                    let new_fd = match abi.allocate_fd(new_handle) {
+                        Ok(fd) => fd,
+                        Err(_) => {
+                            let _ = task.handle_table.remove(new_handle);
+                            return errno::to_result(errno::EMFILE);
+                        }
+                    };
+                    pending_fd = Some(new_fd as i32);
+                    atomic_data = Some(data);
+                }
+                Err(IpcError::ChannelEmpty) => {
+                    // No handle available; fall back to regular stream read
+                }
+                Err(_) => {
+                    return errno::to_result(errno::EIO);
+                }
+            }
+        }
+    }
+
+    // Copy data from atomic receive or read from stream
+    if let Some(ref data) = atomic_data {
+        // Copy atomically received data into iovecs
+        let mut data_offset = 0;
+        let data_len = data.len();
+        for iovec in iovecs {
+            if data_offset >= data_len {
+                break;
+            }
+            if iovec.iov_len == 0 {
+                continue;
+            }
+
+            let buf_addr = match task.vm_manager.translate_to_kva(iovec.iov_base as usize) {
+                Some(addr) => addr as *mut u8,
+                None => return errno::to_result(errno::EFAULT),
+            };
+
+            if buf_addr.is_null() {
+                return errno::to_result(errno::EFAULT);
+            }
+
+            let remaining = data.len() - data_offset;
+            let to_copy = remaining.min(iovec.iov_len);
+            let buffer = unsafe { core::slice::from_raw_parts_mut(buf_addr, to_copy) };
+            buffer.copy_from_slice(&data[data_offset..data_offset + to_copy]);
+            data_offset += to_copy;
+            total_read += to_copy;
+        }
+    } else {
+        // No handle received; read data from stream
+        for iovec in iovecs {
+            if iovec.iov_len == 0 {
+                continue;
+            }
+
+            let buf_addr = match task.vm_manager.translate_to_kva(iovec.iov_base as usize) {
+                Some(addr) => addr as *mut u8,
+                None => {
+                    return errno::to_result(errno::EFAULT);
+                }
+            };
+
+            if buf_addr.is_null() {
+                return errno::to_result(errno::EFAULT);
+            }
+
+            let buffer = unsafe { core::slice::from_raw_parts_mut(buf_addr, iovec.iov_len) };
+
+            match stream.read(buffer) {
+                Ok(n) => {
+                    total_read = total_read.saturating_add(n);
+                    if n < iovec.iov_len {
+                        break;
+                    }
+                }
+                Err(StreamError::WouldBlock) => {
+                    return if total_read == 0 {
+                        errno::to_result(errno::EAGAIN)
+                    } else {
+                        total_read
+                    };
+                }
+                Err(_) => {
+                    return errno::to_result(errno::EIO);
+                }
+            }
+        }
+    }
+
+    if let Some(fd_value) = pending_fd {
+        let cmsg_addr = match task.vm_manager.translate_to_kva(msg.msg_control as usize) {
+            Some(addr) => addr as *mut LinuxCmsghdr,
+            None => return errno::to_result(errno::EFAULT),
+        };
+
+        if cmsg_addr.is_null() {
+            return errno::to_result(errno::EFAULT);
+        }
+
+        unsafe {
+            (*cmsg_addr).cmsg_len = size_of::<LinuxCmsghdr>() + size_of::<i32>();
+            (*cmsg_addr).cmsg_level = SOL_SOCKET;
+            (*cmsg_addr).cmsg_type = SCM_RIGHTS;
+            let data_ptr = cmsg_addr.add(1) as *mut i32;
+            *data_ptr = fd_value;
+        }
+
+        msg_controllen = size_of::<LinuxCmsghdr>() + size_of::<i32>();
+    }
+
+    unsafe {
+        (*msg_addr).msg_flags = 0;
+        (*msg_addr).msg_controllen = msg_controllen as u64;
+    }
+
+    total_read
+}
+
+/// Linux sys_sendto implementation
+///
+/// Send a message on a socket. Unlike sendmsg, this directly takes a buffer and address.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: buf (pointer to data buffer)
+///   - arg2: len (length of data)
+///   - arg3: flags (send flags)
+///   - arg4: dest_addr (pointer to destination address, may be NULL for connected sockets)
+///   - arg5: addrlen (size of destination address)
+///
+/// Returns:
+/// - number of bytes sent on success
+/// - negative errno on error
+pub fn sys_sendto(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::ESRCH),
+    };
+
+    let sockfd = trapframe.get_arg(0);
+    let buf_ptr = trapframe.get_arg(1);
+    let len = trapframe.get_arg(2);
+    let flags = trapframe.get_arg(3) as u32;
+    let dest_addr_ptr = trapframe.get_arg(4);
+    let addrlen = trapframe.get_arg(5) as u32;
+
+    trapframe.increment_pc_next(task);
+
+    // Get socket handle
+    let handle = match abi.get_handle(sockfd) {
+        Some(h) => h,
+        None => return errno::to_result(errno::EBADF),
+    };
+
+    // Get socket object
+    let socket = match task.handle_table.get(handle) {
+        Some(KernelObject::Socket(s)) => s.clone(),
+        _ => return errno::to_result(errno::ENOTSOCK),
+    };
+
+    // Translate buffer pointer
+    let buf_kaddr = match task.vm_manager.translate_to_kva(buf_ptr) {
+        Some(addr) => addr,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let data = unsafe { core::slice::from_raw_parts(buf_kaddr as *const u8, len) };
+
+    // Parse destination address if provided
+    let dest_addr = if dest_addr_ptr != 0 && addrlen > 0 {
+        let addr_kaddr = match task.vm_manager.translate_to_kva(dest_addr_ptr) {
+            Some(addr) => addr,
+            None => return errno::to_result(errno::EFAULT),
+        };
+
+        // Read address family
+        let sa_family = unsafe { *(addr_kaddr as *const u16) };
+
+        match sa_family {
+            AF_INET_U16 => {
+                if addrlen < size_of::<SockaddrIn>() as u32 {
+                    return errno::to_result(errno::EINVAL);
+                }
+                let sockaddr = unsafe { *(addr_kaddr as *const SockaddrIn) };
+                let port = u16::from_be(sockaddr.sin_port);
+                let addr_bytes = sockaddr.sin_addr.to_be_bytes();
+                crate::network::SocketAddress::Inet(crate::network::Inet4SocketAddress::new(
+                    addr_bytes, port,
+                ))
+            }
+            AF_UNIX_U16 => {
+                // Unix domain socket sendto - usually not used for stream sockets
+                crate::network::SocketAddress::Unspecified
+            }
+            _ => return errno::to_result(errno::EAFNOSUPPORT),
+        }
+    } else {
+        // No address - use connected peer
+        crate::network::SocketAddress::Unspecified
+    };
+
+    // Send data
+    match socket.sendto(data, &dest_addr, flags) {
+        Ok(n) => n,
+        Err(crate::network::socket::SocketError::WouldBlock) => errno::to_result(errno::EAGAIN),
+        Err(crate::network::socket::SocketError::NotConnected) => errno::to_result(errno::ENOTCONN),
+        Err(crate::network::socket::SocketError::NoRoute) => errno::to_result(errno::ENETUNREACH),
+        Err(crate::network::socket::SocketError::InvalidAddress) => errno::to_result(errno::EINVAL),
+        Err(_) => errno::to_result(errno::EIO),
+    }
+}
+
+/// Linux sys_recvfrom implementation
+///
+/// Receive a message from a socket. Returns the source address if provided.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: buf (pointer to receive buffer)
+///   - arg2: len (length of buffer)
+///   - arg3: flags (receive flags)
+///   - arg4: src_addr (pointer to store source address, may be NULL)
+///   - arg5: addrlen (pointer to address length, input/output)
+///
+/// Returns:
+/// - number of bytes received on success
+/// - negative errno on error
+pub fn sys_recvfrom(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::ESRCH),
+    };
+
+    let sockfd = trapframe.get_arg(0);
+    let buf_ptr = trapframe.get_arg(1);
+    let len = trapframe.get_arg(2);
+    let flags = trapframe.get_arg(3) as u32;
+    let src_addr_ptr = trapframe.get_arg(4);
+    let addrlen_ptr = trapframe.get_arg(5);
+
+    trapframe.increment_pc_next(task);
+
+    // Get socket handle
+    let handle = match abi.get_handle(sockfd) {
+        Some(h) => h,
+        None => return errno::to_result(errno::EBADF),
+    };
+
+    // Get socket object
+    let socket = match task.handle_table.get(handle) {
+        Some(KernelObject::Socket(s)) => s.clone(),
+        _ => return errno::to_result(errno::ENOTSOCK),
+    };
+
+    // Translate buffer pointer
+    let buf_kaddr = match task.vm_manager.translate_to_kva(buf_ptr) {
+        Some(addr) => addr,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let buffer = unsafe { core::slice::from_raw_parts_mut(buf_kaddr as *mut u8, len) };
+
+    // Check for non-blocking mode
+    let nonblocking = (flags & (MSG_DONTWAIT as u32)) != 0
+        || abi
+            .get_file_status_flags(sockfd)
+            .map(|f| ((f as i32) & O_NONBLOCK) != 0)
+            .unwrap_or(false);
+
+    // Set non-blocking if requested
+    if let Some(selectable) = socket.as_selectable() {
+        if nonblocking {
+            selectable.set_nonblocking(true);
+        }
+    }
+
+    // Receive data
+    let result = socket.recvfrom(buffer, flags);
+
+    // Restore blocking mode if we changed it
+    if nonblocking {
+        if let Some(selectable) = socket.as_selectable() {
+            selectable.set_nonblocking(false);
+        }
+    }
+
+    match result {
+        Ok((n, src_addr)) => {
+            // Store source address if requested
+            if src_addr_ptr != 0 && addrlen_ptr != 0 {
+                let addrlen_paddr = match task.vm_manager.translate_to_kva(addrlen_ptr) {
+                    Some(addr) => addr as *mut u32,
+                    None => return errno::to_result(errno::EFAULT),
+                };
+
+                let provided_len = unsafe { *addrlen_paddr };
+
+                match src_addr {
+                    crate::network::SocketAddress::Inet(inet) => {
+                        if provided_len >= size_of::<SockaddrIn>() as u32 {
+                            let addr_paddr = match task.vm_manager.translate_to_kva(src_addr_ptr) {
+                                Some(addr) => addr as *mut SockaddrIn,
+                                None => return errno::to_result(errno::EFAULT),
+                            };
+
+                            let sockaddr = SockaddrIn {
+                                sin_family: AF_INET as u16,
+                                sin_port: inet.port.to_be(),
+                                sin_addr: u32::from_be_bytes(inet.addr),
+                                sin_zero: [0; 8],
+                            };
+                            unsafe {
+                                *addr_paddr = sockaddr;
+                                *addrlen_paddr = size_of::<SockaddrIn>() as u32;
+                            }
+                        }
+                    }
+                    crate::network::SocketAddress::Local(_) => {
+                        // Unix domain socket - store sockaddr_un
+                        unsafe {
+                            *addrlen_paddr = 0;
+                        }
+                    }
+                    crate::network::SocketAddress::Unspecified => unsafe {
+                        *addrlen_paddr = 0;
+                    },
+                    _ => unsafe {
+                        *addrlen_paddr = 0;
+                    },
+                }
+            }
+            n
+        }
+        Err(crate::network::socket::SocketError::WouldBlock) => errno::to_result(errno::EAGAIN),
+        Err(crate::network::socket::SocketError::NotConnected) => errno::to_result(errno::ENOTCONN),
+        Err(_) => errno::to_result(errno::EIO),
+    }
+}
+
+/// Linux sys_socketpair implementation
+///
+/// Create a pair of connected sockets. This is primarily used for AF_UNIX sockets
+/// to create a bidirectional communication channel between processes.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: domain (address family, must be AF_UNIX)
+///   - arg1: type (socket type, e.g., SOCK_STREAM)
+///   - arg2: protocol (usually 0)
+///   - arg3: sv (pointer to int[2] to receive the file descriptors)
+///
+/// Returns:
+/// - 0 on success
+/// - negative errno on error
+pub fn sys_socketpair(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::ESRCH),
+    };
+
+    let domain = trapframe.get_arg(0) as i32;
+    let socket_type = trapframe.get_arg(1) as i32;
+    let _protocol = trapframe.get_arg(2) as i32;
+    let sv_ptr = trapframe.get_arg(3);
+
+    trapframe.increment_pc_next(task);
+
+    // Validate domain - socketpair only supports AF_UNIX
+    if domain != AF_UNIX {
+        return errno::to_result(errno::EAFNOSUPPORT);
+    }
+
+    // Extract socket type flags
+    let base_type = socket_type & SOCK_TYPE_MASK;
+    let flags = socket_type & !SOCK_TYPE_MASK;
+    let nonblocking = (flags & SOCK_NONBLOCK) != 0;
+    let cloexec = (flags & SOCK_CLOEXEC) != 0;
+
+    // Validate socket type - we support SOCK_STREAM and SOCK_DGRAM
+    if base_type != SOCK_STREAM && base_type != SOCK_DGRAM {
+        return errno::to_result(errno::ESOCKTNOSUPPORT);
+    }
+
+    // Translate sv pointer (needs to write 2 i32 values)
+    let sv_paddr = match task.vm_manager.translate_to_kva(sv_ptr) {
+        Some(addr) => addr as *mut i32,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    // Create connected socket pair
+    let (socket1, socket2) = LocalSocket::create_connected_pair(
+        alloc::string::String::from("socketpair:0"),
+        alloc::string::String::from("socketpair:1"),
+    );
+
+    // Set non-blocking mode if requested
+    if nonblocking {
+        socket1.set_nonblocking(true);
+        socket2.set_nonblocking(true);
+    }
+
+    // Add first socket to handle table
+    let kernel_obj1 = KernelObject::Socket(socket1);
+    let handle1 = match task.handle_table.insert(kernel_obj1) {
+        Ok(id) => id,
+        Err(_) => return errno::to_result(errno::EMFILE),
+    };
+
+    // Add second socket to handle table
+    let kernel_obj2 = KernelObject::Socket(socket2);
+    let handle2 = match task.handle_table.insert(kernel_obj2) {
+        Ok(id) => id,
+        Err(_) => {
+            // Clean up handle1 if handle2 allocation fails
+            let _ = task.handle_table.remove(handle1);
+            return errno::to_result(errno::EMFILE);
+        }
+    };
+
+    // Allocate file descriptors
+    let fd1 = match abi.allocate_fd(handle1) {
+        Ok(fd) => fd,
+        Err(_) => {
+            let _ = task.handle_table.remove(handle1);
+            let _ = task.handle_table.remove(handle2);
+            return errno::to_result(errno::EMFILE);
+        }
+    };
+
+    let fd2 = match abi.allocate_fd(handle2) {
+        Ok(fd) => fd,
+        Err(_) => {
+            let _ = abi.remove_fd(fd1);
+            let _ = task.handle_table.remove(handle1);
+            let _ = task.handle_table.remove(handle2);
+            return errno::to_result(errno::EMFILE);
+        }
+    };
+
+    // Set flags
+    if nonblocking {
+        let _ = abi.set_file_status_flags(fd1, O_NONBLOCK as u32);
+        let _ = abi.set_file_status_flags(fd2, O_NONBLOCK as u32);
+    }
+    if cloexec {
+        let _ = abi.set_fd_flags(fd1, FD_CLOEXEC);
+        let _ = abi.set_fd_flags(fd2, FD_CLOEXEC);
+    }
+
+    // Write file descriptors to user space
+    unsafe {
+        *sv_paddr = fd1 as i32;
+        *sv_paddr.add(1) = fd2 as i32;
+    }
+
+    0
+}
+
+/// Linux sys_shutdown implementation
+///
+/// Shut down part of a full-duplex connection.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: sockfd (socket file descriptor)
+///   - arg1: how (0=SHUT_RD, 1=SHUT_WR, 2=SHUT_RDWR)
+///
+/// Returns:
+/// - 0 on success
+/// - negative errno on error
+pub fn sys_shutdown(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return errno::to_result(errno::ESRCH),
+    };
+
+    let sockfd = trapframe.get_arg(0);
+    let how = trapframe.get_arg(1) as u32;
+
+    trapframe.increment_pc_next(task);
+
+    // Get socket handle
+    let handle = match abi.get_handle(sockfd) {
+        Some(h) => h,
+        None => return errno::to_result(errno::EBADF),
+    };
+
+    // Get socket object
+    let socket = match task.handle_table.get(handle) {
+        Some(KernelObject::Socket(s)) => s.clone(),
+        _ => return errno::to_result(errno::ENOTSOCK),
+    };
+
+    // Convert how to ShutdownHow
+    let shutdown_how = match how {
+        0 => crate::network::socket::ShutdownHow::Read,
+        1 => crate::network::socket::ShutdownHow::Write,
+        2 => crate::network::socket::ShutdownHow::Both,
+        _ => return errno::to_result(errno::EINVAL),
+    };
+
+    match socket.shutdown(shutdown_how) {
+        Ok(()) => 0,
+        Err(crate::network::socket::SocketError::NotConnected) => errno::to_result(errno::ENOTCONN),
+        Err(_) => errno::to_result(errno::EIO),
+    }
+}

--- a/kernel/src/abi/linux/generic/time.rs
+++ b/kernel/src/abi/linux/generic/time.rs
@@ -1,0 +1,726 @@
+//! Time-related system calls for Linux ABI
+//!
+//! This module implements Linux time system calls for the Scarlet kernel,
+//! providing compatibility with Linux userspace programs that need time information.
+
+use super::{
+    errno,
+    signal::{LinuxSignal, SignalState},
+};
+use crate::{
+    abi::linux::generic::LinuxAbi,
+    arch::Trapframe,
+    sched::scheduler::get_scheduler,
+    task::mytask,
+    time::current_time,
+    timer::{TimerHandler, add_timer, cancel_timer, get_tick, ns_to_ticks, ticks_to_ns},
+};
+use alloc::sync::{Arc, Weak};
+use spin::Mutex;
+
+const NSEC_PER_SEC_I64: i64 = 1_000_000_000;
+const NSEC_PER_SEC_U64: u64 = 1_000_000_000;
+const TIMER_ABSTIME: i32 = 1;
+
+/// Linux POSIX timer shared state guarded by a spin mutex for interior mutability.
+pub struct PosixTimerShared {
+    state: Mutex<PosixTimerState>,
+}
+
+impl PosixTimerShared {
+    fn new(
+        id: u64,
+        clock_id: i32,
+        sigev_notify: i32,
+        sigev_signo: i32,
+        sigev_value: u64,
+        owner_task_id: usize,
+        signal_state: Arc<spin::Mutex<SignalState>>,
+    ) -> Self {
+        Self {
+            state: Mutex::new(PosixTimerState {
+                id,
+                clock_id,
+                sigev_notify,
+                sigev_signo,
+                sigev_value,
+                interval_ns: 0,
+                timer_entry_id: None,
+                next_deadline_tick: None,
+                active: false,
+                owner_task_id,
+                signal_state,
+                overrun_count: 0,
+            }),
+        }
+    }
+
+    fn lock(&self) -> spin::MutexGuard<'_, PosixTimerState> {
+        self.state.lock()
+    }
+}
+
+/// Mutable state stored for each POSIX timer.
+pub struct PosixTimerState {
+    pub id: u64,
+    pub clock_id: i32,
+    pub sigev_notify: i32,
+    pub sigev_signo: i32,
+    pub sigev_value: u64,
+    pub interval_ns: u64,
+    pub timer_entry_id: Option<u64>,
+    pub next_deadline_tick: Option<u64>,
+    pub active: bool,
+    pub owner_task_id: usize,
+    pub signal_state: Arc<spin::Mutex<SignalState>>,
+    pub overrun_count: u32,
+}
+
+/// Public representation of a POSIX timer stored in the Linux ABI state.
+#[derive(Clone)]
+pub struct PosixTimer {
+    pub id: u64,
+    shared: Arc<PosixTimerShared>,
+    handler: Arc<PosixTimerHandler>,
+}
+
+impl PosixTimer {
+    pub fn new(
+        id: u64,
+        clock_id: i32,
+        sigev_notify: i32,
+        sigev_signo: i32,
+        sigev_value: u64,
+        owner_task_id: usize,
+        signal_state: Arc<spin::Mutex<SignalState>>,
+    ) -> Self {
+        let shared = Arc::new(PosixTimerShared::new(
+            id,
+            clock_id,
+            sigev_notify,
+            sigev_signo,
+            sigev_value,
+            owner_task_id,
+            signal_state,
+        ));
+        let handler = Arc::new(PosixTimerHandler {
+            timer_id: id,
+            shared: Arc::downgrade(&shared),
+        });
+        Self {
+            id,
+            shared,
+            handler,
+        }
+    }
+
+    /// Schedule (or reschedule) this timer with the specified first expiration and interval.
+    ///
+    /// A zero `first_ns` disarms the timer.
+    pub fn schedule(&self, first_ns: u64, interval_ns: u64) {
+        let mut state = self.shared.lock();
+        if let Some(entry_id) = state.timer_entry_id.take() {
+            cancel_timer(entry_id);
+        }
+        state.interval_ns = interval_ns;
+        state.overrun_count = 0;
+
+        if first_ns == 0 {
+            state.active = false;
+            state.next_deadline_tick = None;
+            return;
+        }
+
+        let mut ticks = ns_to_ticks(first_ns);
+        if ticks == 0 {
+            ticks = 1;
+        }
+        let target_tick = get_tick().saturating_add(ticks);
+        let handler_dyn: Arc<dyn TimerHandler> = self.handler.clone();
+        let new_id = add_timer(target_tick, &handler_dyn, self.id as usize);
+        state.timer_entry_id = Some(new_id);
+        state.next_deadline_tick = Some(target_tick);
+        state.active = true;
+    }
+
+    /// Cancel any outstanding kernel timer and mark this POSIX timer inactive.
+    pub fn cancel(&self) {
+        let mut state = self.shared.lock();
+        if let Some(entry_id) = state.timer_entry_id.take() {
+            cancel_timer(entry_id);
+        }
+        state.active = false;
+        state.next_deadline_tick = None;
+    }
+
+    /// Snapshot the remaining time (in ns) and current interval (in ns).
+    pub fn snapshot(&self) -> (u64, u64) {
+        let state = self.shared.lock();
+        let interval = state.interval_ns;
+        let remaining = match state.next_deadline_tick {
+            Some(deadline) => {
+                let now = get_tick();
+                if deadline > now {
+                    ticks_to_ns(deadline - now)
+                } else {
+                    0
+                }
+            }
+            None => 0,
+        };
+        (remaining, interval)
+    }
+
+    pub fn state(&self) -> spin::MutexGuard<'_, PosixTimerState> {
+        self.shared.lock()
+    }
+}
+
+struct PosixTimerHandler {
+    timer_id: u64,
+    shared: Weak<PosixTimerShared>,
+}
+
+impl TimerHandler for PosixTimerHandler {
+    fn on_timer_expired(self: Arc<Self>, _context: usize) {
+        let Some(shared) = self.shared.upgrade() else {
+            return;
+        };
+
+        // Snapshot data while holding the state lock
+        let (notify, signo, interval_ns, owner_task_id, signal_state) = {
+            let mut state = shared.lock();
+            if !state.active {
+                return;
+            }
+            state.timer_entry_id = None;
+            state.next_deadline_tick = None;
+            (
+                state.sigev_notify,
+                state.sigev_signo,
+                state.interval_ns,
+                state.owner_task_id,
+                state.signal_state.clone(),
+            )
+        };
+
+        // Deliver notifications outside of the lock
+        if notify == SIGEV_SIGNAL {
+            if let Some(signal) = LinuxSignal::from_u32(signo as u32) {
+                let mut locked = signal_state.lock();
+                locked.add_pending(signal);
+                drop(locked);
+                let scheduler = get_scheduler();
+                let _ = scheduler.wake_task(owner_task_id);
+            }
+        }
+
+        if notify == SIGEV_NONE {
+            // No wake required for SIGEV_NONE.
+        }
+
+        // Re-arm periodic timers.
+        if interval_ns > 0 {
+            let mut state = shared.lock();
+            let mut ticks = ns_to_ticks(interval_ns);
+            if ticks == 0 {
+                ticks = 1;
+            }
+            let target_tick = get_tick().saturating_add(ticks);
+            let handler_dyn: Arc<dyn TimerHandler> = self.clone();
+            let entry_id = add_timer(target_tick, &handler_dyn, self.timer_id as usize);
+            state.timer_entry_id = Some(entry_id);
+            state.next_deadline_tick = Some(target_tick);
+            state.active = true;
+        } else {
+            let mut state = shared.lock();
+            state.active = false;
+        }
+    }
+}
+
+/// Linux sigevent notification values (subset).
+pub const SIGEV_SIGNAL: i32 = 0;
+pub const SIGEV_NONE: i32 = 1;
+pub const SIGEV_THREAD: i32 = 2;
+pub const SIGEV_THREAD_ID: i32 = 4;
+
+fn is_supported_clock(clock_id: i32) -> bool {
+    matches!(
+        clock_id,
+        CLOCK_REALTIME
+            | CLOCK_MONOTONIC
+            | CLOCK_PROCESS_CPUTIME_ID
+            | CLOCK_THREAD_CPUTIME_ID
+            | CLOCK_MONOTONIC_RAW
+            | CLOCK_REALTIME_COARSE
+            | CLOCK_MONOTONIC_COARSE
+            | CLOCK_BOOTTIME
+    )
+}
+
+fn timespec_to_ns(ts: &TimeSpec) -> Result<u64, usize> {
+    if ts.tv_sec < 0 || ts.tv_nsec < 0 || ts.tv_nsec >= NSEC_PER_SEC_I64 {
+        return Err(errno::EINVAL);
+    }
+    let sec = ts.tv_sec as u128;
+    let nsec = ts.tv_nsec as u128;
+    let total = sec
+        .saturating_mul(NSEC_PER_SEC_U64 as u128)
+        .saturating_add(nsec);
+    Ok(total.min(u64::MAX as u128) as u64)
+}
+
+fn ns_to_timespec(ns: u64) -> TimeSpec {
+    let sec = (ns / NSEC_PER_SEC_U64).min(i64::MAX as u64);
+    let nsec = if sec >= i64::MAX as u64 {
+        (NSEC_PER_SEC_U64 - 1) as i64
+    } else {
+        (ns % NSEC_PER_SEC_U64) as i64
+    };
+    TimeSpec {
+        tv_sec: sec as i64,
+        tv_nsec: nsec,
+    }
+}
+
+/// Linux timespec structure (matches Linux userspace)
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct TimeSpec {
+    pub tv_sec: i64,  // seconds
+    pub tv_nsec: i64, // nanoseconds
+}
+
+/// Linux itimerspec structure used by timer_settime/gettime.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ItimerSpec {
+    it_interval: TimeSpec,
+    it_value: TimeSpec,
+}
+
+/// Linux clock IDs (subset of commonly used ones)
+pub const CLOCK_REALTIME: i32 = 0;
+pub const CLOCK_MONOTONIC: i32 = 1;
+pub const CLOCK_PROCESS_CPUTIME_ID: i32 = 2;
+pub const CLOCK_THREAD_CPUTIME_ID: i32 = 3;
+pub const CLOCK_MONOTONIC_RAW: i32 = 4;
+pub const CLOCK_REALTIME_COARSE: i32 = 5;
+pub const CLOCK_MONOTONIC_COARSE: i32 = 6;
+pub const CLOCK_BOOTTIME: i32 = 7;
+
+/// Linux `timer_create` implementation.
+///
+/// Returns 0 on success or negative errno on failure.
+pub fn sys_timer_create(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(task) => task,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let clock_id = trapframe.get_arg(0) as i32;
+    let sevp_ptr = trapframe.get_arg(1);
+    let timerid_ptr = trapframe.get_arg(2);
+
+    trapframe.increment_pc_next(&task);
+
+    if !is_supported_clock(clock_id) {
+        return errno::to_result(errno::EINVAL);
+    }
+
+    if timerid_ptr == 0 {
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let timerid_paddr = match task.vm_manager.translate_to_kva(timerid_ptr) {
+        Some(ptr) => ptr as *mut u64,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    // Defaults if user does not supply struct sigevent
+    let mut sigev_notify = SIGEV_SIGNAL;
+    let mut sigev_signo = LinuxSignal::SIGALRM as i32;
+    let mut sigev_value = 0u64;
+
+    if sevp_ptr != 0 {
+        let sevp_paddr = match task.vm_manager.translate_to_kva(sevp_ptr) {
+            Some(addr) => addr,
+            None => return errno::to_result(errno::EFAULT),
+        };
+
+        unsafe {
+            let base = sevp_paddr as *const u8;
+            sigev_value = *(base as *const u64);
+            sigev_signo = *(base.add(8) as *const i32);
+            sigev_notify = *(base.add(12) as *const i32);
+        }
+
+        match sigev_notify {
+            SIGEV_SIGNAL => {
+                if sigev_signo <= 0 || LinuxSignal::from_u32(sigev_signo as u32).is_none() {
+                    return errno::to_result(errno::EINVAL);
+                }
+            }
+            SIGEV_NONE => {
+                // No additional validation needed
+            }
+            SIGEV_THREAD | SIGEV_THREAD_ID => {
+                // Thread-based notifications require pthread helpers we do not have yet.
+                return errno::to_result(errno::ENOSYS);
+            }
+            _ => {
+                return errno::to_result(errno::EINVAL);
+            }
+        }
+    }
+
+    let timer_id = abi.allocate_posix_timer_id();
+    let timer = PosixTimer::new(
+        timer_id,
+        clock_id,
+        sigev_notify,
+        sigev_signo,
+        sigev_value,
+        task.get_id(),
+        abi.signal_state.clone(),
+    );
+    abi.store_posix_timer(timer);
+
+    unsafe {
+        *timerid_paddr = timer_id as u64;
+    }
+
+    trapframe.set_return_value(0);
+    0
+}
+
+/// Linux `timer_settime` implementation.
+pub fn sys_timer_settime(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(task) => task,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let timer_id = trapframe.get_arg(0) as u64;
+    let flags = trapframe.get_arg(1) as i32;
+    let new_value_ptr = trapframe.get_arg(2);
+    let old_value_ptr = trapframe.get_arg(3);
+
+    trapframe.increment_pc_next(&task);
+
+    if (flags & !TIMER_ABSTIME) != 0 {
+        return errno::to_result(errno::EINVAL);
+    }
+    if (flags & TIMER_ABSTIME) != 0 {
+        return errno::to_result(errno::ENOSYS);
+    }
+    if new_value_ptr == 0 {
+        return errno::to_result(errno::EINVAL);
+    }
+
+    let timer = match abi.get_posix_timer(timer_id) {
+        Some(timer) => timer,
+        None => return errno::to_result(errno::EINVAL),
+    };
+
+    let new_value_paddr = match task.vm_manager.translate_to_kva(new_value_ptr) {
+        Some(addr) => addr,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let new_spec = unsafe { *(new_value_paddr as *const ItimerSpec) };
+
+    let first_ns = match timespec_to_ns(&new_spec.it_value) {
+        Ok(ns) => ns,
+        Err(errno_val) => return errno::to_result(errno_val),
+    };
+    let interval_ns = match timespec_to_ns(&new_spec.it_interval) {
+        Ok(ns) => ns,
+        Err(errno_val) => return errno::to_result(errno_val),
+    };
+
+    if old_value_ptr != 0 {
+        let old_value_paddr = match task.vm_manager.translate_to_kva(old_value_ptr) {
+            Some(addr) => addr as *mut ItimerSpec,
+            None => return errno::to_result(errno::EFAULT),
+        };
+        let (remaining_ns, previous_interval_ns) = timer.snapshot();
+        let snapshot = ItimerSpec {
+            it_interval: ns_to_timespec(previous_interval_ns),
+            it_value: ns_to_timespec(remaining_ns),
+        };
+        unsafe {
+            *old_value_paddr = snapshot;
+        }
+    }
+
+    timer.schedule(first_ns, interval_ns);
+
+    trapframe.set_return_value(0);
+    0
+}
+
+/// Linux `timer_gettime` implementation.
+pub fn sys_timer_gettime(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(task) => task,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let timer_id = trapframe.get_arg(0) as u64;
+    let setting_ptr = trapframe.get_arg(1);
+
+    trapframe.increment_pc_next(&task);
+
+    if setting_ptr == 0 {
+        return errno::to_result(errno::EFAULT);
+    }
+
+    let timer = match abi.get_posix_timer(timer_id) {
+        Some(timer) => timer,
+        None => return errno::to_result(errno::EINVAL),
+    };
+
+    let setting_paddr = match task.vm_manager.translate_to_kva(setting_ptr) {
+        Some(addr) => addr as *mut ItimerSpec,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let (remaining_ns, interval_ns) = timer.snapshot();
+    let current = ItimerSpec {
+        it_interval: ns_to_timespec(interval_ns),
+        it_value: ns_to_timespec(remaining_ns),
+    };
+
+    unsafe {
+        *setting_paddr = current;
+    }
+
+    trapframe.set_return_value(0);
+    0
+}
+
+/// Linux `timer_getoverrun` implementation (simple stub returning 0).
+pub fn sys_timer_getoverrun(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(task) => task,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let timer_id = trapframe.get_arg(0) as u64;
+
+    trapframe.increment_pc_next(&task);
+
+    let timer = match abi.get_posix_timer(timer_id) {
+        Some(timer) => timer,
+        None => return errno::to_result(errno::EINVAL),
+    };
+
+    let overrun = {
+        let state = timer.state();
+        state.overrun_count as usize
+    };
+
+    trapframe.set_return_value(overrun);
+    overrun
+}
+
+/// Linux `timer_delete` implementation.
+pub fn sys_timer_delete(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(task) => task,
+        None => return errno::to_result(errno::EFAULT),
+    };
+
+    let timer_id = trapframe.get_arg(0) as u64;
+
+    trapframe.increment_pc_next(&task);
+
+    let timer = match abi.remove_posix_timer(timer_id) {
+        Some(timer) => timer,
+        None => return errno::to_result(errno::EINVAL),
+    };
+
+    timer.cancel();
+
+    trapframe.set_return_value(0);
+    0
+}
+
+/// sys_clock_gettime - Get time from specified clock
+///
+/// Arguments:
+/// - a0 (x10): clock_id - which clock to read from
+/// - a1 (x11): timespec - pointer to timespec structure to fill
+///
+/// Returns:
+/// - 0 on success
+/// - -EINVAL (-22) for invalid clock_id
+/// - -EFAULT (-14) for invalid timespec pointer
+pub fn sys_clock_gettime(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = mytask().expect("No current task found");
+    let clock_id = trapframe.get_arg(0) as i32; // a0
+
+    trapframe.increment_pc_next(&task);
+
+    let timespec_ptr = match task.vm_manager.translate_to_kva(trapframe.get_arg(1)) {
+        Some(ptr) => ptr as *mut TimeSpec,   // a1
+        None => return (-14_isize) as usize, // -EFAULT
+    };
+
+    // Get the current time based on the clock type
+    let timespec = match clock_id {
+        CLOCK_REALTIME | CLOCK_REALTIME_COARSE => {
+            // For now, we use the same monotonic time for realtime
+            // In a full implementation, this would be adjusted to Unix epoch
+            let time_us = current_time();
+            TimeSpec {
+                tv_sec: (time_us / 1_000_000) as i64,
+                tv_nsec: ((time_us % 1_000_000) * 1000) as i64,
+            }
+        }
+        CLOCK_MONOTONIC | CLOCK_MONOTONIC_RAW | CLOCK_MONOTONIC_COARSE => {
+            // Monotonic time since boot
+            let time_us = current_time();
+            TimeSpec {
+                tv_sec: (time_us / 1_000_000) as i64,
+                tv_nsec: ((time_us % 1_000_000) * 1000) as i64,
+            }
+        }
+        CLOCK_BOOTTIME => {
+            // Boot time (same as monotonic for now)
+            let time_us = current_time();
+            TimeSpec {
+                tv_sec: (time_us / 1_000_000) as i64,
+                tv_nsec: ((time_us % 1_000_000) * 1000) as i64,
+            }
+        }
+        CLOCK_PROCESS_CPUTIME_ID | CLOCK_THREAD_CPUTIME_ID => {
+            // CPU time for process/thread (simplified implementation)
+            // In a full implementation, this would track actual CPU time
+            let time_us = current_time();
+            TimeSpec {
+                tv_sec: (time_us / 1_000_000) as i64,
+                tv_nsec: ((time_us % 1_000_000) * 1000) as i64,
+            }
+        }
+        _ => {
+            return (-22_isize) as usize; // -EINVAL
+        }
+    };
+
+    // Write the timespec to user space
+    unsafe {
+        *timespec_ptr = timespec;
+    }
+
+    0 // Success
+}
+
+/// sys_nanosleep - Sleep for the specified time (Linux ABI)
+///
+/// Arguments:
+/// - a0 (x10): rqtp - pointer to requested sleep time (struct __kernel_timespec __user *)
+/// - a1 (x11): rmtp - pointer to remaining time (struct __kernel_timespec __user *)
+///
+/// Returns:
+/// - 0 on success
+/// - -EFAULT (-14) for invalid pointer
+/// - -EINTR (-4) if interrupted by signal (not implemented, always 0)
+pub fn sys_nanosleep(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    // Get current task
+    let task = match mytask() {
+        Some(task) => task,
+        None => return (-14_isize) as usize, // -EFAULT
+    };
+    trapframe.increment_pc_next(&task);
+
+    // Get user pointer to requested timespec
+    let rqtp_ptr = trapframe.get_arg(0);
+    let _rmtp_ptr = trapframe.get_arg(1);
+    let rqtp = match task.vm_manager.translate_to_kva(rqtp_ptr) {
+        Some(ptr) => unsafe { &*(ptr as *const TimeSpec) },
+        None => return (-14_isize) as usize, // -EFAULT
+    };
+    // Convert timespec to nanoseconds
+    let ns = rqtp
+        .tv_sec
+        .saturating_mul(1_000_000_000)
+        .saturating_add(rqtp.tv_nsec);
+    if ns <= 0 {
+        return 0;
+    }
+    // Convert nanoseconds to kernel ticks
+    let ticks = ns_to_ticks(ns as u64);
+    trapframe.set_return_value(0); // Set return value to 0 (success)
+    // Sleep the current task for the specified ticks
+    task.sleep(trapframe, ticks);
+    // If sleep is successful, this will not be reached. If interrupted, return -EINTR (not implemented)
+    0
+}
+
+/// Linux sys_clock_getres implementation (stub)
+///
+/// Get clock resolution. This is a stub implementation that
+/// returns a reasonable resolution for the specified clock.
+///
+/// Arguments:
+/// - abi: LinuxAbi context
+/// - trapframe: Trapframe containing syscall arguments
+///   - arg0: clk_id (clock ID)
+///   - arg1: res (pointer to timespec structure for resolution)
+///
+/// Returns:
+/// - 0 on success
+/// - usize::MAX on error
+pub fn sys_clock_getres(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
+    let task = match mytask() {
+        Some(t) => t,
+        None => return usize::MAX,
+    };
+
+    let _clk_id = trapframe.get_arg(0) as i32;
+    let res_ptr = trapframe.get_arg(1);
+
+    // Increment PC to avoid infinite loop
+    trapframe.increment_pc_next(task);
+
+    // If res pointer is provided, write resolution
+    if res_ptr != 0 {
+        if let Some(res_paddr) = task.vm_manager.translate_to_kva(res_ptr) {
+            unsafe {
+                // Write timespec structure with nanosecond resolution
+                // struct timespec { long tv_sec; long tv_nsec; }
+                let timespec = res_paddr as *mut [u64; 2];
+                *timespec = [
+                    0,         // tv_sec = 0
+                    1_000_000, // tv_nsec = 1 millisecond (reasonable resolution)
+                ];
+            }
+        }
+    }
+
+    0 // Always succeed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test_case]
+    fn test_timespec_size() {
+        // Ensure TimeSpec matches Linux ABI
+        assert_eq!(core::mem::size_of::<TimeSpec>(), 16);
+        assert_eq!(core::mem::align_of::<TimeSpec>(), 8);
+    }
+
+    #[test_case]
+    fn test_clock_constants() {
+        // Verify clock constants match Linux values
+        assert_eq!(CLOCK_REALTIME, 0);
+        assert_eq!(CLOCK_MONOTONIC, 1);
+        assert_eq!(CLOCK_PROCESS_CPUTIME_ID, 2);
+        assert_eq!(CLOCK_THREAD_CPUTIME_ID, 3);
+    }
+}

--- a/kernel/src/abi/linux/mod.rs
+++ b/kernel/src/abi/linux/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
 pub mod device;
+pub mod generic;
 #[cfg(target_arch = "riscv64")]
 pub mod riscv64;

--- a/kernel/src/abi/linux/riscv64/mod.rs
+++ b/kernel/src/abi/linux/riscv64/mod.rs
@@ -15,6 +15,8 @@ use crate::{
     vm::setup_user_stack,
 };
 
+pub mod signal;
+
 #[derive(Clone)]
 pub struct LinuxRiscv64Abi(pub generic::LinuxAbi);
 
@@ -65,6 +67,10 @@ impl AbiModule for LinuxRiscv64Abi {
             return Ok(result);
         }
 
+        if let Some(result) = signal::dispatch_arch_syscall(self, trapframe, syscall_number) {
+            return Ok(result);
+        }
+
         crate::println!("Invalid Syscall number: {}", syscall_number);
         Err("Invalid syscall number")
     }
@@ -88,7 +94,7 @@ impl AbiModule for LinuxRiscv64Abi {
             match action {
                 generic::signal::SignalAction::Custom(handler_addr) => {
                     let trapframe = target_task.get_trapframe();
-                    generic::signal::setup_signal_handler(trapframe, handler_addr, signal);
+                    signal::setup_signal_handler(trapframe, handler_addr, signal);
                 }
                 generic::signal::SignalAction::Ignore => {}
                 generic::signal::SignalAction::ForceTerminate => {

--- a/kernel/src/abi/linux/riscv64/signal.rs
+++ b/kernel/src/abi/linux/riscv64/signal.rs
@@ -1,498 +1,18 @@
-//! Linux RISC-V 64 signal syscalls and signal handling
+//! RISC-V 64 arch-specific signal handling
 //!
-//! Implements POSIX signals with Linux-compatible semantics, integrated with Scarlet's
-//! event system for cross-ABI signal delivery.
+//! Provides `setup_signal_handler` and `sys_rt_sigreturn` for RISC-V.
+//! Signal types and generic logic live in `generic::signal`.
 
+use crate::abi::linux::generic::signal::LinuxSignal;
 use crate::abi::linux::riscv64::LinuxRiscv64Abi;
 use crate::arch::Trapframe;
-use crate::ipc::event::{Event, EventContent, ProcessControlType};
 use crate::task::mytask;
-use alloc::collections::BTreeMap;
-
-/// Linux signal numbers (POSIX standard)
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum LinuxSignal {
-    SIGHUP = 1,
-    SIGINT = 2,
-    SIGQUIT = 3,
-    SIGILL = 4,
-    SIGTRAP = 5,
-    SIGABRT = 6,
-    SIGBUS = 7,
-    SIGFPE = 8,
-    SIGKILL = 9,
-    SIGUSR1 = 10,
-    SIGSEGV = 11,
-    SIGUSR2 = 12,
-    SIGPIPE = 13,
-    SIGALRM = 14,
-    SIGTERM = 15,
-    SIGSTKFLT = 16,
-    SIGCHLD = 17,
-    SIGCONT = 18,
-    SIGSTOP = 19,
-    SIGTSTP = 20,
-    SIGTTIN = 21,
-    SIGTTOU = 22,
-    SIGURG = 23,
-    SIGXCPU = 24,
-    SIGXFSZ = 25,
-    SIGVTALRM = 26,
-    SIGPROF = 27,
-    SIGWINCH = 28,
-    SIGIO = 29,
-    SIGPWR = 30,
-    SIGSYS = 31,
-}
-
-impl LinuxSignal {
-    /// Convert from u32 to LinuxSignal
-    pub fn from_u32(signal: u32) -> Option<Self> {
-        match signal {
-            1 => Some(Self::SIGHUP),
-            2 => Some(Self::SIGINT),
-            3 => Some(Self::SIGQUIT),
-            4 => Some(Self::SIGILL),
-            5 => Some(Self::SIGTRAP),
-            6 => Some(Self::SIGABRT),
-            7 => Some(Self::SIGBUS),
-            8 => Some(Self::SIGFPE),
-            9 => Some(Self::SIGKILL),
-            10 => Some(Self::SIGUSR1),
-            11 => Some(Self::SIGSEGV),
-            12 => Some(Self::SIGUSR2),
-            13 => Some(Self::SIGPIPE),
-            14 => Some(Self::SIGALRM),
-            15 => Some(Self::SIGTERM),
-            16 => Some(Self::SIGSTKFLT),
-            17 => Some(Self::SIGCHLD),
-            18 => Some(Self::SIGCONT),
-            19 => Some(Self::SIGSTOP),
-            20 => Some(Self::SIGTSTP),
-            21 => Some(Self::SIGTTIN),
-            22 => Some(Self::SIGTTOU),
-            23 => Some(Self::SIGURG),
-            24 => Some(Self::SIGXCPU),
-            25 => Some(Self::SIGXFSZ),
-            26 => Some(Self::SIGVTALRM),
-            27 => Some(Self::SIGPROF),
-            28 => Some(Self::SIGWINCH),
-            29 => Some(Self::SIGIO),
-            30 => Some(Self::SIGPWR),
-            31 => Some(Self::SIGSYS),
-            _ => None,
-        }
-    }
-
-    /// Get default action for this signal
-    pub fn default_action(&self) -> SignalAction {
-        match self {
-            Self::SIGKILL | Self::SIGSTOP => SignalAction::ForceTerminate,
-            Self::SIGCHLD | Self::SIGURG | Self::SIGWINCH => SignalAction::Ignore,
-            Self::SIGCONT => SignalAction::Continue,
-            Self::SIGTSTP | Self::SIGTTIN | Self::SIGTTOU => SignalAction::Stop,
-            _ => SignalAction::Terminate,
-        }
-    }
-}
-
-/// Signal action types
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SignalAction {
-    /// Default action: terminate process
-    Terminate,
-    /// Force terminate (cannot be caught/ignored)
-    ForceTerminate,
-    /// Ignore signal
-    Ignore,
-    /// Stop process
-    Stop,
-    /// Continue process
-    Continue,
-    /// Custom handler
-    Custom(usize), // Handler function address
-}
-
-/// Signal mask for blocking signals
-#[derive(Debug, Clone, Copy, Default)]
-pub struct SignalMask {
-    mask: u64, // Bit mask for signals 1-64
-}
-
-impl SignalMask {
-    pub fn new() -> Self {
-        Self { mask: 0 }
-    }
-
-    pub fn block_signal(&mut self, signal: LinuxSignal) {
-        self.mask |= 1u64 << (signal as u32 - 1);
-    }
-
-    pub fn unblock_signal(&mut self, signal: LinuxSignal) {
-        self.mask &= !(1u64 << (signal as u32 - 1));
-    }
-
-    pub fn is_blocked(&self, signal: LinuxSignal) -> bool {
-        (self.mask & (1u64 << (signal as u32 - 1))) != 0
-    }
-
-    pub fn raw(&self) -> u64 {
-        self.mask
-    }
-
-    pub fn set_raw(&mut self, mask: u64) {
-        self.mask = mask;
-    }
-}
-
-/// Signal handler state for a task
-#[derive(Debug, Clone)]
-pub struct SignalState {
-    /// Signal handlers (signal number -> handler action)
-    pub handlers: BTreeMap<LinuxSignal, SignalAction>,
-    /// Blocked signals mask
-    pub blocked: SignalMask,
-    /// Pending signals that are blocked
-    pub pending: SignalMask,
-}
-
-impl Default for SignalState {
-    fn default() -> Self {
-        let mut handlers = BTreeMap::new();
-        // Set default actions for all signals
-        for signal_num in 1..=31 {
-            if let Some(signal) = LinuxSignal::from_u32(signal_num) {
-                handlers.insert(signal, signal.default_action());
-            }
-        }
-
-        Self {
-            handlers,
-            blocked: SignalMask::new(),
-            pending: SignalMask::new(),
-        }
-    }
-}
-
-impl SignalState {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Set signal handler
-    pub fn set_handler(&mut self, signal: LinuxSignal, action: SignalAction) {
-        // SIGKILL and SIGSTOP cannot be caught or ignored
-        if signal != LinuxSignal::SIGKILL && signal != LinuxSignal::SIGSTOP {
-            self.handlers.insert(signal, action);
-        }
-    }
-
-    /// Get signal handler
-    pub fn get_handler(&self, signal: LinuxSignal) -> SignalAction {
-        self.handlers
-            .get(&signal)
-            .copied()
-            .unwrap_or(signal.default_action())
-    }
-
-    /// Add pending signal
-    pub fn add_pending(&mut self, signal: LinuxSignal) {
-        self.pending.block_signal(signal);
-    }
-
-    /// Remove pending signal
-    pub fn remove_pending(&mut self, signal: LinuxSignal) {
-        self.pending.unblock_signal(signal);
-    }
-
-    /// Check if signal is pending
-    pub fn is_pending(&self, signal: LinuxSignal) -> bool {
-        self.pending.is_blocked(signal)
-    }
-
-    /// Get next deliverable signal (not blocked and pending)
-    pub fn next_deliverable_signal(&self) -> Option<LinuxSignal> {
-        for signal_num in 1..=31 {
-            if let Some(signal) = LinuxSignal::from_u32(signal_num) {
-                if self.is_pending(signal) && !self.blocked.is_blocked(signal) {
-                    return Some(signal);
-                }
-            }
-        }
-        None
-    }
-}
-
-/// Linux sigaction structure (simplified)
-/// This matches the Linux sigaction layout for RISC-V
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct Sigaction {
-    /// Signal handler address (or SIG_DFL, SIG_IGN)
-    pub handler: usize,
-    /// Signal flags
-    pub flags: u64,
-    /// Signal mask to apply during handler execution
-    pub mask: u64,
-}
-
-/// Special handler values
-pub const SIG_DFL: usize = 0; // Default action
-pub const SIG_IGN: usize = 1; // Ignore signal
-
-/// Linux rt_sigaction system call implementation
-///
-/// int rt_sigaction(int signum, const struct sigaction *act, struct sigaction *oldact, size_t sigsetsize);
-pub fn sys_rt_sigaction(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize {
-    let task = mytask().unwrap();
-
-    let signum = trapframe.get_arg(0) as u32;
-    let act_ptr = trapframe.get_arg(1);
-    let oldact_ptr = trapframe.get_arg(2);
-    let _sigsetsize = trapframe.get_arg(3);
-
-    // Convert signal number to LinuxSignal
-    let signal = match LinuxSignal::from_u32(signum) {
-        Some(sig) => sig,
-        None => {
-            trapframe.set_return_value(!0usize); // -1 (EINVAL)
-            trapframe.increment_pc_next(task);
-            return !0usize;
-        }
-    };
-
-    let mut signal_state = abi.signal_state.lock();
-
-    // Get old action if requested
-    if oldact_ptr != 0 {
-        let Some(paddr) = task.vm_manager.translate_to_kva(oldact_ptr) else {
-            // Invalid user pointer for oldact: return EFAULT
-            trapframe.set_return_value(!0usize);
-            trapframe.increment_pc_next(task);
-            return !0usize; // -EFAULT
-        };
-        let old_action = signal_state.get_handler(signal);
-        let old_sigaction = sigaction_to_linux(old_action);
-        unsafe {
-            core::ptr::write(paddr as *mut Sigaction, old_sigaction);
-        }
-    }
-
-    // Set new action if provided
-    if act_ptr != 0 {
-        let Some(paddr) = task.vm_manager.translate_to_kva(act_ptr) else {
-            // Invalid user pointer for act: return EFAULT
-            trapframe.set_return_value(!0usize);
-            trapframe.increment_pc_next(task);
-            return !0usize; // -EFAULT
-        };
-        let new_sigaction = unsafe { core::ptr::read(paddr as *const Sigaction) };
-        let new_action = linux_to_sigaction(new_sigaction, signal);
-        signal_state.set_handler(signal, new_action);
-    }
-
-    trapframe.set_return_value(0);
-    trapframe.increment_pc_next(task);
-    0
-}
-
-/// Convert internal SignalAction to Linux sigaction
-fn sigaction_to_linux(action: SignalAction) -> Sigaction {
-    match action {
-        SignalAction::Ignore => Sigaction {
-            handler: SIG_IGN,
-            flags: 0,
-            mask: 0,
-        },
-        SignalAction::Custom(addr) => Sigaction {
-            handler: addr,
-            flags: 0,
-            mask: 0,
-        },
-        _ => Sigaction {
-            handler: SIG_DFL,
-            flags: 0,
-            mask: 0,
-        },
-    }
-}
-
-/// Convert Linux sigaction to internal SignalAction
-fn linux_to_sigaction(sigaction: Sigaction, signal: LinuxSignal) -> SignalAction {
-    match sigaction.handler {
-        SIG_DFL => signal.default_action(), // Restore per-signal default action
-        SIG_IGN => SignalAction::Ignore,
-        addr => SignalAction::Custom(addr),
-    }
-}
-
-/// Linux rt_sigprocmask system call implementation
-///
-/// int rt_sigprocmask(int how, const sigset_t *set, sigset_t *oldset, size_t sigsetsize);
-pub fn sys_rt_sigprocmask(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize {
-    let task = mytask().unwrap();
-
-    let how = trapframe.get_arg(0);
-    let set_ptr = trapframe.get_arg(1);
-    let oldset_ptr = trapframe.get_arg(2);
-    let _sigsetsize = trapframe.get_arg(3);
-
-    let mut signal_state = abi.signal_state.lock();
-
-    // Save old mask if requested
-    if oldset_ptr != 0 {
-        let Some(paddr) = task.vm_manager.translate_to_kva(oldset_ptr) else {
-            // Invalid user pointer for oldset: return EFAULT
-            trapframe.set_return_value(!0usize);
-            trapframe.increment_pc_next(task);
-            return !0usize; // -EFAULT
-        };
-        let old_mask = signal_state.blocked.raw();
-        unsafe {
-            core::ptr::write(paddr as *mut u64, old_mask);
-        }
-    }
-
-    // Modify mask if new set is provided
-    if set_ptr != 0 {
-        let Some(paddr) = task.vm_manager.translate_to_kva(set_ptr) else {
-            // Invalid user pointer for set: return EFAULT
-            trapframe.set_return_value(!0usize);
-            trapframe.increment_pc_next(task);
-            return !0usize; // -EFAULT
-        };
-        let new_mask = unsafe { core::ptr::read(paddr as *const u64) };
-        let mut new_signal_mask = SignalMask::new();
-        new_signal_mask.set_raw(new_mask);
-
-        // SIG_BLOCK = 0, SIG_UNBLOCK = 1, SIG_SETMASK = 2
-        match how {
-            0 => {
-                // SIG_BLOCK: Add new_mask to current blocked signals
-                let current = signal_state.blocked.raw();
-                signal_state.blocked.set_raw(current | new_mask);
-            }
-            1 => {
-                // SIG_UNBLOCK: Remove new_mask from current blocked signals
-                let current = signal_state.blocked.raw();
-                signal_state.blocked.set_raw(current & !new_mask);
-            }
-            2 => {
-                // SIG_SETMASK: Replace blocked signals with new_mask
-                signal_state.blocked = new_signal_mask;
-            }
-            _ => {
-                trapframe.set_return_value(!0usize); // -1 (EINVAL)
-                trapframe.increment_pc_next(task);
-                return !0usize;
-            }
-        }
-    }
-
-    trapframe.set_return_value(0);
-    trapframe.increment_pc_next(task);
-    0
-}
-
-/// Convert Scarlet ProcessControlType to Linux signal
-pub fn process_control_to_signal(control_type: ProcessControlType) -> Option<LinuxSignal> {
-    match control_type {
-        ProcessControlType::Terminate => Some(LinuxSignal::SIGTERM),
-        ProcessControlType::Kill => Some(LinuxSignal::SIGKILL),
-        ProcessControlType::Stop => Some(LinuxSignal::SIGSTOP),
-        ProcessControlType::Continue => Some(LinuxSignal::SIGCONT),
-        ProcessControlType::Interrupt => Some(LinuxSignal::SIGINT),
-        ProcessControlType::Quit => Some(LinuxSignal::SIGQUIT),
-        ProcessControlType::Hangup => Some(LinuxSignal::SIGHUP),
-        ProcessControlType::ChildExit => Some(LinuxSignal::SIGCHLD),
-        ProcessControlType::PipeBroken => Some(LinuxSignal::SIGPIPE),
-        ProcessControlType::Alarm => Some(LinuxSignal::SIGALRM),
-        ProcessControlType::IoReady => Some(LinuxSignal::SIGIO),
-        ProcessControlType::User(sig) => LinuxSignal::from_u32(sig + 32), // Map to RT signals
-    }
-}
-
-/// Handle incoming event and convert to signal if needed
-pub fn handle_event_to_signal(event: &Event) -> Option<LinuxSignal> {
-    match &event.content {
-        EventContent::ProcessControl(control_type) => process_control_to_signal(*control_type),
-        _ => None, // Non-signal events are ignored in Linux ABI
-    }
-}
-
-/// Deliver a signal to a task's signal state
-pub fn deliver_signal_to_task(abi: &LinuxRiscv64Abi, signal: LinuxSignal) {
-    // Add signal to pending if it's not already pending
-    let mut signal_state = abi.signal_state.lock();
-    if !signal_state.is_pending(signal) {
-        signal_state.add_pending(signal);
-    }
-}
-
-/// Check if task has pending signals and return the next one to handle
-pub fn get_next_pending_signal(abi: &LinuxRiscv64Abi) -> Option<LinuxSignal> {
-    let signal_state = abi.signal_state.lock();
-    signal_state.next_deliverable_signal()
-}
-
-/// Process pending signals for a task with explicit signal state
-/// Returns true if a signal was handled and execution should be interrupted
-pub fn process_pending_signals_with_state(
-    signal_state: &mut SignalState,
-    trapframe: &mut Trapframe,
-) -> bool {
-    if let Some(signal) = signal_state.next_deliverable_signal() {
-        let action = signal_state.get_handler(signal);
-
-        // Remove signal from pending
-        signal_state.remove_pending(signal);
-
-        match action {
-            SignalAction::Terminate | SignalAction::ForceTerminate => {
-                // TODO: Implement actual task termination
-                // This should call task.set_state(TaskState::Terminated)
-                // and set exit code based on signal
-                crate::early_println!("Signal {}: Terminating task", signal as u32);
-                true
-            }
-            SignalAction::Ignore => {
-                // Signal ignored, continue execution
-                false
-            }
-            SignalAction::Stop => {
-                // TODO: Implement actual task stopping
-                // This should call task.set_state(TaskState::Stopped)
-                crate::early_println!("Signal {}: Stopping task", signal as u32);
-                true
-            }
-            SignalAction::Continue => {
-                // TODO: Implement actual task continuation
-                // This should call task.set_state(TaskState::Ready) if stopped
-                crate::early_println!("Signal {}: Continuing task", signal as u32);
-                false
-            }
-            SignalAction::Custom(handler_addr) => {
-                // Set up user-space signal handler execution
-                crate::early_println!(
-                    "Signal {}: Calling custom handler at {:#x}",
-                    signal as u32,
-                    handler_addr
-                );
-                setup_signal_handler(trapframe, handler_addr, signal);
-                true
-            }
-        }
-    } else {
-        false
-    }
-}
 
 /// Set up user-space signal handler execution with context save/restore.
 ///
-/// Signal frame layout on user stack (RISC-V, simplified `rt_sigframe`):
+/// Signal frame layout on user stack (RISC-V):
 /// ```text
-///   [frame_base + 0]:   trampoline (li a7, 139; ecall) — rt_sigreturn
+///   [frame_base + 0]:   trampoline (li a7, 139; ecall)
 ///   [frame_base + 8]:   signal number
 ///   [frame_base + 16]:  saved regs[0..31] (256 bytes)
 ///   [frame_base + 272]: saved epc (8 bytes)
@@ -500,7 +20,7 @@ pub fn process_pending_signals_with_state(
 pub fn setup_signal_handler(trapframe: &mut Trapframe, handler_addr: usize, signal: LinuxSignal) {
     let mut sp = trapframe.regs.reg[2];
 
-    // trampoline(8) + signo(8) + regs(32×8) + epc(8) = 280
+    // trampoline(8) + signo(8) + regs(32x8) + epc(8) = 280
     const SIGNAL_FRAME_SIZE: usize = 8 + 8 + (32 * 8) + 8;
     sp -= SIGNAL_FRAME_SIZE;
     sp &= !0xF;
@@ -548,55 +68,10 @@ pub fn setup_signal_handler(trapframe: &mut Trapframe, handler_addr: usize, sign
     trapframe.regs.reg[1] = frame_base; // ra = trampoline (rt_sigreturn)
 }
 
-/// Handle fatal signals that should terminate immediately
-/// This is a simplified implementation for basic signal handling
-pub fn handle_fatal_signal_immediately(signal: LinuxSignal) -> Result<(), &'static str> {
-    if let Some(task) = crate::task::mytask() {
-        let exit_code = match signal {
-            LinuxSignal::SIGKILL => 128 + 9,  // Standard SIGKILL exit code
-            LinuxSignal::SIGTERM => 128 + 15, // Standard SIGTERM exit code
-            LinuxSignal::SIGINT => 128 + 2,   // Standard SIGINT exit code
-            _ => return Err("Not a fatal signal"),
-        };
-
-        crate::early_println!(
-            "Signal {}: Immediately terminating task {} with exit code {}",
-            signal as u32,
-            task.get_id(),
-            exit_code
-        );
-
-        // Set task state to terminated and exit
-        task.exit(exit_code);
-        Ok(())
-    } else {
-        Err("No current task to terminate")
-    }
-}
-
-/// Check if a signal should be handled immediately (cannot be blocked/ignored)
-pub fn is_fatal_signal(signal: LinuxSignal) -> bool {
-    matches!(
-        signal,
-        LinuxSignal::SIGKILL | LinuxSignal::SIGTERM | LinuxSignal::SIGINT
-    )
-}
-
 /// Linux sys_rt_sigreturn — Restore context saved by `setup_signal_handler`.
 ///
 /// Reads the signal frame from the current user stack pointer and restores
-/// all 32 general-purpose registers plus `epc`.  The frame layout matches
-/// what `setup_signal_handler` wrote:
-///
-/// ```text
-///   [sp + 0]:   trampoline (8 bytes, ignored here)
-///   [sp + 8]:   signal number (8 bytes, ignored here)
-///   [sp + 16]:  saved regs[0..31] (256 bytes)
-///   [sp + 272]: saved epc (8 bytes)
-/// ```
-///
-/// After restoration the task resumes at the instruction that was
-/// interrupted by the signal.
+/// all 32 general-purpose registers plus `epc`.
 pub fn sys_rt_sigreturn(_abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize {
     let task = match mytask() {
         Some(t) => t,
@@ -606,7 +81,6 @@ pub fn sys_rt_sigreturn(_abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -
     let frame_base = trapframe.regs.reg[2]; // SP points to signal frame
 
     unsafe {
-        // Restore all 32 general-purpose registers
         for i in 0..32 {
             let paddr = match task.vm_manager.translate_to_kva(frame_base + 16 + i * 8) {
                 Some(p) => p,
@@ -615,7 +89,6 @@ pub fn sys_rt_sigreturn(_abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -
             trapframe.regs.reg[i] = *(paddr as *const usize);
         }
 
-        // Restore epc (program counter at time of signal)
         let paddr = match task.vm_manager.translate_to_kva(frame_base + 272) {
             Some(p) => p,
             None => return usize::MAX,
@@ -623,48 +96,17 @@ pub fn sys_rt_sigreturn(_abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -
         trapframe.epc = *(paddr as *const u64);
     }
 
-    // Return value is irrelevant — a0 was already restored from the frame.
     0
 }
 
-/// Linux sys_tkill - Send a signal to a specific thread
-///
-/// tkill() sends a signal to a specific thread within the same thread group.
-/// This is a simplified implementation that mainly prevents crashes.
-///
-/// Arguments:
-/// - abi: LinuxRiscv64Abi context
-/// - trapframe: Trapframe containing syscall arguments
-///   - arg0: tid (thread ID)
-///   - arg1: sig (signal number)
-///
-/// Returns:
-/// - 0 on success
-/// - usize::MAX (Linux -1) on error
-pub fn sys_tkill(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize {
-    let task = match mytask() {
-        Some(t) => t,
-        None => return usize::MAX,
-    };
-
-    let tid = trapframe.get_arg(0) as i32;
-    let sig = trapframe.get_arg(1) as i32;
-
-    // Increment PC to avoid infinite loop
-    trapframe.increment_pc_next(task);
-
-    // For now, just log and return success
-    // A proper implementation would:
-    // 1. Find the target task by TID
-    // 2. Add the signal to its pending signal queue
-    // 3. Wake the task if it's sleeping
-    crate::early_println!(
-        "[sys_tkill] tid={} sig={} - NOOP (signal delivery not implemented)",
-        tid,
-        sig
-    );
-
-    // Return success to avoid crashing applications
-    // Many applications use tkill for thread management
-    0
+/// Arch-specific fallback syscall table for RISC-V 64.
+pub fn dispatch_arch_syscall(
+    abi: &mut LinuxRiscv64Abi,
+    trapframe: &mut Trapframe,
+    syscall_number: usize,
+) -> Option<usize> {
+    match syscall_number {
+        139 => Some(sys_rt_sigreturn(abi, trapframe)),
+        _ => None,
+    }
 }

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -318,6 +318,10 @@ impl Trapframe {
         }
     }
 
+    pub fn set_pc(&mut self, pc: u64) {
+        self.elr = pc;
+    }
+
     /// Increment the program counter (epc) to the next instruction
     /// This is typically used after handling a trap or syscall to continue execution.
     ///

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -395,6 +395,10 @@ impl Trapframe {
         self.epc
     }
 
+    pub fn set_pc(&mut self, pc: u64) {
+        self.epc = pc;
+    }
+
     /// Increment the program counter (epc) to the next instruction
     /// This is typically used after handling a trap or syscall to continue execution.
     ///


### PR DESCRIPTION
- Introduced a new generic module for shared Linux ABI functionality.
- Simplified the RISC-V ABI by delegating common functionality to the generic module.
- Removed redundant file descriptor management and signal handling code from the RISC-V ABI.
- Added support for AArch64 architecture in the Linux ABI.
- Enhanced syscall handling by integrating common dispatch logic.
- Updated trapframe structures for both RISC-V and AArch64 to include a method for setting the program counter.
- Cleaned up unnecessary comments and debug statements for better readability.