### PR TITLE
SMP support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,6 +275,12 @@ Additional features in user libraries:
 5. Write/update documentation
 6. Commit frequently with descriptive messages
 
+### Architecture-Specific Code Separation
+
+- **No `#[cfg(target_arch)]` in common code**: Architecture-specific logic must live in `kernel/src/arch/{riscv64,aarch64}/`. The common `kernel/src/` must not contain `#[cfg(target_arch = "...")]` blocks.
+- **Expose arch-specific functions via `crate::arch::*`**: Each arch module (`riscv64`, `aarch64`) exports a unified public API. Common code calls `crate::arch::function_name()` without conditional compilation.
+- **Both arches must implement the same public API**: If `riscv64` exports `fn start_secondary_cpus()`, `aarch64` must export the same function signature (even if it's a no-op).
+
 ### Key Principles
 
 - **Safety First**: Leverage Rust's safety guarantees

--- a/bsp/aarch64-limine/tools/run_aarch64.sh
+++ b/bsp/aarch64-limine/tools/run_aarch64.sh
@@ -161,7 +161,7 @@ qemu-system-aarch64 \
     -machine virt,virtualization=on,gic-version=3,acpi=off \
     -cpu max \
     -m 8G \
-    -smp 2 \
+    -smp 4 \
     -nographic \
     -serial mon:stdio \
     --no-reboot \

--- a/bsp/aarch64-limine/tools/run_aarch64.sh
+++ b/bsp/aarch64-limine/tools/run_aarch64.sh
@@ -161,6 +161,7 @@ qemu-system-aarch64 \
     -machine virt,virtualization=on,gic-version=3,acpi=off \
     -cpu max \
     -m 8G \
+    -smp 2 \
     -nographic \
     -serial mon:stdio \
     --no-reboot \

--- a/bsp/riscv64-limine/tools/run.sh
+++ b/bsp/riscv64-limine/tools/run.sh
@@ -127,7 +127,7 @@ fi
 qemu-system-riscv64 \
     -machine virt,acpi=off \
     -m 8G \
-    -smp 2 \
+    -smp 4 \
     -nographic \
     -serial mon:stdio \
     --no-reboot \

--- a/bsp/riscv64-limine/tools/run.sh
+++ b/bsp/riscv64-limine/tools/run.sh
@@ -127,7 +127,7 @@ fi
 qemu-system-riscv64 \
     -machine virt,acpi=off \
     -m 8G \
-    -smp 4 \
+    -smp 16 \
     -nographic \
     -serial mon:stdio \
     --no-reboot \

--- a/bsp/riscv64-limine/tools/run.sh
+++ b/bsp/riscv64-limine/tools/run.sh
@@ -127,6 +127,7 @@ fi
 qemu-system-riscv64 \
     -machine virt,acpi=off \
     -m 8G \
+    -smp 2 \
     -nographic \
     -serial mon:stdio \
     --no-reboot \

--- a/drivers/gpio/apple-pinctrl/src/lib.rs
+++ b/drivers/gpio/apple-pinctrl/src/lib.rs
@@ -17,7 +17,7 @@ use scarlet::device::{
     platform::{PlatformDeviceDriver, PlatformDeviceInfo, resource::PlatformDeviceResourceType},
 };
 use scarlet::driver_initcall;
-use scarlet::interrupt::{InterruptError, InterruptId, InterruptManager, InterruptResult};
+use scarlet::interrupt::{InterruptError, InterruptId, InterruptResult};
 use scarlet::vm;
 
 const REG_DATA_BASE: usize = 0x10_000;
@@ -228,12 +228,10 @@ impl ApplePinctrl {
                 irq_res.start as u32
             };
 
-            InterruptManager::with_manager(|mgr| {
-                mgr.register_interrupt_device(irq_id, pinctrl.clone())
-            })
-            .map_err(|_| "apple-pinctrl: failed to register parent IRQ handler")?;
+            scarlet::interrupt::register_interrupt_device(irq_id, pinctrl.clone())
+                .map_err(|_| "apple-pinctrl: failed to register parent IRQ handler")?;
 
-            InterruptManager::with_manager(|mgr| mgr.enable_external_interrupt(irq_id, 0))
+            scarlet::interrupt::enable_external_interrupt(irq_id, 0)
                 .map_err(|_| "apple-pinctrl: failed to enable parent IRQ")?;
 
             pinctrl.parent_irqs.lock().push(irq_id);

--- a/drivers/pic/apple-aic/src/lib.rs
+++ b/drivers/pic/apple-aic/src/lib.rs
@@ -14,7 +14,7 @@ use scarlet::{
     },
     early_initcall,
     interrupt::{
-        CpuId, InterruptError, InterruptId, InterruptManager, InterruptResult, Priority,
+        CpuId, InterruptError, InterruptId, InterruptResult, Priority,
         controllers::ExternalInterruptController,
     },
 };
@@ -553,11 +553,9 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
     let aic = Box::new(Aic::new(base_addr, max_cpus));
 
     // Register with interrupt manager
-    match InterruptManager::with_manager(|manager| {
-        manager
-            .register_external_controller(aic)
-            .map_err(|_| "Failed to register AIC")
-    }) {
+    match scarlet::interrupt::register_external_controller(aic)
+        .map_err(|_| "Failed to register AIC")
+    {
         Ok(()) => {
             scarlet::arch::interrupt::configure_timer_interrupt_route(
                 scarlet::arch::interrupt::TimerInterruptRoute::FastInterrupt,

--- a/drivers/uart/s5l-uart/src/lib.rs
+++ b/drivers/uart/s5l-uart/src/lib.rs
@@ -21,7 +21,7 @@ use scarlet::{
         },
     },
     driver_initcall,
-    interrupt::{InterruptId, InterruptManager, InterruptResult},
+    interrupt::{InterruptId, InterruptResult},
     object::capability::{ControlOps, MemoryMappingOps, Selectable},
     traits::serial::Serial,
 };
@@ -116,7 +116,7 @@ impl S5lUart {
         let ucon = self.reg_read(UCON);
         self.reg_write(UCON, ucon | UCON_RXTHRESH_ENA | UCON_RXTO_ENA);
 
-        InterruptManager::with_manager(|mgr| mgr.enable_external_interrupt(interrupt_id, 0))
+        scarlet::interrupt::enable_external_interrupt(interrupt_id, 0)
             .map_err(|_| "Failed to enable interrupt")?;
 
         Ok(())
@@ -370,9 +370,9 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
         } else {
             scarlet::early_println!("[S5L] probe: interrupts enabled");
 
-            if let Err(e) = InterruptManager::with_manager(|mgr| {
-                mgr.register_interrupt_device(interrupt_id, uart.clone())
-            }) {
+            if let Err(e) =
+                scarlet::interrupt::register_interrupt_device(interrupt_id, uart.clone())
+            {
                 scarlet::early_println!("[S5L] probe: failed to register interrupt device: {}", e);
             } else {
                 scarlet::early_println!("[S5L] probe: interrupt device registered");

--- a/kernel/src/abi/linux/aarch64/mod.rs
+++ b/kernel/src/abi/linux/aarch64/mod.rs
@@ -107,11 +107,18 @@ impl AbiModule for LinuxAarch64Abi {
                     target_task.set_state(crate::task::TaskState::Blocked(
                         crate::task::BlockedType::Interruptible,
                     ));
+                    crate::sched::scheduler::mark_blocked(target_task.get_id());
+                    crate::sched::scheduler::remove_from_ready_queues(target_task.get_id());
                 }
                 generic::signal::SignalAction::Continue => {
                     let current_state = target_task.get_state();
                     if matches!(current_state, crate::task::TaskState::Blocked(_)) {
                         target_task.set_state(crate::task::TaskState::Ready);
+                        crate::sched::scheduler::unmark_blocked(target_task.get_id());
+                        crate::sched::scheduler::push_ready_task(
+                            crate::arch::get_cpu().get_cpuid(),
+                            target_task.get_id(),
+                        );
                     }
                 }
             }

--- a/kernel/src/abi/linux/aarch64/mod.rs
+++ b/kernel/src/abi/linux/aarch64/mod.rs
@@ -81,9 +81,7 @@ impl AbiModule for LinuxAarch64Abi {
         target_task_id: u32,
     ) -> Result<(), &'static str> {
         if let Some(signal) = generic::signal::handle_event_to_signal(&event) {
-            let scheduler = crate::sched::scheduler::get_scheduler();
-            let target_task = scheduler
-                .get_task_by_id(target_task_id as usize)
+            let target_task = crate::sched::scheduler::get_task_by_id(target_task_id as usize)
                 .ok_or("Target task not found")?;
 
             let action = {

--- a/kernel/src/abi/linux/generic/fs.rs
+++ b/kernel/src/abi/linux/generic/fs.rs
@@ -8,7 +8,7 @@ use crate::{
         cstring_to_string, parse_c_string_from_userspace, parse_string_array_from_userspace,
     },
     object::capability::StreamError,
-    sched::scheduler::get_scheduler,
+    sched::scheduler::schedule,
     task::mytask,
 };
 use alloc::{
@@ -935,7 +935,7 @@ pub fn sys_read(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                         if nonblocking {
                             return errno::to_result(errno::EAGAIN);
                         } else {
-                            get_scheduler().schedule(trapframe);
+                            schedule(trapframe);
                             usize::MAX
                         }
                     }
@@ -1039,7 +1039,7 @@ pub fn sys_write(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                 if nonblocking {
                     return errno::to_result(errno::EAGAIN);
                 } else {
-                    get_scheduler().schedule(trapframe);
+                    schedule(trapframe);
                     usize::MAX
                 }
             }
@@ -1165,7 +1165,7 @@ pub fn sys_pread64(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                 trapframe.increment_pc_next(task);
                 errno::to_result(errno::EAGAIN)
             } else {
-                get_scheduler().schedule(trapframe);
+                schedule(trapframe);
                 usize::MAX
             }
         }
@@ -1250,7 +1250,7 @@ pub fn sys_pwrite64(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                 trapframe.increment_pc_next(task);
                 errno::to_result(errno::EAGAIN)
             } else {
-                get_scheduler().schedule(trapframe);
+                schedule(trapframe);
                 usize::MAX
             }
         }
@@ -1388,7 +1388,7 @@ pub fn sys_writev(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                         break;
                     }
                 } else {
-                    get_scheduler().schedule(trapframe);
+                    schedule(trapframe);
                     return usize::MAX;
                 }
             }
@@ -2781,7 +2781,7 @@ pub fn sys_getdents64(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
             Ok(_) => break, // partial read, treat as error/EOF
             Err(StreamError::EndOfStream) => break,
             Err(StreamError::WouldBlock) => {
-                get_scheduler().schedule(trapframe);
+                schedule(trapframe);
                 return usize::MAX;
             }
             Err(_) => break,
@@ -2872,7 +2872,7 @@ pub fn sys_readv(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                         break;
                     }
                 } else {
-                    get_scheduler().schedule(trapframe);
+                    schedule(trapframe);
                     return usize::MAX;
                 }
             }

--- a/kernel/src/abi/linux/generic/proc.rs
+++ b/kernel/src/abi/linux/generic/proc.rs
@@ -1,7 +1,7 @@
 use crate::{
     abi::linux::generic::LinuxAbi,
-    arch::{Trapframe, get_cpu},
-    sched::scheduler::{add_task, get_task_by_id, schedule},
+    arch::Trapframe,
+    sched::scheduler::{get_task_by_id, schedule},
     task::{CloneFlags, mytask},
 };
 
@@ -560,7 +560,7 @@ pub fn sys_clone(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     }
 
     let ret = match parent_task.clone_task(cflags) {
-        Ok(mut child_task) => {
+        Ok(child_task) => {
             child_task.vcpu.lock().iregs.reg[10] = 0; // a0 = 0 in child
             // If child_stack is provided, set child's user SP
             if child_stack != 0 {
@@ -573,11 +573,12 @@ pub fn sys_clone(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                 child_task.vcpu.lock().iregs.reg[4] = tls; // x4 = tp
             }
 
-            let cpu_id = get_cpu().get_cpuid();
+            let cpu_id = crate::sched::scheduler::select_cpu();
             let parent_id = parent_task.get_id();
 
-            // Add child and get allocated ID
-            let child_id = add_task(child_task, cpu_id);
+            // Register first, complete clone metadata/TID writes, then enqueue.
+            // A remote CPU may run the child immediately after enqueue via IPI.
+            let child_id = crate::sched::scheduler::register_task(child_task);
 
             // Establish parent-child relationship now that both have valid IDs
             if let Some(child) = get_task_by_id(child_id) {
@@ -612,6 +613,7 @@ pub fn sys_clone(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                     }
                 }
             }
+            crate::sched::scheduler::enqueue_task(child_id, cpu_id);
             child_id
         }
         Err(_) => usize::MAX,

--- a/kernel/src/abi/linux/generic/proc.rs
+++ b/kernel/src/abi/linux/generic/proc.rs
@@ -86,7 +86,7 @@ pub fn sys_exit_group(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     let task = mytask().unwrap();
     task.vcpu.lock().store(trapframe);
     let exit_code = trapframe.get_arg(0) as i32;
-    task.exit(exit_code);
+    task.exit_group(exit_code);
     schedule(trapframe);
     usize::MAX
 }

--- a/kernel/src/abi/linux/generic/proc.rs
+++ b/kernel/src/abi/linux/generic/proc.rs
@@ -1,7 +1,7 @@
 use crate::{
     abi::linux::generic::LinuxAbi,
     arch::{Trapframe, get_cpu},
-    sched::scheduler::get_scheduler,
+    sched::scheduler::{add_task, get_task_by_id, schedule},
     task::{CloneFlags, mytask},
 };
 
@@ -78,7 +78,7 @@ pub fn sys_exit(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     let exit_code = trapframe.get_arg(0) as i32;
 
     task.exit(exit_code);
-    get_scheduler().schedule(trapframe);
+    schedule(trapframe);
     usize::MAX
 }
 
@@ -87,7 +87,7 @@ pub fn sys_exit_group(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     task.vcpu.lock().store(trapframe);
     let exit_code = trapframe.get_arg(0) as i32;
     task.exit(exit_code);
-    get_scheduler().schedule(trapframe);
+    schedule(trapframe);
     usize::MAX
 }
 
@@ -573,18 +573,17 @@ pub fn sys_clone(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                 child_task.vcpu.lock().iregs.reg[4] = tls; // x4 = tp
             }
 
-            let scheduler = get_scheduler();
             let cpu_id = get_cpu().get_cpuid();
             let parent_id = parent_task.get_id();
 
             // Add child and get allocated ID
-            let child_id = scheduler.add_task(child_task, cpu_id);
+            let child_id = add_task(child_task, cpu_id);
 
             // Establish parent-child relationship now that both have valid IDs
-            if let Some(child) = scheduler.get_task_by_id(child_id) {
+            if let Some(child) = get_task_by_id(child_id) {
                 child.set_parent_id(parent_id);
             }
-            if let Some(parent) = scheduler.get_task_by_id(parent_id) {
+            if let Some(parent) = get_task_by_id(parent_id) {
                 parent.add_child(child_id);
             }
 
@@ -603,8 +602,7 @@ pub fn sys_clone(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
             // IMPORTANT: Only write child TID when CLONE_CHILD_SETTID is set.
             // For CLONE_CHILD_CLEARTID, the pointer is a futex lock to clear on exit.
             if (flags & CLONE_CHILD_SETTID) != 0 && !child_tid_ptr.is_null() {
-                if let Some(paddr) = get_scheduler()
-                    .get_task_by_id(child_id)
+                if let Some(paddr) = get_task_by_id(child_id)
                     .unwrap()
                     .vm_manager
                     .translate_to_kva(child_tid_ptr as usize)

--- a/kernel/src/abi/linux/generic/socket.rs
+++ b/kernel/src/abi/linux/generic/socket.rs
@@ -8,7 +8,7 @@ use crate::{
     network::{NetworkManager, SocketDomain, SocketProtocol, SocketType, local::LocalSocket},
     object::KernelObject,
     object::capability::selectable::Selectable,
-    sched::scheduler::get_scheduler,
+    sched::scheduler::schedule,
     task::mytask,
 };
 use alloc::sync::Arc;
@@ -1165,7 +1165,7 @@ pub fn sys_sendmsg(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                         total_written
                     };
                 }
-                get_scheduler().schedule(trapframe);
+                schedule(trapframe);
                 return usize::MAX;
             }
             Err(_) => {

--- a/kernel/src/abi/linux/generic/time.rs
+++ b/kernel/src/abi/linux/generic/time.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     abi::linux::generic::LinuxAbi,
     arch::Trapframe,
-    sched::scheduler::get_scheduler,
+    sched::scheduler::wake_task,
     task::mytask,
     time::current_time,
     timer::{TimerHandler, add_timer, cancel_timer, get_tick, ns_to_ticks, ticks_to_ns},
@@ -210,8 +210,7 @@ impl TimerHandler for PosixTimerHandler {
                 let mut locked = signal_state.lock();
                 locked.add_pending(signal);
                 drop(locked);
-                let scheduler = get_scheduler();
-                let _ = scheduler.wake_task(owner_task_id);
+                let _ = wake_task(owner_task_id);
             }
         }
 

--- a/kernel/src/abi/linux/riscv64/fs.rs
+++ b/kernel/src/abi/linux/riscv64/fs.rs
@@ -935,7 +935,7 @@ pub fn sys_read(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize {
                         if nonblocking {
                             return errno::to_result(errno::EAGAIN);
                         } else {
-                            get_scheduler().schedule(trapframe);
+                            schedule(trapframe);
                             usize::MAX
                         }
                     }
@@ -1039,7 +1039,7 @@ pub fn sys_write(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize 
                 if nonblocking {
                     return errno::to_result(errno::EAGAIN);
                 } else {
-                    get_scheduler().schedule(trapframe);
+                    schedule(trapframe);
                     usize::MAX
                 }
             }
@@ -1165,7 +1165,7 @@ pub fn sys_pread64(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usiz
                 trapframe.increment_pc_next(task);
                 errno::to_result(errno::EAGAIN)
             } else {
-                get_scheduler().schedule(trapframe);
+                schedule(trapframe);
                 usize::MAX
             }
         }
@@ -1250,7 +1250,7 @@ pub fn sys_pwrite64(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usi
                 trapframe.increment_pc_next(task);
                 errno::to_result(errno::EAGAIN)
             } else {
-                get_scheduler().schedule(trapframe);
+                schedule(trapframe);
                 usize::MAX
             }
         }
@@ -1388,7 +1388,7 @@ pub fn sys_writev(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize
                         break;
                     }
                 } else {
-                    get_scheduler().schedule(trapframe);
+                    schedule(trapframe);
                     return usize::MAX;
                 }
             }
@@ -2781,7 +2781,7 @@ pub fn sys_getdents64(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> u
             Ok(_) => break, // partial read, treat as error/EOF
             Err(StreamError::EndOfStream) => break,
             Err(StreamError::WouldBlock) => {
-                get_scheduler().schedule(trapframe);
+                schedule(trapframe);
                 return usize::MAX;
             }
             Err(_) => break,
@@ -2872,7 +2872,7 @@ pub fn sys_readv(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize 
                         break;
                     }
                 } else {
-                    get_scheduler().schedule(trapframe);
+                    schedule(trapframe);
                     return usize::MAX;
                 }
             }

--- a/kernel/src/abi/linux/riscv64/mod.rs
+++ b/kernel/src/abi/linux/riscv64/mod.rs
@@ -107,11 +107,18 @@ impl AbiModule for LinuxRiscv64Abi {
                     target_task.set_state(crate::task::TaskState::Blocked(
                         crate::task::BlockedType::Interruptible,
                     ));
+                    crate::sched::scheduler::mark_blocked(target_task.get_id());
+                    crate::sched::scheduler::remove_from_ready_queues(target_task.get_id());
                 }
                 generic::signal::SignalAction::Continue => {
                     let current_state = target_task.get_state();
                     if matches!(current_state, crate::task::TaskState::Blocked(_)) {
                         target_task.set_state(crate::task::TaskState::Ready);
+                        crate::sched::scheduler::unmark_blocked(target_task.get_id());
+                        crate::sched::scheduler::push_ready_task(
+                            crate::arch::get_cpu().get_cpuid(),
+                            target_task.get_id(),
+                        );
                     }
                 }
             }

--- a/kernel/src/abi/linux/riscv64/mod.rs
+++ b/kernel/src/abi/linux/riscv64/mod.rs
@@ -81,9 +81,7 @@ impl AbiModule for LinuxRiscv64Abi {
         target_task_id: u32,
     ) -> Result<(), &'static str> {
         if let Some(signal) = generic::signal::handle_event_to_signal(&event) {
-            let scheduler = crate::sched::scheduler::get_scheduler();
-            let target_task = scheduler
-                .get_task_by_id(target_task_id as usize)
+            let target_task = crate::sched::scheduler::get_task_by_id(target_task_id as usize)
                 .ok_or("Target task not found")?;
 
             let action = {

--- a/kernel/src/abi/linux/riscv64/proc.rs
+++ b/kernel/src/abi/linux/riscv64/proc.rs
@@ -568,11 +568,12 @@ pub fn sys_clone(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize 
                 child_task.vcpu.lock().iregs.reg[4] = tls; // x4 = tp
             }
 
-            let cpu_id = get_cpu().get_cpuid();
+            let cpu_id = crate::sched::scheduler::select_cpu();
             let parent_id = parent_task.get_id();
 
-            // Add child and get allocated ID
-            let child_id = add_task(child_task, cpu_id);
+            // Register first, complete clone metadata/TID writes, then enqueue.
+            // A remote CPU may run the child immediately after enqueue via IPI.
+            let child_id = crate::sched::scheduler::register_task(child_task);
 
             // Establish parent-child relationship now that both have valid IDs
             if let Some(child) = get_task_by_id(child_id) {
@@ -607,6 +608,7 @@ pub fn sys_clone(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize 
                     }
                 }
             }
+            crate::sched::scheduler::enqueue_task(child_id, cpu_id);
             child_id
         }
         Err(_) => usize::MAX,

--- a/kernel/src/abi/linux/riscv64/proc.rs
+++ b/kernel/src/abi/linux/riscv64/proc.rs
@@ -78,7 +78,7 @@ pub fn sys_exit(_abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize 
     let exit_code = trapframe.get_arg(0) as i32;
 
     task.exit(exit_code);
-    get_scheduler().schedule(trapframe);
+    schedule(trapframe);
     usize::MAX
 }
 
@@ -87,7 +87,7 @@ pub fn sys_exit_group(_abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> 
     task.vcpu.lock().store(trapframe);
     let exit_code = trapframe.get_arg(0) as i32;
     task.exit(exit_code);
-    get_scheduler().schedule(trapframe);
+    schedule(trapframe);
     usize::MAX
 }
 
@@ -568,18 +568,17 @@ pub fn sys_clone(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize 
                 child_task.vcpu.lock().iregs.reg[4] = tls; // x4 = tp
             }
 
-            let scheduler = get_scheduler();
             let cpu_id = get_cpu().get_cpuid();
             let parent_id = parent_task.get_id();
 
             // Add child and get allocated ID
-            let child_id = scheduler.add_task(child_task, cpu_id);
+            let child_id = add_task(child_task, cpu_id);
 
             // Establish parent-child relationship now that both have valid IDs
-            if let Some(child) = scheduler.get_task_by_id(child_id) {
+            if let Some(child) = get_task_by_id(child_id) {
                 child.set_parent_id(parent_id);
             }
-            if let Some(parent) = scheduler.get_task_by_id(parent_id) {
+            if let Some(parent) = get_task_by_id(parent_id) {
                 parent.add_child(child_id);
             }
 
@@ -598,8 +597,7 @@ pub fn sys_clone(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usize 
             // IMPORTANT: Only write child TID when CLONE_CHILD_SETTID is set.
             // For CLONE_CHILD_CLEARTID, the pointer is a futex lock to clear on exit.
             if (flags & CLONE_CHILD_SETTID) != 0 && !child_tid_ptr.is_null() {
-                if let Some(paddr) = get_scheduler()
-                    .get_task_by_id(child_id)
+                if let Some(paddr) = get_task_by_id(child_id)
                     .unwrap()
                     .vm_manager
                     .translate_to_kva(child_tid_ptr as usize)

--- a/kernel/src/abi/linux/riscv64/proc.rs
+++ b/kernel/src/abi/linux/riscv64/proc.rs
@@ -86,7 +86,7 @@ pub fn sys_exit_group(_abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> 
     let task = mytask().unwrap();
     task.vcpu.lock().store(trapframe);
     let exit_code = trapframe.get_arg(0) as i32;
-    task.exit(exit_code);
+    task.exit_group(exit_code);
     schedule(trapframe);
     usize::MAX
 }

--- a/kernel/src/abi/linux/riscv64/socket.rs
+++ b/kernel/src/abi/linux/riscv64/socket.rs
@@ -1165,7 +1165,7 @@ pub fn sys_sendmsg(abi: &mut LinuxRiscv64Abi, trapframe: &mut Trapframe) -> usiz
                         total_written
                     };
                 }
-                get_scheduler().schedule(trapframe);
+                schedule(trapframe);
                 return usize::MAX;
             }
             Err(_) => {

--- a/kernel/src/abi/linux/riscv64/time.rs
+++ b/kernel/src/abi/linux/riscv64/time.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     abi::linux::riscv64::LinuxRiscv64Abi,
     arch::Trapframe,
-    sched::scheduler::get_scheduler,
+    sched::scheduler::wake_task,
     task::mytask,
     time::current_time,
     timer::{TimerHandler, add_timer, cancel_timer, get_tick, ns_to_ticks, ticks_to_ns},
@@ -210,8 +210,7 @@ impl TimerHandler for PosixTimerHandler {
                 let mut locked = signal_state.lock();
                 locked.add_pending(signal);
                 drop(locked);
-                let scheduler = get_scheduler();
-                let _ = scheduler.wake_task(owner_task_id);
+                let _ = wake_task(owner_task_id);
             }
         }
 

--- a/kernel/src/abi/scarlet/aarch64.rs
+++ b/kernel/src/abi/scarlet/aarch64.rs
@@ -344,17 +344,22 @@ impl ScarletAbi {
                 Ok(())
             }
             ProcessControlType::Stop => {
-                // Set task state to blocked
                 task.set_state(crate::task::TaskState::Blocked(
                     crate::task::BlockedType::Interruptible,
                 ));
+                crate::sched::scheduler::mark_blocked(task.get_id());
+                crate::sched::scheduler::remove_from_ready_queues(task.get_id());
                 Ok(())
             }
             ProcessControlType::Continue => {
-                // Resume the task if it was stopped
                 let current_state = task.get_state();
                 if matches!(current_state, crate::task::TaskState::Blocked(_)) {
                     task.set_state(crate::task::TaskState::Ready);
+                    crate::sched::scheduler::unmark_blocked(task.get_id());
+                    crate::sched::scheduler::push_ready_task(
+                        crate::arch::get_cpu().get_cpuid(),
+                        task.get_id(),
+                    );
                 }
                 Ok(())
             }

--- a/kernel/src/abi/scarlet/riscv64.rs
+++ b/kernel/src/abi/scarlet/riscv64.rs
@@ -344,17 +344,22 @@ impl ScarletAbi {
                 Ok(())
             }
             ProcessControlType::Stop => {
-                // Set task state to blocked
                 task.set_state(crate::task::TaskState::Blocked(
                     crate::task::BlockedType::Interruptible,
                 ));
+                crate::sched::scheduler::mark_blocked(task.get_id());
+                crate::sched::scheduler::remove_from_ready_queues(task.get_id());
                 Ok(())
             }
             ProcessControlType::Continue => {
-                // Resume the task if it was stopped
                 let current_state = task.get_state();
                 if matches!(current_state, crate::task::TaskState::Blocked(_)) {
                     task.set_state(crate::task::TaskState::Ready);
+                    crate::sched::scheduler::unmark_blocked(task.get_id());
+                    crate::sched::scheduler::push_ready_task(
+                        crate::arch::get_cpu().get_cpuid(),
+                        task.get_id(),
+                    );
                 }
                 Ok(())
             }

--- a/kernel/src/abi/xv6/riscv64/proc.rs
+++ b/kernel/src/abi/xv6/riscv64/proc.rs
@@ -1,8 +1,8 @@
 use crate::{
-    arch::{Trapframe, get_cpu},
+    arch::Trapframe,
     fs::FileType,
     library::std::string::cstring_to_string,
-    sched::scheduler::{add_task, get_task_by_id, schedule},
+    sched::scheduler::{get_task_by_id, schedule},
     task::{CloneFlags, WaitError, get_parent_waitpid_waker, mytask},
 };
 use alloc::string::{String, ToString};
@@ -39,14 +39,15 @@ pub fn sys_fork(
 
     /* Clone the task */
     match parent_task.clone_task(CloneFlags::default()) {
-        Ok(mut child_task) => {
+        Ok(child_task) => {
             child_task.vcpu.lock().iregs.reg[10] = 0; /* Set the return value (a0) to 0 in the child proc */
 
-            let cpu_id = get_cpu().get_cpuid();
+            let cpu_id = crate::sched::scheduler::select_cpu();
             let parent_id = parent_task.get_id();
 
-            // Add child and get allocated ID
-            let child_id = add_task(child_task, cpu_id);
+            // Register first, complete parent/child metadata, then enqueue.
+            // A remote CPU may run the child immediately after enqueue via IPI.
+            let child_id = crate::sched::scheduler::register_task(child_task);
 
             // Establish parent-child relationship now that both have valid IDs
             if let Some(child) = get_task_by_id(child_id) {
@@ -60,6 +61,8 @@ pub fn sys_fork(
             let child_namespace_id = get_task_by_id(child_id)
                 .map(|t| t.get_namespace_id())
                 .unwrap_or(0);
+
+            crate::sched::scheduler::enqueue_task(child_id, cpu_id);
 
             /* Return the child task namespace ID as pid to the parent proc */
             child_namespace_id

--- a/kernel/src/abi/xv6/riscv64/proc.rs
+++ b/kernel/src/abi/xv6/riscv64/proc.rs
@@ -2,7 +2,7 @@ use crate::{
     arch::{Trapframe, get_cpu},
     fs::FileType,
     library::std::string::cstring_to_string,
-    sched::scheduler::get_scheduler,
+    sched::scheduler::{add_task, get_task_by_id, schedule},
     task::{CloneFlags, WaitError, get_parent_waitpid_waker, mytask},
 };
 use alloc::string::{String, ToString};
@@ -42,24 +42,22 @@ pub fn sys_fork(
         Ok(mut child_task) => {
             child_task.vcpu.lock().iregs.reg[10] = 0; /* Set the return value (a0) to 0 in the child proc */
 
-            let scheduler = get_scheduler();
             let cpu_id = get_cpu().get_cpuid();
             let parent_id = parent_task.get_id();
 
             // Add child and get allocated ID
-            let child_id = scheduler.add_task(child_task, cpu_id);
+            let child_id = add_task(child_task, cpu_id);
 
             // Establish parent-child relationship now that both have valid IDs
-            if let Some(child) = scheduler.get_task_by_id(child_id) {
+            if let Some(child) = get_task_by_id(child_id) {
                 child.set_parent_id(parent_id);
             }
-            if let Some(parent) = scheduler.get_task_by_id(parent_id) {
+            if let Some(parent) = get_task_by_id(parent_id) {
                 parent.add_child(child_id);
             }
 
             // Get namespace-local ID to return to user space (this is the PID visible to xv6 programs)
-            let child_namespace_id = scheduler
-                .get_task_by_id(child_id)
+            let child_namespace_id = get_task_by_id(child_id)
                 .map(|t| t.get_namespace_id())
                 .unwrap_or(0);
 
@@ -80,7 +78,7 @@ pub fn sys_exit(
     task.vcpu.lock().store(trapframe);
     let exit_code = trapframe.get_arg(0) as i32;
     task.exit(exit_code);
-    get_scheduler().schedule(trapframe);
+    schedule(trapframe);
     usize::MAX // -1 (If exit is successful, this will not be reached)
 }
 
@@ -144,8 +142,7 @@ pub fn sys_kill(
     }
 
     // Find the target task via scheduler
-    let scheduler = get_scheduler();
-    if let Some(target_task) = scheduler.get_task_by_id(pid) {
+    if let Some(target_task) = get_task_by_id(pid) {
         // For xv6 compatibility, immediately terminate the target task
         target_task.exit(9); // SIGKILL equivalent - exit with signal 9
         0 // Success

--- a/kernel/src/arch/aarch64/boot/limine.rs
+++ b/kernel/src/arch/aarch64/boot/limine.rs
@@ -1,22 +1,25 @@
 use core::arch::{asm, naked_asm};
 use core::mem::MaybeUninit;
 
+use limine::mp::MpInfo;
+
 use crate::boot::limine::{
     DTB_REQUEST, EXECUTABLE_ADDRESS_REQUEST, FRAMEBUFFER_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST,
-    MODULE_REQUEST, ensure_base_revision_supported, framebuffer_area, hhdm_physical_span,
-    module_area, reserve_front, response, select_usable_region,
+    MODULE_REQUEST, MP_REQUEST, ensure_base_revision_supported, framebuffer_area,
+    hhdm_physical_span, module_area, reserve_front, response, select_usable_region,
 };
 use crate::device::fdt::{FdtManager, init_fdt, relocate_fdt};
 use crate::environment::STACK_SIZE;
 use crate::mem::{KERNEL_STACK, init_bss};
 use crate::vm::addr::{init_boot_direct_map_range, init_limine_addressing, phys_to_virt};
 use crate::vm::vmem::MemoryArea;
-use crate::{BootInfo, DeviceSource, early_println, start_ap, start_kernel};
+use crate::{
+    BootInfo, DeviceSource, early_println, println, start_ap, start_kernel, wait_for_ap_release,
+};
 use core::sync::atomic::compiler_fence;
 
 static mut EARLY_BOOTINFO: MaybeUninit<BootInfo> = MaybeUninit::uninit();
 
-// VHE/hypervisor availability flags set during early boot
 static mut VHE_ENABLED: bool = false;
 static mut HV_AVAILABLE: bool = false;
 
@@ -28,6 +31,66 @@ pub fn is_hv_available() -> bool {
     unsafe { HV_AVAILABLE }
 }
 
+#[unsafe(naked)]
+unsafe extern "C" fn limine_ap_entry(_info: &MpInfo) -> ! {
+    naked_asm!(
+        // x0 = &MpInfo (from Limine)
+        "ldr x8, [x0, #8]",         // x8 = mp_info.mpidr (offset 8)
+        "and x8, x8, #0xff",        // x8 = cpu_id
+        // Compute stack_top = &KERNEL_STACK + STACK_SIZE * (cpu_id + 1)
+        "adrp x9, {kernel_stack}",
+        "add  x9, x9, #:lo12:{kernel_stack}",
+        "mov  x10, {stack_size}",
+        "add  x11, x8, #1",         // x11 = cpu_id + 1
+        "mul  x11, x11, x10",       // x11 = STACK_SIZE * (cpu_id + 1)
+        "add  x9, x9, x11",         // x9 = &KERNEL_STACK + offset = stack_top
+        // Switch to SP_EL1 and set stack
+        "msr spsel, #1",
+        "mov sp, x9",
+        "isb",
+        // x0 = cpu_id, jump to ap_entry_wait
+        "mov x0, x8",
+        "b {ap_wait}",
+        kernel_stack = sym KERNEL_STACK,
+        stack_size = const STACK_SIZE,
+        ap_wait = sym ap_entry_wait,
+    );
+}
+
+fn ap_entry_wait(cpu_id: usize) -> ! {
+    wait_for_ap_release();
+    start_ap(cpu_id)
+}
+
+fn start_secondary_cpus() {
+    crate::release_aps();
+}
+
+fn bootstrap_aps() {
+    let mp_resp = match MP_REQUEST.response() {
+        Some(resp) => resp,
+        None => {
+            early_println!("[aarch64] No Limine MP response, single-CPU mode");
+            return;
+        }
+    };
+
+    let bsp_mpidr = mp_resp.bsp_mpidr;
+    early_println!(
+        "[aarch64] BSP mpidr={:#x}, {} CPU(s) detected by Limine",
+        bsp_mpidr,
+        mp_resp.cpus().len()
+    );
+
+    for cpu in mp_resp.cpus() {
+        if cpu.mpidr == bsp_mpidr {
+            continue;
+        }
+        early_println!("[aarch64] Bootstrapping CPU mpidr={:#x}...", cpu.mpidr);
+        cpu.bootstrap(limine_ap_entry, cpu.mpidr);
+    }
+}
+
 #[inline(always)]
 fn current_el() -> u64 {
     let el: u64;
@@ -37,18 +100,13 @@ fn current_el() -> u64 {
     (el >> 2) & 0x3
 }
 
-/// With Limine Base Revision 6, the bootloader may enter the kernel at EL2.
-/// We check CurrentEL and verify VHE by reading HCR_EL2.E2H.
-/// _EL12 register aliases are only valid when VHE is active (E2H=1).
 fn detect_el() -> (u64, bool) {
     let el = current_el();
     let vhe = if el == 2 {
-        // SAFETY: Reading HCR_EL2 at EL2 is a safe system register access.
         let hcr_el2: u64;
         unsafe {
             asm!("mrs {}, HCR_EL2", out(reg) hcr_el2, options(nostack));
         }
-        // E2H bit (bit 34) indicates VHE is active
         (hcr_el2 & (1u64 << 34)) != 0
     } else {
         false
@@ -122,6 +180,8 @@ pub extern "C" fn limine_entry() -> ! {
     let cpu_id = current_cpu_id();
     let framebuffer_paddr = framebuffer_area(FRAMEBUFFER_REQUEST.response());
 
+    bootstrap_aps();
+
     let bootinfo = BootInfo::new(
         cpu_id,
         cpu_count,
@@ -132,6 +192,7 @@ pub extern "C" fn limine_entry() -> ! {
         cmdline,
         DeviceSource::Fdt(relocated_fdt_paddr),
         framebuffer_paddr,
+        Some(start_secondary_cpus),
     );
 
     crate::arch::init_user_context_from_fdt();

--- a/kernel/src/arch/aarch64/boot/limine.rs
+++ b/kernel/src/arch/aarch64/boot/limine.rs
@@ -13,9 +13,7 @@ use crate::environment::STACK_SIZE;
 use crate::mem::{KERNEL_STACK, init_bss};
 use crate::vm::addr::{init_boot_direct_map_range, init_limine_addressing, phys_to_virt};
 use crate::vm::vmem::MemoryArea;
-use crate::{
-    BootInfo, DeviceSource, early_println, println, start_ap, start_kernel, wait_for_ap_release,
-};
+use crate::{BootInfo, DeviceSource, early_println, start_ap, start_kernel, wait_for_ap_release};
 use core::sync::atomic::compiler_fence;
 
 static mut EARLY_BOOTINFO: MaybeUninit<BootInfo> = MaybeUninit::uninit();

--- a/kernel/src/arch/aarch64/instruction/mod.rs
+++ b/kernel/src/arch/aarch64/instruction/mod.rs
@@ -24,6 +24,7 @@ impl Instruction {
 
 pub fn idle() -> ! {
     loop {
+        crate::arch::interrupt::enable_interrupts();
         unsafe {
             core::arch::asm!("wfi", options(nomem, nostack, preserves_flags));
         }

--- a/kernel/src/arch/aarch64/interrupt/mod.rs
+++ b/kernel/src/arch/aarch64/interrupt/mod.rs
@@ -91,6 +91,13 @@ pub fn enable_external_interrupts() {
     // }
 }
 
+/// Enable software interrupt reception at CPU level.
+///
+/// AArch64 scheduler IPIs are delivered as GIC SGIs, which share the IRQ CPU
+/// mask with other external interrupts. The per-SGI source enable is handled by
+/// the GIC driver, so there is no separate architectural CPU bit to set here.
+pub fn enable_software_interrupts() {}
+
 /// Disable external interrupts (IRQ) at CPU level.
 pub fn disable_external_interrupts() {
     // unsafe {

--- a/kernel/src/arch/aarch64/interrupt/mod.rs
+++ b/kernel/src/arch/aarch64/interrupt/mod.rs
@@ -171,8 +171,8 @@ pub fn disable_timer_source_interrupt() {
 /// 1. Enables the timer at the local controller level (CNTV_CTL_EL0)
 /// 2. Attempts to enable the timer PPI at the external controller level
 ///
-/// On GIC-based systems, the timer uses PPI 27 which must be enabled in the
-/// distributor. On Apple Silicon (AIC), the timer bypasses the AIC entirely
+/// On GIC-based systems, the timer uses PPI 27 (EL1) or PPI 28 (EL2 VHE).
+/// On Apple Silicon (AIC), the timer bypasses the AIC entirely
 /// (it's wired to FIQ), so the external enable gracefully fails and is ignored.
 pub fn enable_arch_timer_interrupt() -> Result<(), &'static str> {
     let cpu_id = get_cpu().get_cpuid() as u32;

--- a/kernel/src/arch/aarch64/interrupt/mod.rs
+++ b/kernel/src/arch/aarch64/interrupt/mod.rs
@@ -138,29 +138,42 @@ pub fn disable_external_interrupt_line(interrupt_id: u32) -> Result<(), &'static
 
 /// Unmask the architectural timer interrupt at the timer source.
 ///
-/// This is the closest equivalent to RISC-V's per-source enable bit like STIE,
-/// but on AArch64 we use CNTV_CTL_EL0 (virtual timer).
+/// This is the closest equivalent to RISC-V's per-source enable bit like STIE.
+/// Uses CNTP_CTL_EL0 (physical) in VHE mode, CNTV_CTL_EL0 (virtual) otherwise.
 pub fn enable_timer_source_interrupt() {
+    let mut ctl: u64;
     unsafe {
-        let mut ctl: u64;
-        asm!("mrs {0}, cntv_ctl_el0", out(reg) ctl, options(nostack));
-        // IMASK bit (1): 0 = unmask timer interrupt.
-        ctl &= !(1 << 1);
-        // ENABLE bit (0): 1 = enable timer.
-        ctl |= 1;
-        asm!("msr cntv_ctl_el0, {0}", in(reg) ctl, options(nostack));
+        if crate::arch::aarch64::is_vhe_enabled() {
+            asm!("mrs {0}, cntp_ctl_el0", out(reg) ctl, options(nostack));
+        } else {
+            asm!("mrs {0}, cntv_ctl_el0", out(reg) ctl, options(nostack));
+        }
+        ctl &= !(1 << 1); // IMASK=0: unmask
+        ctl |= 1; // ENABLE=1
+        if crate::arch::aarch64::is_vhe_enabled() {
+            asm!("msr cntp_ctl_el0, {0}", in(reg) ctl, options(nostack));
+        } else {
+            asm!("msr cntv_ctl_el0, {0}", in(reg) ctl, options(nostack));
+        }
         asm!("isb", options(nostack));
     }
 }
 
 /// Mask the architectural timer interrupt at the timer source.
 pub fn disable_timer_source_interrupt() {
+    let mut ctl: u64;
     unsafe {
-        let mut ctl: u64;
-        asm!("mrs {0}, cntv_ctl_el0", out(reg) ctl, options(nostack));
-        // IMASK bit (1): 1 = mask timer interrupt.
-        ctl |= 1 << 1;
-        asm!("msr cntv_ctl_el0, {0}", in(reg) ctl, options(nostack));
+        if crate::arch::aarch64::is_vhe_enabled() {
+            asm!("mrs {0}, cntp_ctl_el0", out(reg) ctl, options(nostack));
+        } else {
+            asm!("mrs {0}, cntv_ctl_el0", out(reg) ctl, options(nostack));
+        }
+        ctl |= 1 << 1; // IMASK=1: mask
+        if crate::arch::aarch64::is_vhe_enabled() {
+            asm!("msr cntp_ctl_el0, {0}", in(reg) ctl, options(nostack));
+        } else {
+            asm!("msr cntv_ctl_el0, {0}", in(reg) ctl, options(nostack));
+        }
         asm!("isb", options(nostack));
     }
 }
@@ -171,7 +184,7 @@ pub fn disable_timer_source_interrupt() {
 /// 1. Enables the timer at the local controller level (CNTV_CTL_EL0)
 /// 2. Attempts to enable the timer PPI at the external controller level
 ///
-/// On GIC-based systems, the timer uses PPI 27 (EL1) or PPI 28 (EL2 VHE).
+/// On GIC-based systems, the timer uses PPI 27 (EL1 virtual) or PPI 26 (EL2 physical/VHE).
 /// On Apple Silicon (AIC), the timer bypasses the AIC entirely
 /// (it's wired to FIQ), so the external enable gracefully fails and is ignored.
 pub fn enable_arch_timer_interrupt() -> Result<(), &'static str> {

--- a/kernel/src/arch/aarch64/interrupt/mod.rs
+++ b/kernel/src/arch/aarch64/interrupt/mod.rs
@@ -177,7 +177,6 @@ pub fn disable_timer_source_interrupt() {
 pub fn enable_arch_timer_interrupt() -> Result<(), &'static str> {
     let cpu_id = get_cpu().get_cpuid() as u32;
 
-    // Enable at local controller level (CNTV_CTL_EL0)
     InterruptManager::with_manager(|mgr| {
         mgr.enable_local_interrupt(cpu_id, LocalInterruptType::Timer)
     })

--- a/kernel/src/arch/aarch64/interrupt/mod.rs
+++ b/kernel/src/arch/aarch64/interrupt/mod.rs
@@ -6,7 +6,7 @@ use core::arch::asm;
 use core::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 
 use crate::arch::get_cpu;
-use crate::interrupt::{InterruptError, InterruptManager, controllers::LocalInterruptType};
+use crate::interrupt::{InterruptError, controllers::LocalInterruptType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimerInterruptRoute {
@@ -102,38 +102,34 @@ pub fn disable_external_interrupts() {
 ///
 /// This corresponds to "core-local" enables such as the architectural timer.
 pub fn enable_core_local_interrupt(source: LocalInterruptType) -> Result<(), &'static str> {
-    InterruptManager::with_manager(|mgr| {
-        let cpu_id = get_cpu().get_cpuid() as u32;
-        mgr.enable_local_interrupt(cpu_id, source)
-    })
-    .map_err(|_| "failed to enable core-local interrupt")
+    let cpu_id = get_cpu().get_cpuid() as u32;
+    crate::interrupt::InterruptManager::global()
+        .enable_local_interrupt(cpu_id, source)
+        .map_err(|_| "failed to enable core-local interrupt")
 }
 
 /// Disable a core-local interrupt source via the InterruptManager.
 pub fn disable_core_local_interrupt(source: LocalInterruptType) -> Result<(), &'static str> {
-    InterruptManager::with_manager(|mgr| {
-        let cpu_id = get_cpu().get_cpuid() as u32;
-        mgr.disable_local_interrupt(cpu_id, source)
-    })
-    .map_err(|_| "failed to disable core-local interrupt")
+    let cpu_id = get_cpu().get_cpuid() as u32;
+    crate::interrupt::InterruptManager::global()
+        .disable_local_interrupt(cpu_id, source)
+        .map_err(|_| "failed to disable core-local interrupt")
 }
 
 /// Enable an external interrupt line (GIC-backed) for the current CPU.
 pub fn enable_external_interrupt_line(interrupt_id: u32) -> Result<(), &'static str> {
-    InterruptManager::with_manager(|mgr| {
-        let cpu_id = get_cpu().get_cpuid() as u32;
-        mgr.enable_external_interrupt(interrupt_id, cpu_id)
-    })
-    .map_err(|_| "failed to enable external interrupt line")
+    let cpu_id = get_cpu().get_cpuid() as u32;
+    crate::interrupt::InterruptManager::global()
+        .enable_external_interrupt(interrupt_id, cpu_id)
+        .map_err(|_| "failed to enable external interrupt line")
 }
 
 /// Disable an external interrupt line (GIC-backed) for the current CPU.
 pub fn disable_external_interrupt_line(interrupt_id: u32) -> Result<(), &'static str> {
-    InterruptManager::with_manager(|mgr| {
-        let cpu_id = get_cpu().get_cpuid() as u32;
-        mgr.disable_external_interrupt(interrupt_id, cpu_id)
-    })
-    .map_err(|_| "failed to disable external interrupt line")
+    let cpu_id = get_cpu().get_cpuid() as u32;
+    crate::interrupt::InterruptManager::global()
+        .disable_external_interrupt(interrupt_id, cpu_id)
+        .map_err(|_| "failed to disable external interrupt line")
 }
 
 /// Unmask the architectural timer interrupt at the timer source.
@@ -190,26 +186,24 @@ pub fn disable_timer_source_interrupt() {
 pub fn enable_arch_timer_interrupt() -> Result<(), &'static str> {
     let cpu_id = get_cpu().get_cpuid() as u32;
 
-    InterruptManager::with_manager(|mgr| {
-        mgr.enable_local_interrupt(cpu_id, LocalInterruptType::Timer)
-    })
-    .map_err(|_| "failed to enable local timer interrupt")?;
+    crate::interrupt::InterruptManager::global()
+        .enable_local_interrupt(cpu_id, LocalInterruptType::Timer)
+        .map_err(|_| "failed to enable local timer interrupt")?;
 
     match timer_interrupt_route() {
         TimerInterruptRoute::FastInterrupt => {}
         TimerInterruptRoute::ExternalControllerIrq => {
             let interrupt_id = timer_external_interrupt_id()
                 .ok_or("external timer interrupt route is not configured")?;
-            InterruptManager::with_manager(|mgr| {
-                mgr.enable_external_interrupt(interrupt_id, cpu_id)
-            })
-            .or_else(|e| {
-                if matches!(e, InterruptError::InvalidInterruptId) {
-                    Ok(())
-                } else {
-                    Err("failed to enable timer PPI in external controller")
-                }
-            })?;
+            crate::interrupt::InterruptManager::global()
+                .enable_external_interrupt(interrupt_id, cpu_id)
+                .or_else(|e| {
+                    if matches!(e, InterruptError::InvalidInterruptId) {
+                        Ok(())
+                    } else {
+                        Err("failed to enable timer PPI in external controller")
+                    }
+                })?;
         }
         TimerInterruptRoute::Unknown => return Err("timer interrupt route is not configured"),
     }
@@ -221,26 +215,24 @@ pub fn enable_arch_timer_interrupt() -> Result<(), &'static str> {
 pub fn disable_arch_timer_interrupt() -> Result<(), &'static str> {
     let cpu_id = get_cpu().get_cpuid() as u32;
 
-    InterruptManager::with_manager(|mgr| {
-        mgr.disable_local_interrupt(cpu_id, LocalInterruptType::Timer)
-    })
-    .map_err(|_| "failed to disable local timer interrupt")?;
+    crate::interrupt::InterruptManager::global()
+        .disable_local_interrupt(cpu_id, LocalInterruptType::Timer)
+        .map_err(|_| "failed to disable local timer interrupt")?;
 
     match timer_interrupt_route() {
         TimerInterruptRoute::FastInterrupt => {}
         TimerInterruptRoute::ExternalControllerIrq => {
             let interrupt_id = timer_external_interrupt_id()
                 .ok_or("external timer interrupt route is not configured")?;
-            InterruptManager::with_manager(|mgr| {
-                mgr.disable_external_interrupt(interrupt_id, cpu_id)
-            })
-            .or_else(|e| {
-                if matches!(e, InterruptError::InvalidInterruptId) {
-                    Ok(())
-                } else {
-                    Err("failed to disable timer PPI in external controller")
-                }
-            })?;
+            crate::interrupt::InterruptManager::global()
+                .disable_external_interrupt(interrupt_id, cpu_id)
+                .or_else(|e| {
+                    if matches!(e, InterruptError::InvalidInterruptId) {
+                        Ok(())
+                    } else {
+                        Err("failed to disable timer PPI in external controller")
+                    }
+                })?;
         }
         TimerInterruptRoute::Unknown => return Err("timer interrupt route is not configured"),
     }
@@ -249,10 +241,9 @@ pub fn disable_arch_timer_interrupt() -> Result<(), &'static str> {
 }
 
 pub fn is_arch_timer_pending() -> bool {
-    InterruptManager::with_manager(|mgr| {
-        let cpu_id = get_cpu().get_cpuid() as u32;
-        mgr.is_local_interrupt_pending(cpu_id, LocalInterruptType::Timer)
-    })
+    let cpu_id = get_cpu().get_cpuid() as u32;
+    crate::interrupt::InterruptManager::global()
+        .is_local_interrupt_pending(cpu_id, LocalInterruptType::Timer)
 }
 
 pub fn with_interrupts_disabled<F, R>(f: F) -> R

--- a/kernel/src/arch/aarch64/kernel/mod.rs
+++ b/kernel/src/arch/aarch64/kernel/mod.rs
@@ -6,9 +6,5 @@
 // This includes CPU management and kernel utilities
 
 pub fn get_cpu() -> &'static crate::arch::Aarch64 {
-    // TODO: Get current CPU context
-    unsafe {
-        let cpu_id = 0; // TODO: Get actual CPU ID
-        core::mem::transmute(&super::CPUS[cpu_id] as *const _ as usize)
-    }
+    super::get_cpu()
 }

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -111,9 +111,12 @@ pub fn first_switch_to_user(task: &mut Task) -> ! {
     // Populate the trapframe from the task VCPU state.
     // Use a raw pointer to avoid borrow checker conflicts with get_trapframe().
     let task_ptr = task as *mut Task;
+    let task_mode = task.vcpu.lock().get_mode();
     unsafe {
         let trapframe = (*task_ptr).get_trapframe();
         (*task_ptr).vcpu.lock().switch(trapframe);
+
+        trapframe.spsr = target_spsr_for_mode(task_mode);
 
         // Ensure IRQs are unmasked in the user PSTATE after `eret`.
         crate::arch::configure_user_entry(
@@ -130,10 +133,14 @@ pub fn first_switch_to_user(task: &mut Task) -> ! {
     let trampoline_base = crate::vm::get_trampoline_trap_vector();
     let trap_exit_addr = trampoline_base.wrapping_add(trap_exit_offset);
 
-    // Program per-CPU arch pointer and VBAR to the trampoline right before the jump.
+    // Program per-CPU arch pointer and the target trap vector right before the jump.
     let cpu_id = cpu.get_cpuid();
     set_arch(crate::vm::get_trampoline_arch(cpu_id));
-    set_trapvector(trampoline_base);
+    if is_privileged_return_mode(task.get_trapframe().spsr) {
+        set_trapvector(get_kernel_trapvector_paddr());
+    } else {
+        set_trapvector(trampoline_base);
+    }
 
     let trapframe_addr = (kernel_sp as usize).wrapping_sub(core::mem::size_of::<Trapframe>());
 
@@ -420,23 +427,24 @@ pub fn get_trapvector() -> usize {
 pub fn configure_user_entry(trapframe: &mut Trapframe, options: crate::arch::UserEntryOptions) {
     use crate::arch::UserReturnIrqPolicy;
 
-    // DAIF bits in PSTATE/SPSR: D=9, A=8, I=7, F=6. 1 means masked.
     const DAIF_I: u64 = 1 << 7;
     const DAIF_F: u64 = 1 << 6;
-    match options.irq_policy {
-        UserReturnIrqPolicy::Inherit => {}
-        UserReturnIrqPolicy::Enable => {
-            trapframe.spsr &= !DAIF_I;
-            trapframe.spsr &= !DAIF_F;
-        }
-        UserReturnIrqPolicy::Disable => {
-            trapframe.spsr |= DAIF_I;
-            trapframe.spsr |= DAIF_F;
-        }
-    }
+    const DAIF_MASK: u64 = DAIF_I | DAIF_F;
+    const SPSR_MODE_MASK: u64 = 0xF;
 
-    // Configure EL0 FP/SIMD access for the next user return.
-    // DTB-driven runtime gating complements the build-time feature.
+    let el = if let Some(task) = crate::sched::scheduler::current_task(get_cpu().get_cpuid()) {
+        target_spsr_for_mode(task.vcpu.lock().get_mode())
+    } else {
+        target_spsr_for_mode(crate::arch::Mode::User)
+    };
+
+    let daif = match options.irq_policy {
+        UserReturnIrqPolicy::Inherit => trapframe.spsr & DAIF_MASK,
+        UserReturnIrqPolicy::Enable => 0,
+        UserReturnIrqPolicy::Disable => DAIF_MASK,
+    };
+    trapframe.spsr = el | daif | (trapframe.spsr & !(SPSR_MODE_MASK | DAIF_MASK));
+
     if crate::arch::user_fpu_enabled() {
         let cpu_id = get_cpu().get_cpuid();
         if let Some(task) = crate::sched::scheduler::current_task(cpu_id) {
@@ -499,11 +507,30 @@ pub fn get_cpu() -> &'static mut Aarch64 {
     return unsafe { transmute(tpidr_el1) };
 }
 
-pub fn set_next_mode(_mode: crate::arch::Mode) {
-    // AArch64 return mode is currently chosen in the trampoline (`_switch_to_user`).
-    // Keep this as a no-op so shared scheduler code can call it without
-    // architecture-specific branching or noisy TODO logs.
-    let _ = _mode;
+pub fn set_next_mode(mode: crate::arch::Mode) {
+    let spsr = target_spsr_for_mode(mode);
+    // SAFETY: writing SPSR_EL1 only affects the exception-return EL.
+    unsafe {
+        core::arch::asm!("msr spsr_el1, {0}", in(reg) spsr);
+    }
+}
+
+pub fn is_privileged_return_mode(spsr: u64) -> bool {
+    matches!(spsr & 0xF, 0x5 | 0x9)
+}
+
+fn target_spsr_for_mode(mode: crate::arch::Mode) -> u64 {
+    const SPSR_EL0T: u64 = 0x0;
+    const SPSR_EL1H: u64 = 0x5;
+    const SPSR_EL2H: u64 = 0x9;
+
+    match mode {
+        crate::arch::Mode::Kernel | crate::arch::Mode::GuestKernel if is_vhe_enabled() => {
+            SPSR_EL2H
+        }
+        crate::arch::Mode::Kernel | crate::arch::Mode::GuestKernel => SPSR_EL1H,
+        _ => SPSR_EL0T,
+    }
 }
 
 /// Memory barrier for device/MMIO (I/O) operations.

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -525,9 +525,7 @@ fn target_spsr_for_mode(mode: crate::arch::Mode) -> u64 {
     const SPSR_EL2H: u64 = 0x9;
 
     match mode {
-        crate::arch::Mode::Kernel | crate::arch::Mode::GuestKernel if is_vhe_enabled() => {
-            SPSR_EL2H
-        }
+        crate::arch::Mode::Kernel | crate::arch::Mode::GuestKernel if is_vhe_enabled() => SPSR_EL2H,
         crate::arch::Mode::Kernel | crate::arch::Mode::GuestKernel => SPSR_EL1H,
         _ => SPSR_EL0T,
     }

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -478,6 +478,13 @@ pub fn disable_interrupt() {
     }
 }
 
+pub fn send_reschedule_ipi(target_cpu: usize) {
+    crate::interrupt::InterruptManager::with_manager(|manager| {
+        use crate::interrupt::controllers::LocalInterruptType;
+        let _ = manager.send_ipi(target_cpu as u32, LocalInterruptType::Software);
+    });
+}
+
 pub fn get_cpu() -> &'static mut Aarch64 {
     // Prefer the EL1 thread pointer (kept at the kernel-mapped Arch address).
     let tpidr_el1: usize;

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -487,10 +487,9 @@ pub fn disable_interrupt() {
 }
 
 pub fn send_reschedule_ipi(target_cpu: usize) {
-    crate::interrupt::InterruptManager::with_manager(|manager| {
-        use crate::interrupt::controllers::LocalInterruptType;
-        let _ = manager.send_ipi(target_cpu as u32, LocalInterruptType::Software);
-    });
+    use crate::interrupt::controllers::LocalInterruptType;
+    let _ = crate::interrupt::InterruptManager::global()
+        .send_ipi(target_cpu as u32, LocalInterruptType::Software);
 }
 
 pub fn get_cpu() -> &'static mut Aarch64 {

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -31,6 +31,8 @@ pub use context::KernelContext;
 pub use earlycon::*;
 pub use registers::IntRegisters;
 
+pub use init_arch as init_ap_cpu;
+
 use crate::arch::vm::get_root_pagetable;
 use crate::vm::vmem::MemoryArea;
 

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -88,7 +88,7 @@ pub fn init_arch(cpu_id: usize) {
 /// - Chooses the task-provided kernel stack (SP_EL1) for the upcoming EL0->EL1 traps.
 /// - Programs per-CPU trampoline-visible state (kernel stack top, trap handler, TTBR0).
 /// - Performs a direct transition via the trampoline exit path.
-pub fn first_switch_to_user(task: &mut Task) -> ! {
+pub fn first_switch_to_user(task: &Task) -> ! {
     // Prefer the high-VA kernel stack window if available.
     let kernel_sp = if let Some((_slot, base)) = task.get_kernel_stack_window_base() {
         (base + crate::environment::PAGE_SIZE + crate::environment::TASK_KERNEL_STACK_SIZE) as u64
@@ -108,24 +108,18 @@ pub fn first_switch_to_user(task: &mut Task) -> ! {
     cpu.set_trap_handler(get_user_trap_handler());
     cpu.set_next_address_space(task.vm_manager.get_asid());
 
-    // Populate the trapframe from the task VCPU state.
-    // Use a raw pointer to avoid borrow checker conflicts with get_trapframe().
-    let task_ptr = task as *mut Task;
     let task_mode = task.vcpu.lock().get_mode();
-    unsafe {
-        let trapframe = (*task_ptr).get_trapframe();
-        (*task_ptr).vcpu.lock().switch(trapframe);
+    let trapframe = task.get_trapframe();
+    task.vcpu.lock().switch(trapframe);
 
-        trapframe.spsr = target_spsr_for_mode(task_mode);
+    trapframe.spsr = target_spsr_for_mode(task_mode);
 
-        // Ensure IRQs are unmasked in the user PSTATE after `eret`.
-        crate::arch::configure_user_entry(
-            trapframe,
-            crate::arch::UserEntryOptions {
-                irq_policy: crate::arch::UserReturnIrqPolicy::Enable,
-            },
-        );
-    }
+    crate::arch::configure_user_entry(
+        trapframe,
+        crate::arch::UserEntryOptions {
+            irq_policy: crate::arch::UserReturnIrqPolicy::Enable,
+        },
+    );
 
     // Compute trampoline exit target.
     let trap_exit_offset = (crate::arch::aarch64::trap::user::_switch_to_user as usize)

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -31,8 +31,6 @@ pub use context::KernelContext;
 pub use earlycon::*;
 pub use registers::IntRegisters;
 
-pub use init_arch as init_ap_cpu;
-
 use crate::arch::vm::get_root_pagetable;
 use crate::vm::vmem::MemoryArea;
 
@@ -76,6 +74,23 @@ pub fn init_arch(cpu_id: usize) {
     // Get raw Aarch64 struct
     let aarch64: &mut Aarch64 = unsafe { transmute(&CPUS[cpu_id] as *const _ as usize) };
     aarch64.cpuid = cpu_id as u64;
+
+    trap_init(aarch64);
+}
+
+pub fn init_ap_cpu(cpu_id: usize) {
+    early_println!("[aarch64] CPU {}: Initializing core....", cpu_id);
+    // Get raw Aarch64 struct
+    let aarch64: &mut Aarch64 = unsafe { transmute(&CPUS[cpu_id] as *const _ as usize) };
+    aarch64.cpuid = cpu_id as u64;
+
+    unsafe {
+        asm!(
+            "mrs {0}, ttbr0_el1",
+            out(reg) aarch64.ttbr0,
+        );
+    }
+
     trap_init(aarch64);
 }
 
@@ -238,6 +253,13 @@ impl Aarch64 {
 
     pub fn set_kernel_ttbr0(&mut self, val: u64) {
         self.kernel_ttbr0 = val;
+
+        // The user trampoline may observe this CPU struct through a different
+        // VA alias, so push the update to PoC before returning to EL0.
+        crate::arch::aarch64::clean_dcache_to_poc_range(
+            self as *const _ as usize,
+            core::mem::size_of::<Aarch64>(),
+        );
     }
 
     pub fn get_kernel_ttbr0(&self) -> u64 {

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -437,7 +437,7 @@ pub fn configure_user_entry(trapframe: &mut Trapframe, options: crate::arch::Use
     // DTB-driven runtime gating complements the build-time feature.
     if crate::arch::user_fpu_enabled() {
         let cpu_id = get_cpu().get_cpuid();
-        if let Some(task) = crate::sched::scheduler::get_scheduler().get_current_task(cpu_id) {
+        if let Some(task) = crate::sched::scheduler::current_task(cpu_id) {
             crate::arch::fpu::set_user_fpu_enabled(task.vcpu.lock().fpu_used);
         } else {
             crate::arch::fpu::set_user_fpu_enabled(false);

--- a/kernel/src/arch/aarch64/timer.rs
+++ b/kernel/src/arch/aarch64/timer.rs
@@ -4,24 +4,22 @@
 
 use core::arch::asm;
 
-use crate::{arch::get_cpu, arch::interrupt, interrupt::InterruptManager};
+use crate::{arch::get_cpu, arch::interrupt};
 
 pub fn timer_init() {
     // Local controller registration happens via early initcall.
 }
 
 pub fn get_time() -> u64 {
-    InterruptManager::with_manager(|mgr| {
-        let cpu_id = get_cpu().get_cpuid() as u32;
-        mgr.get_time(cpu_id).unwrap_or(0)
-    })
+    let cpu_id = get_cpu().get_cpuid() as u32;
+    crate::interrupt::InterruptManager::global()
+        .get_time(cpu_id)
+        .unwrap_or(0)
 }
 
 pub fn set_timer(_time: u64) {
-    InterruptManager::with_manager(|mgr| {
-        let cpu_id = get_cpu().get_cpuid() as u32;
-        let _ = mgr.set_timer(cpu_id, _time);
-    });
+    let cpu_id = get_cpu().get_cpuid() as u32;
+    let _ = crate::interrupt::InterruptManager::global().set_timer(cpu_id, _time);
 }
 
 pub struct ArchTimer {
@@ -33,10 +31,10 @@ pub struct ArchTimer {
 
 impl ArchTimer {
     pub fn new() -> Self {
-        let freq = InterruptManager::with_manager(|mgr| {
-            let cpu_id = get_cpu().get_cpuid() as u32;
-            mgr.get_timer_frequency_hz(cpu_id).unwrap_or(0)
-        });
+        let cpu_id = get_cpu().get_cpuid() as u32;
+        let freq = crate::interrupt::InterruptManager::global()
+            .get_timer_frequency_hz(cpu_id)
+            .unwrap_or(0);
 
         ArchTimer {
             next_event: 0,
@@ -51,17 +49,15 @@ impl ArchTimer {
     }
 
     pub fn get_time(&self) -> u64 {
-        InterruptManager::with_manager(|mgr| {
-            let cpu_id = get_cpu().get_cpuid() as u32;
-            mgr.get_time(cpu_id).unwrap_or(0)
-        })
+        let cpu_id = get_cpu().get_cpuid() as u32;
+        crate::interrupt::InterruptManager::global()
+            .get_time(cpu_id)
+            .unwrap_or(0)
     }
 
     pub fn set_timer(&self, time: u64) {
-        InterruptManager::with_manager(|mgr| {
-            let cpu_id = get_cpu().get_cpuid() as u32;
-            let _ = mgr.set_timer(cpu_id, time);
-        });
+        let cpu_id = get_cpu().get_cpuid() as u32;
+        let _ = crate::interrupt::InterruptManager::global().set_timer(cpu_id, time);
     }
 
     pub fn start(&mut self) {
@@ -103,10 +99,8 @@ impl ArchTimer {
 
         let _ = interrupt::disable_arch_timer_interrupt();
 
-        InterruptManager::with_manager(|mgr| {
-            let cpu_id = get_cpu().get_cpuid() as u32;
-            let _ = mgr.set_timer(cpu_id, u64::MAX);
-        });
+        let cpu_id = get_cpu().get_cpuid() as u32;
+        let _ = crate::interrupt::InterruptManager::global().set_timer(cpu_id, u64::MAX);
     }
 
     pub fn set_interval_us(&mut self, interval_us: u64) {

--- a/kernel/src/arch/aarch64/trap/exception.rs
+++ b/kernel/src/arch/aarch64/trap/exception.rs
@@ -26,6 +26,16 @@ fn current_el_number() -> u64 {
     (get_current_el() >> 2) & 0x3
 }
 
+fn get_hcr_el2() -> u64 {
+    if current_el_number() != 2 {
+        return 0;
+    }
+
+    let val: u64;
+    unsafe { asm!("mrs {}, hcr_el2", out(reg) val) };
+    val
+}
+
 /// Get DAIF value
 fn get_daif() -> u64 {
     let val: u64;
@@ -208,12 +218,16 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, trap_kind: usize) {
             print_trap_info(trapframe, esr);
 
             crate::println!(
-                "[trap] unhandled exception: kind={}({}) ESR={:#x} FAR={:#x} ELR={:#x}",
+                "[trap] unhandled exception: kind={}({}) ESR={:#x} FAR={:#x} ELR={:#x} CurrentEL=EL{} SPSR={:#x} DAIF={:#x} HCR_EL2={:#x}",
                 trap_kind,
                 kind_str,
                 esr,
                 get_far_el1(),
                 trapframe.elr,
+                current_el_number(),
+                trapframe.spsr,
+                get_daif(),
+                get_hcr_el2(),
             );
 
             loop {

--- a/kernel/src/arch/aarch64/trap/exception.rs
+++ b/kernel/src/arch/aarch64/trap/exception.rs
@@ -5,6 +5,7 @@
 
 use core::arch::asm;
 use core::panic;
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use crate::abi::syscall_dispatcher;
 use crate::arch::{Trapframe, get_cpu};
@@ -12,6 +13,10 @@ use crate::object::capability::memory_mapping::{AccessKind, AccessOp};
 use crate::sched::scheduler::current_task;
 use crate::task::mytask;
 use crate::{early_println, println};
+
+static LAST_FAULT_FAR: AtomicU64 = AtomicU64::new(usize::MAX as u64);
+static LAST_FAULT_PC: AtomicU64 = AtomicU64::new(usize::MAX as u64);
+static LAST_FAULT_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Get CurrentEL value
 fn get_current_el() -> u64 {
@@ -262,6 +267,7 @@ fn handle_instruction_fault(trapframe: &mut Trapframe, vaddr: usize) {
 /// Handle data page fault (like RISC-V cause 13/15)
 fn handle_data_fault(trapframe: &mut Trapframe, vaddr: usize, is_write: bool) {
     let task = current_task(get_cpu().get_cpuid()).unwrap();
+    let pc = trapframe.get_current_pc();
 
     let op = if is_write {
         AccessOp::Store
@@ -278,6 +284,49 @@ fn handle_data_fault(trapframe: &mut Trapframe, vaddr: usize, is_write: bool) {
     // Get ESR to determine fault type
     let esr = get_esr_el1();
     let dfsc = esr & 0x3f; // Data Fault Status Code (bits 5:0)
+    let prev_far = LAST_FAULT_FAR.load(Ordering::Relaxed);
+    let prev_pc = LAST_FAULT_PC.load(Ordering::Relaxed);
+
+    if prev_far == vaddr as u64 && prev_pc == pc as u64 {
+        let repeat = LAST_FAULT_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+        if repeat <= 3 {
+            early_println!(
+                "[DF] repeat FAR={:#x} PC={:#x} DFSC={:#x} write={} pid={} task={}",
+                vaddr,
+                pc,
+                dfsc,
+                is_write,
+                task.get_id(),
+                task.name.read(),
+            );
+        }
+    } else {
+        LAST_FAULT_FAR.store(vaddr as u64, Ordering::Relaxed);
+        LAST_FAULT_PC.store(pc as u64, Ordering::Relaxed);
+        LAST_FAULT_COUNT.store(1, Ordering::Relaxed);
+        early_println!(
+            "[DF] fault FAR={:#x} PC={:#x} ESR={:#x} DFSC={:#x} write={} pid={} task={}",
+            vaddr,
+            pc,
+            esr,
+            dfsc,
+            is_write,
+            task.get_id(),
+            task.name.read(),
+        );
+        match task.vm_manager.search_memory_map(vaddr) {
+            Some(map) => early_println!(
+                "[DF] map=[{:#x}..{:#x}] perms={:#x} vm_start={:#x} shared={} owner={}",
+                map.vmarea.start,
+                map.vmarea.end,
+                map.permissions,
+                map.vm_start,
+                map.is_shared,
+                map.owner.is_some(),
+            ),
+            None => early_println!("[DF] no mapping for FAR={:#x}", vaddr),
+        }
+    }
 
     // Debug permission faults
     if dfsc >= 0x0d && dfsc <= 0x0f {
@@ -285,7 +334,7 @@ fn handle_data_fault(trapframe: &mut Trapframe, vaddr: usize, is_write: bool) {
             "[PF] PERMISSION FAULT: vaddr={:#x} write={} PC={:#x} DFSC={:#x}",
             vaddr,
             is_write,
-            trapframe.get_current_pc(),
+            pc,
             dfsc
         );
         // Print current memory mapping for this address
@@ -329,14 +378,12 @@ fn handle_data_fault(trapframe: &mut Trapframe, vaddr: usize, is_write: bool) {
                     task.get_id(),
                     vaddr,
                     is_write,
-                    trapframe.get_current_pc()
+                    pc
                 );
             }
             panic!(
                 "Failed to map page for data fault at vaddr: {:#x} (write={}) from PC: {:#x}",
-                vaddr,
-                is_write,
-                trapframe.get_current_pc()
+                vaddr, is_write, pc
             );
         }
     }

--- a/kernel/src/arch/aarch64/trap/exception.rs
+++ b/kernel/src/arch/aarch64/trap/exception.rs
@@ -5,18 +5,13 @@
 
 use core::arch::asm;
 use core::panic;
-use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use crate::abi::syscall_dispatcher;
 use crate::arch::{Trapframe, get_cpu};
 use crate::object::capability::memory_mapping::{AccessKind, AccessOp};
+use crate::println;
 use crate::sched::scheduler::current_task;
 use crate::task::mytask;
-use crate::{early_println, println};
-
-static LAST_FAULT_FAR: AtomicU64 = AtomicU64::new(usize::MAX as u64);
-static LAST_FAULT_PC: AtomicU64 = AtomicU64::new(usize::MAX as u64);
-static LAST_FAULT_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Get CurrentEL value
 fn get_current_el() -> u64 {
@@ -48,13 +43,6 @@ fn get_daif() -> u64 {
     val
 }
 
-/// Get ISR_EL1 (pending interrupt status)
-fn get_isr_el1() -> u64 {
-    let val: u64;
-    unsafe { asm!("mrs {}, isr_el1", out(reg) val) };
-    val
-}
-
 /// Get ESR_EL1 value
 fn get_esr_el1() -> u64 {
     let val: u64;
@@ -66,13 +54,6 @@ fn get_esr_el1() -> u64 {
 fn get_far_el1() -> u64 {
     let val: u64;
     unsafe { asm!("mrs {}, far_el1", out(reg) val) };
-    val
-}
-
-/// Get SCTLR_EL1 value
-fn get_sctlr_el1() -> u64 {
-    let val: u64;
-    unsafe { asm!("mrs {}, sctlr_el1", out(reg) val) };
     val
 }
 
@@ -116,11 +97,8 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, trap_kind: usize) {
     // ISS layout differs by EC, but WnR(bit 6) and DFSC/IFSC(bits 5:0) are consistent
     // for abort classes.
     let iss = esr & 0x01ff_ffff;
-    let fsc = (iss & 0x3f) as u8;
-    let wnr = ((iss >> 6) & 0x1) as u8;
-
-    // Debug: log every trap using early_println
-    let sctlr = get_sctlr_el1();
+    let _fsc = (iss & 0x3f) as u8;
+    let _wnr = ((iss >> 6) & 0x1) as u8;
 
     let kind_str = match trap_kind {
         0 => "Sync",
@@ -129,28 +107,6 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, trap_kind: usize) {
         3 => "SError",
         _ => "UnknownKind",
     };
-
-    // crate::println!(
-    //     "[trap] kind={}({}) ESR={:#x} EC={:?} ISS={:#x} FSC={:#x} WnR={} FAR={:#x} ELR={:#x} SCTLR={:#x} M={} DAIF={:#x} CurrentEL={:#x}(EL{}) SPSR={:#x} SP_EL0={:#x} KernelSP={:#x} ISR_EL1={:#x}",
-    //     trap_kind,
-    //     kind_str,
-    //     esr,
-    //     ec,
-    //     iss,
-    //     fsc,
-    //     wnr,
-    //     get_far_el1(),
-    //     trapframe.elr,
-    //     sctlr,
-    //     (sctlr & 1) as u8,
-    //     get_daif(),
-    //     get_current_el(),
-    //     current_el_number(),
-    //     trapframe.spsr,
-    //     trapframe.sp,
-    //     trapframe.tpidrro_el0,
-    //     get_isr_el1(),
-    // );
 
     match ec {
         // User tried to execute FP/SIMD while EL0 access is trapped.
@@ -281,98 +237,12 @@ fn handle_data_fault(trapframe: &mut Trapframe, vaddr: usize, is_write: bool) {
         size: None,
     };
 
-    // Get ESR to determine fault type
-    let esr = get_esr_el1();
-    let dfsc = esr & 0x3f; // Data Fault Status Code (bits 5:0)
-    let prev_far = LAST_FAULT_FAR.load(Ordering::Relaxed);
-    let prev_pc = LAST_FAULT_PC.load(Ordering::Relaxed);
-
-    if prev_far == vaddr as u64 && prev_pc == pc as u64 {
-        let repeat = LAST_FAULT_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
-        if repeat <= 3 {
-            early_println!(
-                "[DF] repeat FAR={:#x} PC={:#x} DFSC={:#x} write={} pid={} task={}",
-                vaddr,
-                pc,
-                dfsc,
-                is_write,
-                task.get_id(),
-                task.name.read(),
-            );
-        }
-    } else {
-        LAST_FAULT_FAR.store(vaddr as u64, Ordering::Relaxed);
-        LAST_FAULT_PC.store(pc as u64, Ordering::Relaxed);
-        LAST_FAULT_COUNT.store(1, Ordering::Relaxed);
-        early_println!(
-            "[DF] fault FAR={:#x} PC={:#x} ESR={:#x} DFSC={:#x} write={} pid={} task={}",
-            vaddr,
-            pc,
-            esr,
-            dfsc,
-            is_write,
-            task.get_id(),
-            task.name.read(),
-        );
-        match task.vm_manager.search_memory_map(vaddr) {
-            Some(map) => early_println!(
-                "[DF] map=[{:#x}..{:#x}] perms={:#x} vm_start={:#x} shared={} owner={}",
-                map.vmarea.start,
-                map.vmarea.end,
-                map.permissions,
-                map.vm_start,
-                map.is_shared,
-                map.owner.is_some(),
-            ),
-            None => early_println!("[DF] no mapping for FAR={:#x}", vaddr),
-        }
-    }
-
-    // Debug permission faults
-    if dfsc >= 0x0d && dfsc <= 0x0f {
-        early_println!(
-            "[PF] PERMISSION FAULT: vaddr={:#x} write={} PC={:#x} DFSC={:#x}",
-            vaddr,
-            is_write,
-            pc,
-            dfsc
-        );
-        // Print current memory mapping for this address
-        if let Some(map) = task.vm_manager.search_memory_map(vaddr) {
-            early_println!(
-                "[PF] Mapping found: vmarea=[{:#x}..{:#x}] perms={:#x} (R={} W={} X={} U={})",
-                map.vmarea.start,
-                map.vmarea.end,
-                map.permissions,
-                map.permissions & 0x1 != 0,
-                map.permissions & 0x2 != 0,
-                map.permissions & 0x4 != 0,
-                map.permissions & 0x8 != 0,
-            );
-        } else {
-            early_println!("[PF] No mapping found for vaddr={:#x}", vaddr);
-        }
-        // Print instruction that caused the fault
-        early_println!(
-            "[PF] Registers: x0={:#x} x1={:#x} x2={:#x} x3={:#x}",
-            trapframe.regs.reg[0],
-            trapframe.regs.reg[1],
-            trapframe.regs.reg[2],
-            trapframe.regs.reg[3],
-        );
-
-        // Check if this is actually a TLB issue by reading back TTBR0
-        let current_ttbr0: u64;
-        unsafe { asm!("mrs {}, ttbr0_el1", out(reg) current_ttbr0) };
-        early_println!("[PF] Current TTBR0_EL1={:#x}", current_ttbr0);
-    }
-
     match task.vm_manager.lazy_map_page_with(access) {
         Ok(_) => (),
-        Err(e) => {
+        Err(_e) => {
             print_trap_info(trapframe, get_esr_el1());
             if let Some(task) = current_task(get_cpu().get_cpuid()) {
-                early_println!(
+                println!(
                     "Task {} (PID {}) caused data fault at vaddr: {:#x} (write={}) from PC: {:#x}",
                     task.name.read(),
                     task.get_id(),
@@ -396,7 +266,6 @@ fn print_trap_info(trapframe: &Trapframe, esr: u64) {
     let iss = esr & 0x1ffffff;
     let fsc = iss & 0x3f;
 
-    // NOTE: Use early_println to avoid depending on heap/locking during faults.
     crate::println!("=== Trap Info ===");
     crate::println!("ESR_EL1: {:#018x} (EC={:#x}, FSC={:#x})", esr, ec, fsc);
     crate::println!("FAR_EL1: {:#018x}", far);

--- a/kernel/src/arch/aarch64/trap/exception.rs
+++ b/kernel/src/arch/aarch64/trap/exception.rs
@@ -9,7 +9,7 @@ use core::panic;
 use crate::abi::syscall_dispatcher;
 use crate::arch::{Trapframe, get_cpu};
 use crate::object::capability::memory_mapping::{AccessKind, AccessOp};
-use crate::sched::scheduler::get_scheduler;
+use crate::sched::scheduler::current_task;
 use crate::task::mytask;
 use crate::{early_println, println};
 
@@ -143,7 +143,7 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, trap_kind: usize) {
         ExceptionClass::FpSimdAccess => {
             if crate::arch::user_fpu_enabled() {
                 let cpu_id = get_cpu().get_cpuid();
-                let task = get_scheduler().get_current_task(cpu_id).unwrap();
+                let task = current_task(cpu_id).unwrap();
                 task.vcpu.lock().fpu_used = true;
                 crate::arch::fpu::set_user_fpu_enabled(true);
                 unsafe {
@@ -225,9 +225,7 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, trap_kind: usize) {
 
 /// Handle instruction page fault (like RISC-V cause 12)
 fn handle_instruction_fault(trapframe: &mut Trapframe, vaddr: usize) {
-    let task = get_scheduler()
-        .get_current_task(get_cpu().get_cpuid())
-        .unwrap();
+    let task = current_task(get_cpu().get_cpuid()).unwrap();
 
     let access = AccessKind {
         op: AccessOp::Instruction,
@@ -249,9 +247,7 @@ fn handle_instruction_fault(trapframe: &mut Trapframe, vaddr: usize) {
 
 /// Handle data page fault (like RISC-V cause 13/15)
 fn handle_data_fault(trapframe: &mut Trapframe, vaddr: usize, is_write: bool) {
-    let task = get_scheduler()
-        .get_current_task(get_cpu().get_cpuid())
-        .unwrap();
+    let task = current_task(get_cpu().get_cpuid()).unwrap();
 
     let op = if is_write {
         AccessOp::Store
@@ -312,7 +308,7 @@ fn handle_data_fault(trapframe: &mut Trapframe, vaddr: usize, is_write: bool) {
         Ok(_) => (),
         Err(e) => {
             print_trap_info(trapframe, get_esr_el1());
-            if let Some(task) = get_scheduler().get_current_task(get_cpu().get_cpuid()) {
+            if let Some(task) = current_task(get_cpu().get_cpuid()) {
                 early_println!(
                     "Task {} (PID {}) caused data fault at vaddr: {:#x} (write={}) from PC: {:#x}",
                     task.name.read(),

--- a/kernel/src/arch/aarch64/trap/interrupt.rs
+++ b/kernel/src/arch/aarch64/trap/interrupt.rs
@@ -24,6 +24,7 @@ pub fn arch_irq_handler(trapframe: &mut Trapframe, trap_kind: usize) {
     match claimed {
         Ok(Some(interrupt_id)) => {
             if interrupt_id == RESCHEDULE_SGI {
+                crate::sched::scheduler::debug_log_reschedule_ipi(cpu_id as usize, false, true);
                 crate::sched::scheduler::schedule(trapframe);
                 ran_scheduler = true;
             } else if interrupt_id == crate::drivers::pic::arm_generic_timer::timer_ppi_irq() {

--- a/kernel/src/arch/aarch64/trap/interrupt.rs
+++ b/kernel/src/arch/aarch64/trap/interrupt.rs
@@ -21,7 +21,7 @@ pub fn arch_irq_handler(trapframe: &mut Trapframe, trap_kind: usize) {
 
     match claimed {
         Ok(Some(interrupt_id)) => {
-            if interrupt_id == crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ {
+            if interrupt_id == crate::drivers::pic::arm_generic_timer::timer_ppi_irq() {
                 crate::timer::tick(trapframe);
             }
         }

--- a/kernel/src/arch/aarch64/trap/interrupt.rs
+++ b/kernel/src/arch/aarch64/trap/interrupt.rs
@@ -1,7 +1,6 @@
 //! AArch64 interrupt trap handling
 
 use crate::arch::{Trapframe, get_cpu};
-use crate::interrupt::InterruptManager;
 
 /// Handle an IRQ taken at EL1.
 ///
@@ -17,7 +16,7 @@ pub fn arch_irq_handler(trapframe: &mut Trapframe, trap_kind: usize) {
     }
 
     let claimed =
-        InterruptManager::with_manager(|mgr| mgr.claim_and_handle_external_interrupt(cpu_id));
+        crate::interrupt::InterruptManager::global().claim_and_handle_external_interrupt(cpu_id);
 
     match claimed {
         Ok(Some(interrupt_id)) => {

--- a/kernel/src/arch/aarch64/trap/interrupt.rs
+++ b/kernel/src/arch/aarch64/trap/interrupt.rs
@@ -2,6 +2,8 @@
 
 use crate::arch::{Trapframe, get_cpu};
 
+const RESCHEDULE_SGI: u32 = 0;
+
 /// Handle an IRQ taken at EL1.
 ///
 /// On QEMU virt (GICv2), the virtual timer arrives as a PPI (typically ID 27).
@@ -9,6 +11,7 @@ use crate::arch::{Trapframe, get_cpu};
 /// kernel still needs to run the timer tick logic to advance scheduling.
 pub fn arch_irq_handler(trapframe: &mut Trapframe, trap_kind: usize) {
     let cpu_id = get_cpu().get_cpuid() as u32;
+    let mut ran_scheduler = false;
 
     if trap_kind == 2 && crate::arch::interrupt::is_arch_timer_pending() {
         crate::timer::tick(trapframe);
@@ -20,13 +23,18 @@ pub fn arch_irq_handler(trapframe: &mut Trapframe, trap_kind: usize) {
 
     match claimed {
         Ok(Some(interrupt_id)) => {
-            if interrupt_id == crate::drivers::pic::arm_generic_timer::timer_ppi_irq() {
+            if interrupt_id == RESCHEDULE_SGI {
+                crate::sched::scheduler::schedule(trapframe);
+                ran_scheduler = true;
+            } else if interrupt_id == crate::drivers::pic::arm_generic_timer::timer_ppi_irq() {
                 crate::timer::tick(trapframe);
+                ran_scheduler = true;
             }
         }
         Ok(None) => {
             if crate::arch::interrupt::is_arch_timer_pending() {
                 crate::timer::tick(trapframe);
+                ran_scheduler = true;
             }
         }
         Err(e) => {
@@ -35,5 +43,13 @@ pub fn arch_irq_handler(trapframe: &mut Trapframe, trap_kind: usize) {
                 e
             );
         }
+    }
+
+    let cpu_id = cpu_id as usize;
+    if !ran_scheduler
+        && crate::sched::scheduler::current_task_is_idle(cpu_id)
+        && crate::sched::scheduler::has_ready_tasks(cpu_id)
+    {
+        crate::sched::scheduler::schedule(trapframe);
     }
 }

--- a/kernel/src/arch/aarch64/trap/kernel.rs
+++ b/kernel/src/arch/aarch64/trap/kernel.rs
@@ -72,7 +72,7 @@ pub extern "C" fn _kernel_trap_entry() {
         30: // Sync
             msr daifset, #0xf       // Mask interrupts
             mov x20, sp             // Capture current SP (SP_EL1)
-            sub sp, sp, #288        // Alloc Trapframe
+            sub sp, sp, #304        // Alloc Trapframe
             stp x0, x1, [sp, #0]    // Save x0, x1 first
             mov x1, #0              // x1 (Arg2) = Kind: Sync
             b   40f
@@ -80,7 +80,7 @@ pub extern "C" fn _kernel_trap_entry() {
         31: // IRQ
             msr daifset, #0xf
             mov x20, sp             // Capture current SP (SP_EL1)
-            sub sp, sp, #288
+            sub sp, sp, #304
             stp x0, x1, [sp, #0]
             mov x1, #1              // x1 (Arg2) = Kind: IRQ
             b   40f
@@ -88,7 +88,7 @@ pub extern "C" fn _kernel_trap_entry() {
         32: // FIQ
             msr daifset, #0xf
             mov x20, sp             // Capture current SP (SP_EL1)
-            sub sp, sp, #288
+            sub sp, sp, #304
             stp x0, x1, [sp, #0]
             mov x1, #2              // x1 (Arg2) = Kind: FIQ
             b   40f
@@ -96,7 +96,7 @@ pub extern "C" fn _kernel_trap_entry() {
         33: // SError
             msr daifset, #0xf
             mov x20, sp             // Capture current SP (SP_EL1)
-            sub sp, sp, #288
+            sub sp, sp, #304
             stp x0, x1, [sp, #0]
             mov x1, #3              // x1 (Arg2) = Kind: SError
             b   40f
@@ -133,6 +133,8 @@ pub extern "C" fn _kernel_trap_entry() {
             str x19, [sp, #248]
             mrs x19, spsr_el1
             str x19, [sp, #264]
+            mrs x19, esr_el1
+            str x19, [sp, #288]
 
             // Call Rust Handler
             // fn arch_kernel_trap_handler(tf: &mut Trapframe, kind: usize)
@@ -174,7 +176,7 @@ pub extern "C" fn _kernel_trap_entry() {
 
             // Restore x0, x1 and Free Stack
             ldp x0, x1, [sp, #0]
-            add sp, sp, #288
+            add sp, sp, #304
 
             eret
         "#

--- a/kernel/src/arch/aarch64/trap/user.rs
+++ b/kernel/src/arch/aarch64/trap/user.rs
@@ -13,7 +13,7 @@ use core::arch::{asm, naked_asm};
 
 use super::exception::arch_exception_handler;
 use super::interrupt::arch_irq_handler;
-use crate::arch::{Trapframe, get_kernel_trapvector_paddr, set_arch, set_trapvector};
+use crate::arch::{Trapframe, get_kernel_trapvector_paddr, set_trapvector};
 use crate::vm::get_trampoline_trap_vector;
 
 #[unsafe(export_name = "aarch64_first_switch_to_user_naked")]
@@ -160,8 +160,8 @@ pub extern "C" fn _user_trap_entry() {
             msr ttbr0_el1, x11 // Switch to kernel TTBR
 
             isb
-            tlbi vmalle1is
-            dsb ish
+            tlbi vmalle1
+            dsb nsh
             isb
 
             // 3. Call Handler
@@ -209,8 +209,8 @@ pub extern "C" fn _switch_to_user(_trapframe: &mut Trapframe) -> ! {
         ldr x9, [x10, #16]  // user ttbr0
         msr ttbr0_el1, x9   // Switch to user TTBR
         isb
-        tlbi vmalle1is
-        dsb ish
+        tlbi vmalle1
+        dsb nsh
         isb
         b   3f
 

--- a/kernel/src/arch/aarch64/trap/user.rs
+++ b/kernel/src/arch/aarch64/trap/user.rs
@@ -196,7 +196,15 @@ pub extern "C" fn _switch_to_user(_trapframe: &mut Trapframe) -> ! {
         //   280:    tpidrro_el0 (read-only at EL0)
         //   288:    esr_el1 (not restore)
 
-        // Switch TTBR back to user
+        // Check SPSR mode bits [3:0] to decide TTBR switch
+        ldr x9, [sp, #264]  // Load Trapframe.spsr
+        and x9, x9, #0xF    // Extract mode bits
+        cmp x9, #0x5        // EL1h?
+        b.eq 2f             // Skip TTBR switch for kernel tasks
+        cmp x9, #0x9        // EL2h?
+        b.eq 2f             // Skip TTBR switch for VHE host kernel tasks
+
+        // --- User task path: switch TTBR back to user ---
         mrs x10, tpidr_el1 // x10 = CPU struct ptr
         ldr x9, [x10, #16]  // user ttbr0
         msr ttbr0_el1, x9   // Switch to user TTBR
@@ -204,17 +212,20 @@ pub extern "C" fn _switch_to_user(_trapframe: &mut Trapframe) -> ! {
         tlbi vmalle1is
         dsb ish
         isb
+        b   3f
 
-        // Restore user SP/PC/SPSR
+        2: // --- Kernel task path: no TTBR switch needed ---
+
+        3:
+        // Restore SP/PC/SPSR
         ldr x9, [sp, #248]  // Load Trapframe.sp
-        msr sp_el0, x9    // Restore user SP
-        ldr x9, [sp, #256]   // Load Trapframe.epc
-        msr elr_el1, x9     // Restore user PC
+        msr sp_el0, x9      // Restore SP_EL0
+        ldr x9, [sp, #256]  // Load Trapframe.epc
+        msr elr_el1, x9     // Restore ELR_EL1
         ldr x9, [sp, #264]  // Load Trapframe.spsr
-        msr spsr_el1, x9
-    
+        msr spsr_el1, x9    // Restore SPSR_EL1
 
-        // Restore user TLS
+        // Restore TLS
         ldr x9, [sp, #272]
         msr tpidr_el0, x9
         ldr x9, [sp, #280]
@@ -263,7 +274,17 @@ pub fn arch_switch_to_user(trapframe: &mut Trapframe) -> ! {
         .wrapping_sub(_user_trap_entry as *const () as usize);
     let trampoline_base = get_trampoline_trap_vector();
     let trap_exit_addr = trampoline_base.wrapping_add(trap_exit_offset);
-    set_trapvector(trampoline_base);
+
+    // Determine VBAR based on target EL:
+    // - EL0 (user task): trampoline vector (handles Lower EL traps)
+    // - EL1 (kernel task like idle): kernel vector (handles Current EL traps)
+    if crate::arch::is_privileged_return_mode(trapframe.spsr) {
+        // EL1h/EL2h — kernel task: use kernel vector so privileged traps are handled
+        set_trapvector(get_kernel_trapvector_paddr());
+    } else {
+        // EL0t — user task: use trampoline vector
+        set_trapvector(trampoline_base);
+    }
 
     unsafe {
         asm!(

--- a/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
+++ b/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
@@ -19,6 +19,15 @@ use crate::vm::vmem::VirtualMemoryPermission;
 const SCARLET_MAIR_EL1: u64 = 0x44ff00;
 const SCARLET_TCR_EL1: u64 = 0x1_B510_3510;
 const SCTLR_EL1_ENABLE_MASK: u64 = 1 | (1 << 2) | (1 << 12);
+/// Bits we always clear in SCTLR_EL1 when (re)enabling the MMU.
+///
+/// - bit 1 (A): Strict alignment check for all data accesses. We must keep
+///   this DISABLED so that unaligned loads/stores to Normal memory (e.g.
+///   SIMD `ldr q0, [x8]` from a non-16B-aligned address) do not raise
+///   alignment faults (DFSC=0x21). Limine may leave this set, so we clear it
+///   explicitly. SP-alignment checks (SA/SA0, bits 3/4) are intentionally
+///   left untouched.
+const SCTLR_EL1_DISABLE_MASK: u64 = 1 << 1;
 const DEBUG_DEVICE_FAULT_VA: usize = 0xffff_0008_3afd_b000;
 
 /// Maximum paging levels for AArch64 4KB granule (4 levels: 0-3)
@@ -309,9 +318,6 @@ impl PageTable {
     pub fn switch(&self, asid: u16) {
         let ttbr_val = self.get_val_for_ttbr(asid);
 
-        // Remember kernel TTBR for trampoline
-        crate::arch::aarch64::get_cpu().set_kernel_ttbr0(ttbr_val);
-
         unsafe {
             let mut sctlr: u64;
             asm!("mrs {sctlr}, sctlr_el1", sctlr = out(reg) sctlr, options(nostack));
@@ -326,6 +332,7 @@ impl PageTable {
                     "dsb nsh",
                     "isb",
                     "mrs {tmp}, sctlr_el1",
+                    "bic {tmp}, {tmp}, {sctlr_clear}",
                     "orr {tmp}, {tmp}, {sctlr_flags}",
                     "msr sctlr_el1, {tmp}",
                     "dsb sy",
@@ -334,6 +341,7 @@ impl PageTable {
                     tcr = in(reg) SCARLET_TCR_EL1,
                     ttbr = in(reg) ttbr_val,
                     sctlr_flags = in(reg) SCTLR_EL1_ENABLE_MASK,
+                    sctlr_clear = in(reg) SCTLR_EL1_DISABLE_MASK,
                     tmp = lateout(reg) _,
                     options(nostack),
                 );
@@ -369,7 +377,6 @@ impl PageTable {
 
     pub fn switch_for_boot(&self, asid: u16) {
         let ttbr_val = self.get_val_for_ttbr(asid);
-        crate::arch::aarch64::get_cpu().set_kernel_ttbr0(ttbr_val);
         unsafe {
             asm!(
                 "msr mair_el1, {mair}",
@@ -832,6 +839,7 @@ pub fn init_mmu_registers() {
             "msr tcr_el1, {tcr}",
             "isb",
             "mrs {tmp}, sctlr_el1",
+            "bic {tmp}, {tmp}, {sctlr_clear}",
             "orr {tmp}, {tmp}, {sctlr_flags}",
             "msr sctlr_el1, {tmp}",
             "dsb sy",
@@ -839,6 +847,7 @@ pub fn init_mmu_registers() {
             mair = in(reg) SCARLET_MAIR_EL1,
             tcr = in(reg) SCARLET_TCR_EL1,
             sctlr_flags = in(reg) SCTLR_EL1_ENABLE_MASK,
+            sctlr_clear = in(reg) SCTLR_EL1_DISABLE_MASK,
             tmp = lateout(reg) _,
             options(nostack),
         );
@@ -863,7 +872,9 @@ pub fn sync_el1_translation_registers_if_needed() {
             options(nostack),
         );
 
-        if mair == SCARLET_MAIR_EL1 && tcr == SCARLET_TCR_EL1 {
+        let alignment_check_enabled = (sctlr & SCTLR_EL1_DISABLE_MASK) != 0;
+
+        if mair == SCARLET_MAIR_EL1 && tcr == SCARLET_TCR_EL1 && !alignment_check_enabled {
             return;
         }
 
@@ -871,11 +882,17 @@ pub fn sync_el1_translation_registers_if_needed() {
             "msr mair_el1, {mair}",
             "msr tcr_el1, {tcr}",
             "isb",
+            "mrs {tmp}, sctlr_el1",
+            "bic {tmp}, {tmp}, {sctlr_clear}",
+            "msr sctlr_el1, {tmp}",
+            "isb",
             "tlbi vmalle1",
             "dsb nsh",
             "isb",
             mair = in(reg) SCARLET_MAIR_EL1,
             tcr = in(reg) SCARLET_TCR_EL1,
+            sctlr_clear = in(reg) SCTLR_EL1_DISABLE_MASK,
+            tmp = lateout(reg) _,
             options(nostack),
         );
     }

--- a/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
+++ b/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
@@ -322,8 +322,8 @@ impl PageTable {
                     "isb",
                     "msr ttbr0_el1, {ttbr}",
                     "isb",
-                    "tlbi vmalle1is",
-                    "dsb ish",
+                    "tlbi vmalle1",
+                    "dsb nsh",
                     "isb",
                     "mrs {tmp}, sctlr_el1",
                     "orr {tmp}, {tmp}, {sctlr_flags}",
@@ -341,8 +341,8 @@ impl PageTable {
                 asm!(
                     "msr ttbr0_el1, {ttbr}",
                     "isb",
-                    "tlbi vmalle1is",
-                    "dsb ish",
+                    "tlbi vmalle1",
+                    "dsb nsh",
                     "isb",
                     ttbr = in(reg) ttbr_val,
                     options(nostack),
@@ -358,8 +358,8 @@ impl PageTable {
             asm!(
                 "msr ttbr1_el1, {ttbr}",
                 "isb",
-                "tlbi vmalle1is",
-                "dsb ish",
+                "tlbi vmalle1",
+                "dsb nsh",
                 "isb",
                 ttbr = in(reg) ttbr_val,
                 options(nostack),
@@ -379,8 +379,8 @@ impl PageTable {
                 "msr ttbr1_el1, {ttbr}",
                 "msr ttbr0_el1, {ttbr}",
                 "isb",
-                "tlbi vmalle1is",
-                "dsb ish",
+                "tlbi vmalle1",
+                "dsb nsh",
                 "isb",
                 mair = in(reg) SCARLET_MAIR_EL1,
                 tcr = in(reg) SCARLET_TCR_EL1,
@@ -447,6 +447,9 @@ impl PageTable {
             }
         }
 
+        // Batched local TLB invalidation for all new mappings.
+        unsafe { asm!("dsb nsh", "tlbi vmalle1", "dsb nsh", "isb") };
+
         Ok(())
     }
 
@@ -472,6 +475,9 @@ impl PageTable {
 
         self.try_map_at_level(asid, vaddr, paddr, MapAttrs { permissions }, 0)
             .expect("map: couldn't install a 4 KiB leaf mapping");
+
+        // Local TLB invalidation for new mapping (no stale entries on other CPUs).
+        unsafe { asm!("dsb nsh", "tlbi vmalle1", "dsb nsh", "isb") };
     }
 
     /// Attempts to install a leaf mapping at the specified logical level.
@@ -510,8 +516,7 @@ impl PageTable {
             core::mem::size_of::<PageTableEntry>(),
         );
 
-        // TLB invalidate (like RISC-V's sfence.vma)
-        unsafe { asm!("dsb ish", "tlbi vmalle1is", "dsb ish", "isb") };
+        // TLB invalidation is deferred to the caller for batching.
         Ok(())
     }
 
@@ -866,8 +871,8 @@ pub fn sync_el1_translation_registers_if_needed() {
             "msr mair_el1, {mair}",
             "msr tcr_el1, {tcr}",
             "isb",
-            "tlbi vmalle1is",
-            "dsb ish",
+            "tlbi vmalle1",
+            "dsb nsh",
             "isb",
             mair = in(reg) SCARLET_MAIR_EL1,
             tcr = in(reg) SCARLET_TCR_EL1,

--- a/kernel/src/arch/aarch64/vm/mod.rs
+++ b/kernel/src/arch/aarch64/vm/mod.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use alloc::{boxed::Box, vec};
+use core::sync::atomic::{AtomicU64, Ordering};
 use hashbrown::HashMap;
 use mmu::PageTable;
 use spin::Once;
@@ -23,6 +24,42 @@ use crate::environment::{KERNEL_KSTACK_REGION_END, KERNEL_KSTACK_REGION_START, T
 use crate::vm::addr::kernel_virt_to_phys;
 use crate::vm::manager::VirtualMemoryManager;
 use crate::vm::vmem::{MemoryArea, VirtualMemoryMap, VirtualMemoryPermission};
+
+static KERNEL_TTBR0: AtomicU64 = AtomicU64::new(0);
+static KERNEL_TTBR1: AtomicU64 = AtomicU64::new(0);
+
+pub fn save_kernel_page_table() {
+    let ttbr0: u64;
+    let ttbr1: u64;
+    unsafe {
+        core::arch::asm!(
+            "mrs {}, ttbr0_el1",
+            "mrs {}, ttbr1_el1",
+            out(reg) ttbr0,
+            out(reg) ttbr1,
+        );
+    }
+    KERNEL_TTBR0.store(ttbr0, Ordering::Release);
+    KERNEL_TTBR1.store(ttbr1, Ordering::Release);
+}
+
+pub fn switch_to_kernel_page_table() {
+    let ttbr0 = KERNEL_TTBR0.load(Ordering::Acquire);
+    let ttbr1 = KERNEL_TTBR1.load(Ordering::Acquire);
+    assert!(ttbr0 != 0, "kernel page table not initialized");
+    assert!(ttbr1 != 0, "kernel TTBR1 not initialized");
+    unsafe {
+        core::arch::asm!(
+            "msr ttbr0_el1, {}",
+            "msr ttbr1_el1, {}",
+            "tlbi vmalle1",
+            "dsb nsh",
+            "isb",
+            in(reg) ttbr0,
+            in(reg) ttbr1,
+        );
+    }
+}
 
 unsafe extern "C" {
     static __TRAMPOLINE_START: usize;

--- a/kernel/src/arch/aarch64/vm/mod.rs
+++ b/kernel/src/arch/aarch64/vm/mod.rs
@@ -41,6 +41,13 @@ pub fn save_kernel_page_table() {
     }
     KERNEL_TTBR0.store(ttbr0, Ordering::Release);
     KERNEL_TTBR1.store(ttbr1, Ordering::Release);
+    get_cpu().set_kernel_ttbr0(ttbr0);
+}
+
+pub fn sync_saved_kernel_ttbr0_for_current_cpu() {
+    let ttbr0 = KERNEL_TTBR0.load(Ordering::Acquire);
+    assert!(ttbr0 != 0, "kernel TTBR0 not initialized");
+    get_cpu().set_kernel_ttbr0(ttbr0);
 }
 
 pub fn switch_to_kernel_page_table() {
@@ -48,6 +55,7 @@ pub fn switch_to_kernel_page_table() {
     let ttbr1 = KERNEL_TTBR1.load(Ordering::Acquire);
     assert!(ttbr0 != 0, "kernel page table not initialized");
     assert!(ttbr1 != 0, "kernel TTBR1 not initialized");
+    mmu::sync_el1_translation_registers_if_needed();
     unsafe {
         core::arch::asm!(
             "msr ttbr0_el1, {}",

--- a/kernel/src/arch/aarch64/vm/mod.rs
+++ b/kernel/src/arch/aarch64/vm/mod.rs
@@ -371,6 +371,22 @@ pub fn setup_trampoline_for_kernel(manager: &VirtualMemoryManager) {
 /// Per-task TTBR0 page tables should not pre-map the trampoline.
 pub fn setup_trampoline_for_user(_manager: &VirtualMemoryManager) {}
 
+pub fn register_trampoline_for_ap() {
+    let trampoline_start =
+        kernel_virt_to_phys(unsafe { &__TRAMPOLINE_START as *const usize as usize });
+    let trampoline_end =
+        kernel_virt_to_phys(unsafe { &__TRAMPOLINE_END as *const usize as usize }) - 1;
+    let trampoline_size = trampoline_end - trampoline_start;
+
+    let arch = get_cpu().as_paddr_cpu();
+    let trampoline_vaddr_start = TRAMPOLINE_VA_END - trampoline_size;
+    let arch_paddr = kernel_virt_to_phys(arch as *const Arch as usize);
+    let arch_offset = arch_paddr - trampoline_start;
+    let arch_vaddr = trampoline_vaddr_start + arch_offset;
+
+    crate::vm::set_trampoline_arch(arch.get_cpuid(), arch_vaddr);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/src/arch/riscv64/boot/limine.rs
+++ b/kernel/src/arch/riscv64/boot/limine.rs
@@ -126,7 +126,7 @@ pub fn limine_entry() -> ! {
 
     crate::arch::init_user_context_from_fdt();
     bootstrap_aps();
-    crate::arch::riscv64::boot::init_boot_cpu(bootinfo.cpu_id);
+    crate::arch::riscv64::boot::init_cpu(bootinfo.cpu_id);
 
     unsafe {
         let stack_top = (&raw const KERNEL_STACK) as *const _ as usize + STACK_SIZE;

--- a/kernel/src/arch/riscv64/boot/limine.rs
+++ b/kernel/src/arch/riscv64/boot/limine.rs
@@ -1,17 +1,17 @@
-use crate::environment::STACK_SIZE;
-
-use limine::paging;
-use limine::request::{BspHartidRequest, PagingModeRequest};
+use limine::mp::MpInfo;
 
 use crate::boot::limine::{
     DTB_REQUEST, EXECUTABLE_ADDRESS_REQUEST, HHDM_REQUEST, MEMMAP_REQUEST, MODULE_REQUEST,
-    ensure_base_revision_supported, hhdm_physical_span, module_area, reserve_front, response,
-    select_usable_region,
+    MP_REQUEST, ensure_base_revision_supported, hhdm_physical_span, module_area, reserve_front,
+    response, select_usable_region,
 };
 use crate::device::fdt::{FdtManager, init_fdt, relocate_fdt};
+use crate::environment::STACK_SIZE;
 use crate::mem::{KERNEL_STACK, init_bss};
 use crate::vm::addr::{init_boot_direct_map_range, init_limine_addressing, phys_to_virt};
-use crate::{BootInfo, DeviceSource, start_kernel};
+use crate::{BootInfo, DeviceSource, early_println, start_ap, start_kernel, wait_for_ap_release};
+use limine::paging;
+use limine::request::{BspHartidRequest, PagingModeRequest};
 
 static mut EARLY_BOOTINFO: Option<BootInfo> = None;
 
@@ -26,6 +26,40 @@ static PAGING_MODE_REQUEST: PagingModeRequest = PagingModeRequest::new(
     paging::PagingMode::RISCV_SV48,
     paging::PagingMode::RISCV_SV48,
 );
+
+unsafe extern "C" fn limine_ap_entry(info: &MpInfo) -> ! {
+    wait_for_ap_release();
+    start_ap(info.hartid as usize)
+}
+
+fn start_secondary_cpus() {
+    crate::release_aps();
+}
+
+fn bootstrap_aps() {
+    let mp_resp = match MP_REQUEST.response() {
+        Some(resp) => resp,
+        None => {
+            early_println!("[riscv64] No Limine MP response, single-CPU mode");
+            return;
+        }
+    };
+
+    let bsp_hartid = mp_resp.bsp_hartid;
+    early_println!(
+        "[riscv64] BSP hart={}, {} CPU(s) detected by Limine",
+        bsp_hartid,
+        mp_resp.cpus().len()
+    );
+
+    for cpu in mp_resp.cpus() {
+        if cpu.hartid == bsp_hartid {
+            continue;
+        }
+        early_println!("[riscv64] Bootstrapping hart {}...", cpu.hartid);
+        cpu.bootstrap(limine_ap_entry, cpu.hartid);
+    }
+}
 
 #[unsafe(no_mangle)]
 pub fn limine_entry() -> ! {
@@ -86,10 +120,12 @@ pub fn limine_entry() -> ! {
         hhdm_offset,
         cmdline,
         DeviceSource::Fdt(relocated_fdt_paddr),
-        None, // RISC-V uses SBI debug console, not framebuffer
+        None,
+        Some(start_secondary_cpus),
     );
 
     crate::arch::init_user_context_from_fdt();
+    bootstrap_aps();
     crate::arch::riscv64::boot::init_boot_cpu(bootinfo.cpu_id);
 
     unsafe {

--- a/kernel/src/arch/riscv64/boot/mod.rs
+++ b/kernel/src/arch/riscv64/boot/mod.rs
@@ -16,9 +16,10 @@ use crate::{
     mem::KERNEL_STACK,
 };
 
-pub fn init_boot_cpu(cpu_id: usize) {
+pub fn init_cpu(cpu_id: usize) {
     early_println!("[riscv64] init_boot_cpu: cpu_id={}", cpu_id);
     let riscv = unsafe { &mut *(&raw mut CPUS[cpu_id]) };
+    riscv.hartid = cpu_id as u64;
     early_println!(
         "[riscv64] init_boot_cpu: cpu struct={:#x}",
         riscv as *mut _ as usize

--- a/kernel/src/arch/riscv64/boot/mod.rs
+++ b/kernel/src/arch/riscv64/boot/mod.rs
@@ -17,15 +17,15 @@ use crate::{
 };
 
 pub fn init_cpu(cpu_id: usize) {
-    early_println!("[riscv64] init_boot_cpu: cpu_id={}", cpu_id);
+    early_println!("[riscv64] init_cpu: cpu_id={}", cpu_id);
     let riscv = unsafe { &mut *(&raw mut CPUS[cpu_id]) };
     riscv.hartid = cpu_id as u64;
     early_println!(
-        "[riscv64] init_boot_cpu: cpu struct={:#x}",
+        "[riscv64] init_cpu: cpu struct={:#x}",
         riscv as *mut _ as usize
     );
     trap_init(riscv);
-    early_println!("[riscv64] init_boot_cpu: done");
+    early_println!("[riscv64] init_cpu: done");
 }
 
 #[allow(static_mut_refs)]

--- a/kernel/src/arch/riscv64/instruction/mod.rs
+++ b/kernel/src/arch/riscv64/instruction/mod.rs
@@ -4,6 +4,7 @@ pub mod sbi;
 
 pub fn idle() -> ! {
     loop {
+        crate::arch::interrupt::enable_interrupts();
         unsafe {
             asm!("wfi", options(nostack));
         }

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -44,6 +44,13 @@ use crate::vm::vmem::MemoryArea;
 
 pub type Arch = Riscv64;
 
+/// Per-CPU initialization for secondary CPUs.
+///
+/// Configures trap vectors, FPU, and vector extension for the given hart.
+pub fn init_ap_cpu(cpu_id: usize) {
+    boot::init_boot_cpu(cpu_id);
+}
+
 /// Per-hart ownership of the live Vector register file.
 ///
 /// When a task that used the V extension is rescheduled on the same hart, we can

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -123,7 +123,8 @@ pub fn configure_user_entry(_trapframe: &mut Trapframe, options: crate::arch::Us
         let Some(current_task_id) = crate::sched::scheduler::current_task_id(cpu_id) else {
             return;
         };
-        let Some(current_task_ptr) = get_task_by_id(current_task_id).map(|t| t as *mut Task) else {
+        let Some(current_task_ptr) = get_task_by_id(current_task_id).map(|t| t as *const Task)
+        else {
             return;
         };
 
@@ -131,7 +132,7 @@ pub fn configure_user_entry(_trapframe: &mut Trapframe, options: crate::arch::Us
         let owner_dirty = get_vector_owner_dirty(cpu_id);
         let owner_task_ptr =
             if owner_dirty && owner_id != NO_VECTOR_OWNER && owner_id != current_task_id {
-                get_task_by_id(owner_id).map(|t| t as *mut Task)
+                get_task_by_id(owner_id).map(|t| t as *const Task)
             } else {
                 None
             };
@@ -145,7 +146,7 @@ pub fn configure_user_entry(_trapframe: &mut Trapframe, options: crate::arch::Us
         )
     };
 
-    let task = unsafe { &mut *current_task_ptr };
+    let task = unsafe { &*current_task_ptr };
 
     if !crate::arch::user_fpu_enabled() || !task.vcpu.lock().fpu_used {
         crate::arch::riscv64::fpu::disable_fpu();
@@ -167,7 +168,7 @@ pub fn configure_user_entry(_trapframe: &mut Trapframe, options: crate::arch::Us
     // been saved, save it now before we clobber vregs with our restore.
     if owner_dirty && owner_id != NO_VECTOR_OWNER && owner_id != current_task_id {
         if let Some(owner_ptr) = owner_task_ptr {
-            let owner_task = unsafe { &mut *owner_ptr };
+            let owner_task = unsafe { &*owner_ptr };
             if owner_task.vcpu.lock().vector.is_none() {
                 owner_task.vcpu.lock().vector = Some(alloc::boxed::Box::new(
                     crate::arch::riscv64::fpu::VectorContext::new(),
@@ -205,7 +206,7 @@ pub fn configure_user_entry(_trapframe: &mut Trapframe, options: crate::arch::Us
 /// This avoids bootstrapping the first user entry via a timer IRQ.
 /// The function prepares trampoline-visible per-CPU state and then
 /// jumps to the trampoline exit path which performs `sret` into user mode.
-pub fn first_switch_to_user(task: &mut Task) -> ! {
+pub fn first_switch_to_user(task: &Task) -> ! {
     // Prefer the high-VA kernel stack window if available.
     let kernel_sp = if let Some((_slot, base)) = task.get_kernel_stack_window_base() {
         (base + crate::environment::PAGE_SIZE + crate::environment::TASK_KERNEL_STACK_SIZE) as u64
@@ -231,11 +232,8 @@ pub fn first_switch_to_user(task: &mut Task) -> ! {
     cpu.set_next_address_space(task.vm_manager.get_asid());
 
     // Populate the trapframe from the task VCPU state.
-    let task_ptr = task as *mut Task;
-    unsafe {
-        let trapframe = (*task_ptr).get_trapframe();
-        (*task_ptr).vcpu.lock().switch(trapframe);
-    }
+    let trapframe = task.get_trapframe();
+    task.vcpu.lock().switch(trapframe);
 
     // Ensure the next return is to the correct privilege mode.
     set_next_mode(task.vcpu.lock().get_mode());

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -15,6 +15,7 @@ use crate::early_println;
 use crate::environment::MAX_NUM_CPUS;
 use crate::environment::STACK_SIZE;
 use crate::mem::KERNEL_STACK;
+use crate::sched::scheduler::get_task_by_id;
 use crate::task::Task;
 
 pub mod boot;
@@ -112,14 +113,10 @@ pub fn configure_user_entry(_trapframe: &mut Trapframe, options: crate::arch::Us
     // the trap handler will mark the task as used and re-enable the extension.
     let cpu_id = crate::arch::get_cpu().get_cpuid();
     let (current_task_ptr, current_task_id, owner_task_ptr, owner_id, owner_dirty) = {
-        let sched = crate::sched::scheduler::get_scheduler();
-        let Some(current_task_id) = sched.get_current_task_id(cpu_id) else {
+        let Some(current_task_id) = crate::sched::scheduler::current_task_id(cpu_id) else {
             return;
         };
-        let Some(current_task_ptr) = sched
-            .get_task_by_id(current_task_id)
-            .map(|t| t as *mut Task)
-        else {
+        let Some(current_task_ptr) = get_task_by_id(current_task_id).map(|t| t as *mut Task) else {
             return;
         };
 
@@ -127,7 +124,7 @@ pub fn configure_user_entry(_trapframe: &mut Trapframe, options: crate::arch::Us
         let owner_dirty = get_vector_owner_dirty(cpu_id);
         let owner_task_ptr =
             if owner_dirty && owner_id != NO_VECTOR_OWNER && owner_id != current_task_id {
-                sched.get_task_by_id(owner_id).map(|t| t as *mut Task)
+                get_task_by_id(owner_id).map(|t| t as *mut Task)
             } else {
                 None
             };

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -48,7 +48,7 @@ pub type Arch = Riscv64;
 ///
 /// Configures trap vectors, FPU, and vector extension for the given hart.
 pub fn init_ap_cpu(cpu_id: usize) {
-    boot::init_boot_cpu(cpu_id);
+    boot::init_cpu(cpu_id);
 }
 
 /// Per-hart ownership of the live Vector register file.

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -499,6 +499,10 @@ pub fn disable_interrupt() {
     }
 }
 
+pub fn send_reschedule_ipi(target_cpu: usize) {
+    instruction::sbi::sbi_send_ipi(1 << target_cpu, 0);
+}
+
 /// Full memory barrier for normal memory (RAM).
 ///
 /// This orders previous reads/writes before subsequent reads/writes.

--- a/kernel/src/arch/riscv64/timer.rs
+++ b/kernel/src/arch/riscv64/timer.rs
@@ -1,6 +1,6 @@
 use core::arch::asm;
 
-use crate::{arch::get_cpu, interrupt::InterruptManager};
+use crate::arch::get_cpu;
 
 pub type ArchTimer = Stimer;
 
@@ -12,15 +12,15 @@ pub struct Stimer {
 
 impl Stimer {
     pub fn new() -> Self {
-        let freq = InterruptManager::with_manager(|manager| {
+        let freq = {
             let cpu_id = get_cpu().get_cpuid() as u32;
-            match manager.get_timer_frequency_hz(cpu_id) {
+            match crate::interrupt::InterruptManager::global().get_timer_frequency_hz(cpu_id) {
                 Ok(freq) => freq,
                 Err(e) => {
                     panic!("Failed to get timer frequency: {}", e);
                 }
             }
-        });
+        };
 
         Stimer {
             next_event: 0,
@@ -36,12 +36,13 @@ impl Stimer {
 
     pub fn start(&mut self) {
         self.running = true;
-        InterruptManager::with_manager(|manager| {
-            let cpu_id = get_cpu().get_cpuid() as u32;
-            if manager.set_timer(cpu_id, self.get_next_event()).is_err() {
-                panic!("Failed to set timer for CPU {}", cpu_id);
-            }
-        });
+        let cpu_id = get_cpu().get_cpuid() as u32;
+        if crate::interrupt::InterruptManager::global()
+            .set_timer(cpu_id, self.get_next_event())
+            .is_err()
+        {
+            panic!("Failed to set timer for CPU {}", cpu_id);
+        }
 
         let mut sie: usize;
         unsafe {
@@ -60,12 +61,13 @@ impl Stimer {
 
     pub fn stop(&mut self) {
         self.running = false;
-        InterruptManager::with_manager(|manager| {
-            let cpu_id = get_cpu().get_cpuid() as u32;
-            if manager.set_timer(cpu_id, 0xFFFFFFFFFFFFFFFF).is_err() {
-                panic!("Failed to stop timer for CPU {}", cpu_id);
-            }
-        });
+        let cpu_id = get_cpu().get_cpuid() as u32;
+        if crate::interrupt::InterruptManager::global()
+            .set_timer(cpu_id, 0xFFFFFFFFFFFFFFFF)
+            .is_err()
+        {
+            panic!("Failed to stop timer for CPU {}", cpu_id);
+        }
 
         let mut sie: usize;
         unsafe {

--- a/kernel/src/arch/riscv64/trap/exception.rs
+++ b/kernel/src/arch/riscv64/trap/exception.rs
@@ -5,7 +5,7 @@ use crate::abi::syscall_dispatcher;
 use crate::arch::trap::print_traplog;
 use crate::arch::{Trapframe, get_cpu};
 use crate::println;
-use crate::sched::scheduler::get_scheduler;
+use crate::sched::scheduler::current_task;
 use crate::task::mytask;
 
 fn log_fatal_page_fault_context(
@@ -71,9 +71,7 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, cause: usize) {
                 unreachable!();
             }
 
-            let task = get_scheduler()
-                .get_current_task(get_cpu().get_cpuid())
-                .unwrap();
+            let task = current_task(get_cpu().get_cpuid()).unwrap();
 
             let user_fpu_allowed = crate::arch::user_fpu_enabled();
             let user_vec_allowed = crate::arch::user_vector_enabled();
@@ -229,9 +227,7 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, cause: usize) {
         /* Instruction page fault */
         INSTRUCTION_PAGE_FAULT => {
             let mut vaddr = trapframe.epc as usize;
-            let task = get_scheduler()
-                .get_current_task(get_cpu().get_cpuid())
-                .unwrap();
+            let task = current_task(get_cpu().get_cpuid()).unwrap();
             use crate::object::capability::memory_mapping::{AccessKind, AccessOp};
             loop {
                 let access = AccessKind {
@@ -271,9 +267,7 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, cause: usize) {
             unsafe {
                 asm!("csrr {}, stval", out(reg) vaddr);
             }
-            let task = get_scheduler()
-                .get_current_task(get_cpu().get_cpuid())
-                .unwrap();
+            let task = current_task(get_cpu().get_cpuid()).unwrap();
             use crate::object::capability::memory_mapping::{AccessKind, AccessOp};
             loop {
                 let op = if cause == LOAD_PAGE_FAULT {

--- a/kernel/src/arch/riscv64/trap/interrupt.rs
+++ b/kernel/src/arch/riscv64/trap/interrupt.rs
@@ -1,5 +1,4 @@
 use crate::arch::{Trapframe, get_cpu};
-use crate::interrupt::InterruptManager;
 
 /// RISC-V S-mode interrupt causes
 const SUPERVISOR_SOFTWARE_INTERRUPT: usize = 1;
@@ -45,7 +44,7 @@ fn handle_external_interrupt(trapframe: &mut Trapframe) {
     let cpu_id = get_cpu().get_cpuid() as u32;
 
     // Claim and handle external interrupt through PLIC
-    match InterruptManager::with_manager(|mgr| mgr.claim_and_handle_external_interrupt(cpu_id)) {
+    match crate::interrupt::InterruptManager::global().claim_and_handle_external_interrupt(cpu_id) {
         Ok(Some(interrupt_id)) => {
             // crate::println!("[interrupt] Handled external interrupt {} on CPU {}", interrupt_id, cpu_id);
         }

--- a/kernel/src/arch/riscv64/trap/interrupt.rs
+++ b/kernel/src/arch/riscv64/trap/interrupt.rs
@@ -1,6 +1,5 @@
 use crate::arch::{Trapframe, get_cpu};
 
-/// RISC-V S-mode interrupt causes
 const SUPERVISOR_SOFTWARE_INTERRUPT: usize = 1;
 const SUPERVISOR_TIMER_INTERRUPT: usize = 5;
 const SUPERVISOR_EXTERNAL_INTERRUPT: usize = 9;
@@ -14,12 +13,17 @@ pub fn arch_interrupt_handler(trapframe: &mut Trapframe, cause: usize) {
     }
 }
 
-/// Handle software interrupt (IPI)
-/// TODO: Implement inter-processor interrupt handling
 fn handle_software_interrupt() {
-    crate::println!("[interrupt] Software interrupt received - TODO: implement IPI");
-    // TODO: CLINT software interrupt handling
-    // TODO: Inter-processor interrupt (IPI) support
+    // Clear SSIP (Supervisor Software Interrupt Pending) to prevent
+    // re-triggering. SBI send_ipi sets MSIP via M-mode, which fires
+    // SSIP in S-mode. We must clear it here.
+    unsafe {
+        core::arch::asm!(
+            "csrc sip, {0}",
+            in(reg) 1 << 1,
+            options(nostack)
+        );
+    }
 }
 
 /// Handle timer interrupt from CLINT

--- a/kernel/src/arch/riscv64/trap/interrupt.rs
+++ b/kernel/src/arch/riscv64/trap/interrupt.rs
@@ -6,14 +6,14 @@ const SUPERVISOR_EXTERNAL_INTERRUPT: usize = 9;
 
 pub fn arch_interrupt_handler(trapframe: &mut Trapframe, cause: usize) {
     match cause {
-        SUPERVISOR_SOFTWARE_INTERRUPT => handle_software_interrupt(),
+        SUPERVISOR_SOFTWARE_INTERRUPT => handle_software_interrupt(trapframe),
         SUPERVISOR_TIMER_INTERRUPT => handle_timer_interrupt(trapframe),
         SUPERVISOR_EXTERNAL_INTERRUPT => handle_external_interrupt(trapframe),
         _ => handle_unknown_interrupt(trapframe, cause),
     }
 }
 
-fn handle_software_interrupt() {
+fn handle_software_interrupt(trapframe: &mut Trapframe) {
     // Clear SSIP (Supervisor Software Interrupt Pending) to prevent
     // re-triggering. SBI send_ipi sets MSIP via M-mode, which fires
     // SSIP in S-mode. We must clear it here.
@@ -24,6 +24,8 @@ fn handle_software_interrupt() {
             options(nostack)
         );
     }
+
+    crate::sched::scheduler::schedule(trapframe);
 }
 
 /// Handle timer interrupt from CLINT
@@ -49,7 +51,7 @@ fn handle_external_interrupt(trapframe: &mut Trapframe) {
 
     // Claim and handle external interrupt through PLIC
     match crate::interrupt::InterruptManager::global().claim_and_handle_external_interrupt(cpu_id) {
-        Ok(Some(interrupt_id)) => {
+        Ok(Some(_interrupt_id)) => {
             // crate::println!("[interrupt] Handled external interrupt {} on CPU {}", interrupt_id, cpu_id);
         }
         Ok(None) => {
@@ -61,6 +63,13 @@ fn handle_external_interrupt(trapframe: &mut Trapframe) {
         Err(e) => {
             crate::println!("[interrupt] Failed to handle external interrupt: {}", e);
         }
+    }
+
+    let cpu_id = cpu_id as usize;
+    if crate::sched::scheduler::current_task_is_idle(cpu_id)
+        && crate::sched::scheduler::has_ready_tasks(cpu_id)
+    {
+        crate::sched::scheduler::schedule(trapframe);
     }
 }
 

--- a/kernel/src/arch/riscv64/trap/interrupt.rs
+++ b/kernel/src/arch/riscv64/trap/interrupt.rs
@@ -1,3 +1,4 @@
+use crate::arch::trap::{PRIV_S_MODE, prev_mode};
 use crate::arch::{Trapframe, get_cpu};
 
 const SUPERVISOR_SOFTWARE_INTERRUPT: usize = 1;
@@ -5,15 +6,24 @@ const SUPERVISOR_TIMER_INTERRUPT: usize = 5;
 const SUPERVISOR_EXTERNAL_INTERRUPT: usize = 9;
 
 pub fn arch_interrupt_handler(trapframe: &mut Trapframe, cause: usize) {
+    let from_kernel = prev_mode() == PRIV_S_MODE;
     match cause {
-        SUPERVISOR_SOFTWARE_INTERRUPT => handle_software_interrupt(trapframe),
-        SUPERVISOR_TIMER_INTERRUPT => handle_timer_interrupt(trapframe),
+        SUPERVISOR_SOFTWARE_INTERRUPT => handle_software_interrupt(trapframe, from_kernel),
+        SUPERVISOR_TIMER_INTERRUPT => handle_timer_interrupt(trapframe, from_kernel),
         SUPERVISOR_EXTERNAL_INTERRUPT => handle_external_interrupt(trapframe),
         _ => handle_unknown_interrupt(trapframe, cause),
     }
 }
 
-fn handle_software_interrupt(trapframe: &mut Trapframe) {
+fn can_schedule_from_interrupt(from_kernel: bool) -> bool {
+    if !from_kernel {
+        return true;
+    }
+    let cpu_id = get_cpu().get_cpuid();
+    crate::sched::scheduler::current_task_is_idle(cpu_id)
+}
+
+fn handle_software_interrupt(trapframe: &mut Trapframe, from_kernel: bool) {
     // Clear SSIP (Supervisor Software Interrupt Pending) to prevent
     // re-triggering. SBI send_ipi sets MSIP via M-mode, which fires
     // SSIP in S-mode. We must clear it here.
@@ -25,11 +35,17 @@ fn handle_software_interrupt(trapframe: &mut Trapframe) {
         );
     }
 
-    crate::sched::scheduler::schedule(trapframe);
+    let cpu_id = get_cpu().get_cpuid();
+    let can_schedule = can_schedule_from_interrupt(from_kernel);
+    crate::sched::scheduler::debug_log_reschedule_ipi(cpu_id, from_kernel, can_schedule);
+
+    if can_schedule {
+        crate::sched::scheduler::schedule(trapframe);
+    }
 }
 
 /// Handle timer interrupt from CLINT
-fn handle_timer_interrupt(trapframe: &mut Trapframe) {
+fn handle_timer_interrupt(trapframe: &mut Trapframe, from_kernel: bool) {
     #[cfg(feature = "hypervisor")]
     {
         if crate::arch::hv::trap::is_from_guest() {
@@ -41,8 +57,9 @@ fn handle_timer_interrupt(trapframe: &mut Trapframe) {
         }
     }
 
-    // Increment the global tick counter
-    crate::timer::tick(trapframe);
+    // Increment the global tick counter.  Only run scheduler accounting when
+    // the trapframe is safe to store as the current task context.
+    crate::timer::tick_with_scheduler(trapframe, can_schedule_from_interrupt(from_kernel));
 }
 
 /// Handle external interrupt from PLIC

--- a/kernel/src/arch/riscv64/trap/kernel.rs
+++ b/kernel/src/arch/riscv64/trap/kernel.rs
@@ -1,6 +1,7 @@
 use core::arch::naked_asm;
 use core::{arch::asm, mem::transmute};
 
+use crate::arch::trap::interrupt::arch_interrupt_handler;
 use crate::arch::trap::print_traplog;
 use crate::arch::{Trapframe, get_cpu};
 use crate::environment::PAGE_SIZE;
@@ -122,7 +123,7 @@ pub extern "C" fn arch_kernel_trap_handler(addr: usize) {
 
     let interrupt = cause & 0x8000000000000000 != 0;
     if interrupt {
-        panic!("Interrupt is not supported in kernel mode");
+        arch_interrupt_handler(trapframe, cause & !0x8000000000000000);
     } else {
         arch_kernel_exception_handler(trapframe, cause & !0x8000000000000000);
     }

--- a/kernel/src/arch/riscv64/trap/kernel.rs
+++ b/kernel/src/arch/riscv64/trap/kernel.rs
@@ -163,20 +163,9 @@ fn arch_kernel_exception_handler(trapframe: &mut Trapframe, cause: usize) {
             // Detect kernel stack overflow via guard-page hit
             // Also handle kstack window accesses that might not have VMA
             if let Some(task) = current_task(get_cpu().get_cpuid()) {
-                crate::println!(
-                    "[kpf] task found, checking kstack window for vaddr={:#x}",
-                    vaddr
-                );
                 if let Some((_slot, base)) = task.get_kernel_stack_window_base() {
-                    crate::println!("[kpf] kstack window base={:#x}", base);
                     let kstack_start = base + crate::environment::PAGE_SIZE;
                     let kstack_end = kstack_start + crate::environment::TASK_KERNEL_STACK_SIZE;
-                    crate::println!(
-                        "[kpf] kstack_start={:#x}, kstack_end={:#x}, vaddr={:#x}",
-                        kstack_start,
-                        kstack_end,
-                        vaddr
-                    );
 
                     // Guard page hit
                     if vaddr >= base && vaddr < kstack_start {
@@ -206,7 +195,6 @@ fn arch_kernel_exception_handler(trapframe: &mut Trapframe, cause: usize) {
                                 true,
                                 false,
                             );
-                            crate::println!("Mapped kstack page at vaddr: {:#x}", page_vaddr);
                             return;
                         }
                     }
@@ -216,8 +204,6 @@ fn arch_kernel_exception_handler(trapframe: &mut Trapframe, cause: usize) {
             // For kernel addresses, check if they are valid
             let manager = get_kernel_vm_manager();
             loop {
-                crate::println!("[kernel] Handling page fault at vaddr: {:#x}", vaddr);
-
                 // Additional validation for suspicious addresses
                 if vaddr == 0 || vaddr == usize::MAX {
                     print_traplog(trapframe);
@@ -245,7 +231,6 @@ fn arch_kernel_exception_handler(trapframe: &mut Trapframe, cause: usize) {
                         );
                     }
                 }
-                crate::println!("Mapped page at vaddr: {:#x}", vaddr);
 
                 if vaddr & 0b11 == 0 {
                     // If the address is aligned, we can stop

--- a/kernel/src/arch/riscv64/trap/kernel.rs
+++ b/kernel/src/arch/riscv64/trap/kernel.rs
@@ -5,7 +5,7 @@ use crate::arch::trap::print_traplog;
 use crate::arch::{Trapframe, get_cpu};
 use crate::environment::PAGE_SIZE;
 use crate::object::capability::memory_mapping::{AccessKind, AccessOp};
-use crate::sched::scheduler::get_scheduler;
+use crate::sched::scheduler::current_task;
 use crate::vm::{get_kernel_vm_manager, vmem::VirtualMemoryPermission};
 
 #[unsafe(export_name = "_kernel_trap_entry")]
@@ -162,7 +162,7 @@ fn arch_kernel_exception_handler(trapframe: &mut Trapframe, cause: usize) {
 
             // Detect kernel stack overflow via guard-page hit
             // Also handle kstack window accesses that might not have VMA
-            if let Some(task) = get_scheduler().get_current_task(get_cpu().get_cpuid()) {
+            if let Some(task) = current_task(get_cpu().get_cpuid()) {
                 crate::println!(
                     "[kpf] task found, checking kstack window for vaddr={:#x}",
                     vaddr

--- a/kernel/src/arch/riscv64/trap/user.rs
+++ b/kernel/src/arch/riscv64/trap/user.rs
@@ -97,6 +97,10 @@ pub extern "C" fn _user_trap_entry() {
                 mv      a0, sp
                 jalr    ra, t1, 0 // Riscv64.kernel_trap(a0: &mut Trapframe)
 
+                     /* Keep S-mode interrupts masked while sscratch temporarily
+                         contains the user a0 during the trampoline return path. */
+                     csrci   sstatus, 0x2
+
                 /* Return from Rust handler - restore trapframe and sret */
                 mv      a0, sp
                 /* epc */
@@ -311,6 +315,10 @@ pub extern "C" fn _switch_to_user(trapframe: &mut Trapframe) -> ! {
         .option norvc
         .option norelax
         .align 8
+            /* Keep S-mode interrupts masked while sscratch temporarily
+               contains the user a0 during the first user return path. */
+            csrci   sstatus, 0x2
+
                 /* Restore the context of the current hart from trapframe first */ 
                 /* epc */
                 ld     t0, 256(a0)

--- a/kernel/src/arch/riscv64/vm/mmu/sv48.rs
+++ b/kernel/src/arch/riscv64/vm/mmu/sv48.rs
@@ -269,6 +269,8 @@ impl PageTable {
             }
         }
 
+        unsafe { asm!("sfence.vma zero,zero") };
+
         Ok(())
     }
 
@@ -295,6 +297,7 @@ impl PageTable {
         };
         self.try_map_at_level(asid, vaddr, paddr, attrs, 0)
             .expect("map: couldn't install a 4 KiB leaf mapping");
+        unsafe { asm!("sfence.vma zero,zero") };
     }
 
     /// Attempts to install a leaf mapping at the specified page-table level.
@@ -352,7 +355,7 @@ impl PageTable {
 
         pte.set_ppn(ppn);
         pte.validate();
-        unsafe { asm!("sfence.vma zero,zero") };
+        // sfence.vma deferred to caller for batching.
         Ok(())
     }
 

--- a/kernel/src/arch/riscv64/vm/mod.rs
+++ b/kernel/src/arch/riscv64/vm/mod.rs
@@ -338,6 +338,22 @@ pub fn setup_trampoline_for_user(manager: &VirtualMemoryManager) {
     setup_trampoline_at_end(manager, TRAMPOLINE_VA_END);
 }
 
+pub fn register_trampoline_for_ap() {
+    let trampoline_start =
+        kernel_virt_to_phys(unsafe { &__TRAMPOLINE_START as *const usize as usize });
+    let trampoline_end =
+        kernel_virt_to_phys(unsafe { &__TRAMPOLINE_END as *const usize as usize }) - 1;
+    let trampoline_size = trampoline_end - trampoline_start;
+
+    let arch = get_cpu().as_paddr_cpu();
+    let trampoline_vaddr_start = TRAMPOLINE_VA_END - trampoline_size;
+    let arch_paddr = kernel_virt_to_phys(arch as *const Arch as usize);
+    let arch_offset = arch_paddr - trampoline_start;
+    let arch_vaddr = trampoline_vaddr_start + arch_offset;
+
+    crate::vm::set_trampoline_arch(arch.get_cpuid(), arch_vaddr);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/src/arch/riscv64/vm/mod.rs
+++ b/kernel/src/arch/riscv64/vm/mod.rs
@@ -16,6 +16,8 @@ use mmu::PageTable;
 use spin::Once;
 use spin::RwLock;
 
+use core::sync::atomic::{AtomicU64, Ordering};
+
 use crate::mem::page::{Page, allocate_raw_pages, allocate_raw_pages_aligned, free_raw_pages};
 
 use crate::arch::Arch;
@@ -26,6 +28,28 @@ use crate::environment::{KERNEL_KSTACK_REGION_END, KERNEL_KSTACK_REGION_START, T
 use crate::vm::addr::kernel_virt_to_phys;
 use crate::vm::manager::VirtualMemoryManager;
 use crate::vm::vmem::{MemoryArea, VirtualMemoryMap, VirtualMemoryPermission};
+
+static KERNEL_SATP: AtomicU64 = AtomicU64::new(0);
+
+pub fn save_kernel_page_table() {
+    let satp: u64;
+    unsafe {
+        core::arch::asm!("csrr {}, satp", out(reg) satp);
+    }
+    KERNEL_SATP.store(satp, Ordering::Release);
+}
+
+pub fn switch_to_kernel_page_table() {
+    let satp = KERNEL_SATP.load(Ordering::Acquire);
+    assert!(satp != 0, "kernel page table not initialized");
+    unsafe {
+        core::arch::asm!(
+            "csrw satp, {}",
+            "sfence.vma",
+            in(reg) satp,
+        );
+    }
+}
 
 unsafe extern "C" {
     static __TRAMPOLINE_START: usize;

--- a/kernel/src/boot/limine.rs
+++ b/kernel/src/boot/limine.rs
@@ -2,7 +2,7 @@ use limine::BaseRevision;
 use limine::memmap;
 use limine::request::{
     DtbRequest, ExecutableAddressRequest, FramebufferRequest, FramebufferResponse, HhdmRequest,
-    MemmapRequest, MemmapResponse, ModulesRequest, ModulesResponse,
+    MemmapRequest, MemmapResponse, ModulesRequest, ModulesResponse, MpRequest, MpResponse,
 };
 use limine::{RequestsEndMarker, RequestsStartMarker};
 
@@ -40,6 +40,10 @@ pub static FRAMEBUFFER_REQUEST: FramebufferRequest = FramebufferRequest::new();
 #[unsafe(link_section = ".limine_requests")]
 #[used]
 pub static MODULE_REQUEST: ModulesRequest = ModulesRequest::new();
+
+#[unsafe(link_section = ".limine_requests")]
+#[used]
+pub static MP_REQUEST: MpRequest = MpRequest::new(0);
 
 #[unsafe(link_section = ".limine_requests_end")]
 #[used]

--- a/kernel/src/device/char/tty.rs
+++ b/kernel/src/device/char/tty.rs
@@ -252,16 +252,16 @@ impl TtyDevice {
 
     fn send_interrupt_to_foreground(&self) {
         use crate::ipc::event::{Event, EventPriority, ProcessControlType};
+        use crate::sched::scheduler::{get_all_task_ids, get_task_by_id, wake_task};
         use crate::task::{BlockedType, TaskState};
 
         if let Some(task_group_id) = self.get_foreground_task_group_id() {
-            let scheduler = crate::sched::scheduler::get_scheduler();
-            let task_ids = scheduler.get_all_task_ids();
+            let task_ids = get_all_task_ids();
 
             let mut tasks_to_wake = alloc::vec::Vec::new();
 
             for task_id in task_ids {
-                if let Some(task) = scheduler.get_task_by_id(task_id) {
+                if let Some(task) = get_task_by_id(task_id) {
                     if task.get_task_group_id() == task_group_id {
                         let event = Event::direct_process_control(
                             task_id as u32,
@@ -279,7 +279,7 @@ impl TtyDevice {
             }
 
             for task_id in tasks_to_wake {
-                scheduler.wake_task(task_id);
+                wake_task(task_id);
             }
         }
     }

--- a/kernel/src/device/fdt.rs
+++ b/kernel/src/device/fdt.rs
@@ -545,6 +545,7 @@ pub fn create_bootinfo_from_fdt(cpu_id: usize, relocated_fdt_addr: usize) -> Boo
         cmdline,
         DeviceSource::Fdt(relocated_fdt_addr),
         None,
+        None,
     )
 }
 

--- a/kernel/src/drivers/network/virtio_net.rs
+++ b/kernel/src/drivers/network/virtio_net.rs
@@ -519,7 +519,7 @@ impl VirtioNetDevice {
         }
 
         crate::interrupt::InterruptManager::global()
-            .enable_external_interrupt(interrupt_id, 0)
+            .enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
             .map_err(|_| "Failed to enable interrupt in controller")?;
 
         Ok(())

--- a/kernel/src/drivers/network/virtio_net.rs
+++ b/kernel/src/drivers/network/virtio_net.rs
@@ -518,10 +518,9 @@ impl VirtioNetDevice {
             self.write32_register(Register::InterruptAck, isr & 0x03);
         }
 
-        crate::interrupt::InterruptManager::with_manager(|mgr| {
-            mgr.enable_external_interrupt(interrupt_id, 0)
-        })
-        .map_err(|_| "Failed to enable interrupt in controller")?;
+        crate::interrupt::InterruptManager::global()
+            .enable_external_interrupt(interrupt_id, 0)
+            .map_err(|_| "Failed to enable interrupt in controller")?;
 
         Ok(())
     }

--- a/kernel/src/drivers/pic/arm_generic_timer.rs
+++ b/kernel/src/drivers/pic/arm_generic_timer.rs
@@ -22,10 +22,18 @@ const CNTV_CTL_ENABLE: u64 = 1 << 0;
 const CNTV_CTL_IMASK: u64 = 1 << 1;
 const CNTV_CTL_ISTATUS: u64 = 1 << 2;
 
-/// QEMU virt / ARM Generic Timer: Virtual Timer PPI is 27.
+/// QEMU virt / ARM Generic Timer: Virtual Timer PPI.
 ///
-/// We keep this as a constant so the IRQ handler can cheaply sanity-check timer pending state.
-pub const CNTV_PPI_IRQ: u32 = 27;
+/// At EL1: PPI 27 (virtual timer).
+/// At EL2 with VHE: PPI 28 (CNTHV virtual timer), because `cntv_ctl_el0` is
+/// redirected to `CNTHV_CTL_EL2` which fires on the EL2 virtual timer IRQ.
+pub fn timer_ppi_irq() -> u32 {
+    if crate::arch::aarch64::is_vhe_enabled() {
+        28
+    } else {
+        27
+    }
+}
 
 #[inline]
 fn read_cntfrq_el0() -> u64 {

--- a/kernel/src/drivers/pic/arm_generic_timer.rs
+++ b/kernel/src/drivers/pic/arm_generic_timer.rs
@@ -22,14 +22,13 @@ const CNTV_CTL_ENABLE: u64 = 1 << 0;
 const CNTV_CTL_IMASK: u64 = 1 << 1;
 const CNTV_CTL_ISTATUS: u64 = 1 << 2;
 
-/// QEMU virt / ARM Generic Timer: Virtual Timer PPI.
+/// Timer PPI number.
 ///
-/// At EL1: PPI 27 (virtual timer).
-/// At EL2 with VHE: PPI 28 (CNTHV virtual timer), because `cntv_ctl_el0` is
-/// redirected to `CNTHV_CTL_EL2` which fires on the EL2 virtual timer IRQ.
+/// EL1: Virtual Timer PPI 27.
+/// EL2 VHE: EL2 Physical Timer (CNTHP) PPI 26, reserving the virtual timer for guests.
 pub fn timer_ppi_irq() -> u32 {
     if crate::arch::aarch64::is_vhe_enabled() {
-        28
+        26
     } else {
         27
     }
@@ -45,44 +44,52 @@ fn read_cntfrq_el0() -> u64 {
 }
 
 #[inline]
-fn read_cntvct_el0() -> u64 {
+fn read_counter() -> u64 {
     let v: u64;
     unsafe {
-        asm!("mrs {0}, cntvct_el0", out(reg) v, options(nostack));
+        if crate::arch::aarch64::is_vhe_enabled() {
+            asm!("mrs {0}, cntpct_el0", out(reg) v, options(nostack));
+        } else {
+            asm!("mrs {0}, cntvct_el0", out(reg) v, options(nostack));
+        }
     }
     v
 }
 
 #[inline]
-fn read_cntv_ctl_el0() -> u64 {
+fn read_timer_ctl() -> u64 {
     let v: u64;
     unsafe {
-        asm!("mrs {0}, cntv_ctl_el0", out(reg) v, options(nostack));
+        if crate::arch::aarch64::is_vhe_enabled() {
+            asm!("mrs {0}, cntp_ctl_el0", out(reg) v, options(nostack));
+        } else {
+            asm!("mrs {0}, cntv_ctl_el0", out(reg) v, options(nostack));
+        }
     }
     v
 }
 
 #[inline]
-fn write_cntv_ctl_el0(v: u64) {
+fn write_timer_ctl(v: u64) {
     unsafe {
-        asm!(
-            "msr cntv_ctl_el0, {0}",
-            "isb",
-            in(reg) v,
-            options(nostack)
-        );
+        if crate::arch::aarch64::is_vhe_enabled() {
+            asm!("msr cntp_ctl_el0, {0}", in(reg) v, options(nostack));
+        } else {
+            asm!("msr cntv_ctl_el0, {0}", in(reg) v, options(nostack));
+        }
+        asm!("isb", options(nostack));
     }
 }
 
 #[inline]
-fn write_cntv_cval_el0(v: u64) {
+fn write_timer_cval(v: u64) {
     unsafe {
-        asm!(
-            "msr cntv_cval_el0, {0}",
-            "isb",
-            in(reg) v,
-            options(nostack)
-        );
+        if crate::arch::aarch64::is_vhe_enabled() {
+            asm!("msr cntp_cval_el0, {0}", in(reg) v, options(nostack));
+        } else {
+            asm!("msr cntv_cval_el0, {0}", in(reg) v, options(nostack));
+        }
+        asm!("isb", options(nostack));
     }
 }
 
@@ -97,22 +104,22 @@ impl ArmGenericTimer {
     }
 
     pub fn is_timer_pending() -> bool {
-        (read_cntv_ctl_el0() & CNTV_CTL_ISTATUS) != 0
+        (read_timer_ctl() & CNTV_CTL_ISTATUS) != 0
     }
 
     fn enable_timer_interrupt() {
         // Enable timer and unmask interrupt.
-        let mut ctl = read_cntv_ctl_el0();
+        let mut ctl = read_timer_ctl();
         ctl |= CNTV_CTL_ENABLE;
         ctl &= !CNTV_CTL_IMASK;
-        write_cntv_ctl_el0(ctl);
+        write_timer_ctl(ctl);
     }
 
     fn disable_timer_interrupt() {
         // Mask timer interrupt; keep ENABLE as-is.
-        let mut ctl = read_cntv_ctl_el0();
+        let mut ctl = read_timer_ctl();
         ctl |= CNTV_CTL_IMASK;
-        write_cntv_ctl_el0(ctl);
+        write_timer_ctl(ctl);
     }
 }
 
@@ -181,12 +188,12 @@ impl LocalInterruptController for ArmGenericTimer {
 
     fn set_timer(&mut self, _cpu_id: CpuId, time: u64) -> InterruptResult<()> {
         // Program absolute compare value.
-        write_cntv_cval_el0(time);
+        write_timer_cval(time);
         Ok(())
     }
 
     fn get_time(&self) -> u64 {
-        read_cntvct_el0()
+        read_counter()
     }
 
     fn get_timer_frequency_hz(&self) -> u64 {

--- a/kernel/src/drivers/pic/arm_generic_timer.rs
+++ b/kernel/src/drivers/pic/arm_generic_timer.rs
@@ -15,7 +15,7 @@ use core::arch::asm;
 
 use crate::environment::MAX_NUM_CPUS;
 use crate::interrupt::controllers::{LocalInterruptController, LocalInterruptType};
-use crate::interrupt::{CpuId, InterruptError, InterruptManager, InterruptResult};
+use crate::interrupt::{CpuId, InterruptError, InterruptResult};
 
 /// CNTV_CTL_EL0 bit definitions
 const CNTV_CTL_ENABLE: u64 = 1 << 0;
@@ -131,7 +131,7 @@ impl LocalInterruptController for ArmGenericTimer {
     }
 
     fn enable_interrupt(
-        &mut self,
+        &self,
         _cpu_id: CpuId,
         interrupt_type: LocalInterruptType,
     ) -> InterruptResult<()> {
@@ -145,7 +145,7 @@ impl LocalInterruptController for ArmGenericTimer {
     }
 
     fn disable_interrupt(
-        &mut self,
+        &self,
         _cpu_id: CpuId,
         interrupt_type: LocalInterruptType,
     ) -> InterruptResult<()> {
@@ -178,7 +178,7 @@ impl LocalInterruptController for ArmGenericTimer {
         }
     }
 
-    fn send_software_interrupt(&mut self, _target_cpu: CpuId) -> InterruptResult<()> {
+    fn send_software_interrupt(&self, _target_cpu: CpuId) -> InterruptResult<()> {
         Err(InterruptError::NotSupported)
     }
 
@@ -186,7 +186,7 @@ impl LocalInterruptController for ArmGenericTimer {
         Err(InterruptError::NotSupported)
     }
 
-    fn set_timer(&mut self, _cpu_id: CpuId, time: u64) -> InterruptResult<()> {
+    fn set_timer(&self, _cpu_id: CpuId, time: u64) -> InterruptResult<()> {
         // Program absolute compare value.
         write_timer_cval(time);
         Ok(())
@@ -207,9 +207,8 @@ unsafe impl Sync for ArmGenericTimer {}
 fn register_local_timer_controller() {
     // Register for all CPUs that Scarlet is configured to support.
     let controller = alloc::boxed::Box::new(ArmGenericTimer::new());
-    let _ = InterruptManager::with_manager(|mgr| {
-        mgr.register_local_controller_for_range(controller, 0..(MAX_NUM_CPUS as CpuId))
-    });
+    let _ = crate::interrupt::InterruptManager::global()
+        .register_local_controller_for_range(controller, 0..(MAX_NUM_CPUS as CpuId));
 }
 
 crate::early_initcall!(register_local_timer_controller);

--- a/kernel/src/drivers/pic/clint.rs
+++ b/kernel/src/drivers/pic/clint.rs
@@ -322,55 +322,46 @@ mod tests {
 
     #[test_case]
     fn test_clint_creation() {
-        let clint = Clint::new(0x200_0000, 4, 10_000_000);
-        assert_eq!(clint.max_cpus, 4);
+        let clint = Clint::new(0x200_0000, crate::environment::MAX_NUM_CPUS as CpuId, 10_000_000);
+        assert_eq!(clint.max_cpus, crate::environment::MAX_NUM_CPUS as CpuId);
     }
 
     #[test_case]
     fn test_address_calculation() {
-        let clint = Clint::new(0x200_0000, 4, 10_000_000);
+        let clint = Clint::new(0x200_0000, crate::environment::MAX_NUM_CPUS as CpuId, 10_000_000);
 
-        // Test MSIP addresses
         assert_eq!(clint.msip_addr(0), 0x200_0000);
         assert_eq!(clint.msip_addr(1), 0x200_0004);
         assert_eq!(clint.msip_addr(3), 0x200_000C);
 
-        // Test MTIMECMP addresses
         assert_eq!(clint.mtimecmp_addr(0), 0x200_4000);
         assert_eq!(clint.mtimecmp_addr(1), 0x200_4008);
         assert_eq!(clint.mtimecmp_addr(3), 0x200_4018);
 
-        // Test MTIME address
         assert_eq!(clint.mtime_addr(), 0x200_BFF8);
     }
 
     #[test_case]
     fn test_different_base_address() {
-        // Test with different base address to ensure base_addr is properly used
-        let clint = Clint::new(0x300_0000, 4, 10_000_000);
+        let clint = Clint::new(0x300_0000, crate::environment::MAX_NUM_CPUS as CpuId, 10_000_000);
 
-        // Test MSIP addresses with different base
         assert_eq!(clint.msip_addr(0), 0x300_0000);
         assert_eq!(clint.msip_addr(1), 0x300_0004);
 
-        // Test MTIMECMP addresses with different base
         assert_eq!(clint.mtimecmp_addr(0), 0x300_4000);
         assert_eq!(clint.mtimecmp_addr(1), 0x300_4008);
 
-        // Test MTIME address with different base
         assert_eq!(clint.mtime_addr(), 0x300_BFF8);
     }
 
     #[test_case]
     fn test_validation() {
-        let clint = Clint::new(0x200_0000, 4, 10_000_000);
+        let clint = Clint::new(0x200_0000, crate::environment::MAX_NUM_CPUS as CpuId, 10_000_000);
 
-        // Valid CPU IDs should pass
         assert!(clint.validate_cpu_id(0).is_ok());
-        assert!(clint.validate_cpu_id(3).is_ok());
+        assert!(clint.validate_cpu_id(crate::environment::MAX_NUM_CPUS as CpuId - 1).is_ok());
 
-        // Invalid CPU IDs should fail
-        assert!(clint.validate_cpu_id(4).is_err());
+        assert!(clint.validate_cpu_id(crate::environment::MAX_NUM_CPUS as CpuId).is_err());
         assert!(clint.validate_cpu_id(100).is_err());
     }
 }

--- a/kernel/src/drivers/pic/clint.rs
+++ b/kernel/src/drivers/pic/clint.rs
@@ -13,7 +13,7 @@ use crate::{
     driver_initcall,
     interrupt::{
         controllers::{LocalInterruptController, LocalInterruptType},
-        CpuId, InterruptError, InterruptManager, InterruptResult,
+        CpuId, InterruptError, InterruptResult,
     },
 };
 use alloc::{boxed::Box, vec};
@@ -100,11 +100,7 @@ impl LocalInterruptController for Clint {
     }
 
     /// Enable a specific local interrupt type for a CPU
-    fn enable_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_type: LocalInterruptType,
-    ) -> InterruptResult<()> {
+    fn enable_interrupt(&self, cpu_id: CpuId, interrupt_type: LocalInterruptType) -> InterruptResult<()> {
         self.validate_cpu_id(cpu_id)?;
 
         match interrupt_type {
@@ -126,11 +122,7 @@ impl LocalInterruptController for Clint {
     }
 
     /// Disable a specific local interrupt type for a CPU
-    fn disable_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_type: LocalInterruptType,
-    ) -> InterruptResult<()> {
+    fn disable_interrupt(&self, cpu_id: CpuId, interrupt_type: LocalInterruptType) -> InterruptResult<()> {
         self.validate_cpu_id(cpu_id)?;
 
         match interrupt_type {
@@ -139,8 +131,12 @@ impl LocalInterruptController for Clint {
                 self.set_timer(cpu_id, u64::MAX)
             }
             LocalInterruptType::Software => {
-                // Disable software interrupt by clearing MSIP
-                self.clear_software_interrupt(cpu_id)
+                let addr = self.msip_addr(cpu_id);
+                unsafe {
+                    write_volatile(addr as *mut u32, 0);
+                }
+
+                Ok(())
             }
             LocalInterruptType::External => {
                 // External interrupts are not managed by CLINT
@@ -190,7 +186,7 @@ impl LocalInterruptController for Clint {
     }
 
     /// Send a software interrupt to a specific CPU
-    fn send_software_interrupt(&mut self, target_cpu: CpuId) -> InterruptResult<()> {
+    fn send_software_interrupt(&self, target_cpu: CpuId) -> InterruptResult<()> {
         self.validate_cpu_id(target_cpu)?;
 
         let addr = self.msip_addr(target_cpu);
@@ -217,7 +213,7 @@ impl LocalInterruptController for Clint {
     }
 
     /// Set timer interrupt for a specific CPU
-    fn set_timer(&mut self, cpu_id: CpuId, time: u64) -> InterruptResult<()> {
+    fn set_timer(&self, cpu_id: CpuId, time: u64) -> InterruptResult<()> {
         self.validate_cpu_id(cpu_id)?;
 
         // Set the timer compare register to the specified time using SBI
@@ -285,8 +281,7 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
     }
 
     // Register with InterruptManager instead of DeviceManager
-    match InterruptManager::global()
-        .lock()
+    match crate::interrupt::InterruptManager::global()
         .register_local_controller_for_range(controller, 0..4)
     {
         Ok(_) => {

--- a/kernel/src/drivers/pic/clint.rs
+++ b/kernel/src/drivers/pic/clint.rs
@@ -268,7 +268,7 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
         crate::arch::riscv64::fdt::timebase_frequency_hz_from_fdt().unwrap_or(10_000_000);
 
     // Create CLINT controller
-    let mut controller = Box::new(Clint::new(base_addr, 4, timebase_frequency_hz)); // Example: 4 CPUs for QEMU virt
+    let mut controller = Box::new(Clint::new(base_addr, crate::environment::MAX_NUM_CPUS as CpuId, timebase_frequency_hz));
 
     // Initialize CLINT (Currently only initializes for CPU 0)
     if let Err(e) = controller.init(0) {
@@ -282,7 +282,7 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
 
     // Register with InterruptManager instead of DeviceManager
     match crate::interrupt::InterruptManager::global()
-        .register_local_controller_for_range(controller, 0..4)
+        .register_local_controller_for_range(controller, 0..(crate::environment::MAX_NUM_CPUS as CpuId))
     {
         Ok(_) => {
             crate::early_println!(

--- a/kernel/src/drivers/pic/gic.rs
+++ b/kernel/src/drivers/pic/gic.rs
@@ -192,7 +192,7 @@ impl Gic {
             }
 
             // Pre-enable the virtual timer PPI (ID 27).
-            let timer_ppi = crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ;
+            let timer_ppi = crate::drivers::pic::arm_generic_timer::timer_ppi_irq();
             let timer_ppi_bit = 1u32 << timer_ppi;
             mmio::write32(self.dist_reg_addr(GICD_ISENABLER), timer_ppi_bit);
 
@@ -239,7 +239,7 @@ impl Gic {
         // [14:0] INTID
         let cpu_target_list = 1u32 << (target_cpu_id + 16);
         let int_id = match ipi_type {
-            LocalInterruptType::Timer => crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ,
+            LocalInterruptType::Timer => crate::drivers::pic::arm_generic_timer::timer_ppi_irq(),
             LocalInterruptType::Software => 0, // Software Generated Interrupt
             LocalInterruptType::External => 1, // Software Generated Interrupt
         };
@@ -538,7 +538,7 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
 
     crate::arch::interrupt::configure_timer_interrupt_route(
         crate::arch::interrupt::TimerInterruptRoute::ExternalControllerIrq,
-        Some(crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ),
+        Some(crate::drivers::pic::arm_generic_timer::timer_ppi_irq()),
     );
 
     Ok(())

--- a/kernel/src/drivers/pic/gic.rs
+++ b/kernel/src/drivers/pic/gic.rs
@@ -270,11 +270,7 @@ impl Gic {
 
 impl ExternalInterruptController for Gic {
     fn init(&mut self) -> InterruptResult<()> {
-        // Initialize distributor
         self.init_distributor();
-
-        // Ensure the CPU interface is enabled for the boot CPU so PPIs/IRQs can be delivered.
-        self.init_cpu_interface(0);
         Ok(())
     }
 
@@ -504,7 +500,7 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
 
     // TODO: Parse actual interrupt count and CPU count from device tree
     let max_interrupts = 256; // Typical value
-    let max_cpus = 4; // Typical value
+    let max_cpus = crate::environment::MAX_NUM_CPUS as u32;
 
     let gic = Box::new(Gic::new(
         dist_base_addr,

--- a/kernel/src/drivers/pic/gic.rs
+++ b/kernel/src/drivers/pic/gic.rs
@@ -448,6 +448,11 @@ impl ExternalInterruptController for Gic {
     ) -> InterruptResult<()> {
         self.send_ipi(target_cpu_id, ipi_type)
     }
+
+    fn init_for_cpu(&mut self, cpu_id: CpuId) -> InterruptResult<()> {
+        self.init_cpu_interface(cpu_id);
+        Ok(())
+    }
 }
 
 unsafe impl Send for Gic {}

--- a/kernel/src/drivers/pic/gic.rs
+++ b/kernel/src/drivers/pic/gic.rs
@@ -440,6 +440,14 @@ impl ExternalInterruptController for Gic {
     fn max_cpus(&self) -> CpuId {
         self.max_cpus
     }
+
+    fn send_ipi(
+        &mut self,
+        target_cpu_id: CpuId,
+        ipi_type: LocalInterruptType,
+    ) -> InterruptResult<()> {
+        self.send_ipi(target_cpu_id, ipi_type)
+    }
 }
 
 unsafe impl Send for Gic {}

--- a/kernel/src/drivers/pic/gic.rs
+++ b/kernel/src/drivers/pic/gic.rs
@@ -13,11 +13,12 @@ use crate::{
     },
     driver_initcall, early_initcall,
     interrupt::{
-        CpuId, InterruptError, InterruptId, InterruptManager, InterruptResult, Priority,
+        CpuId, InterruptError, InterruptId, InterruptResult, Priority,
         controllers::{ExternalInterruptController, LocalInterruptType},
     },
 };
 use alloc::{boxed::Box, vec};
+use core::sync::atomic::{AtomicU32, Ordering};
 
 /// GIC Distributor register offsets
 const GICD_CTLR: usize = 0x0000; // Distributor Control Register
@@ -65,7 +66,7 @@ pub struct Gic {
     ///
     /// GICv2 requires writing the same value returned by GICC_IAR back to
     /// GICC_EOIR to complete the interrupt (it includes CPUID bits).
-    last_iar: [u32; MAX_CPUS as usize],
+    last_iar: [AtomicU32; MAX_CPUS as usize],
 }
 
 impl Gic {
@@ -88,7 +89,7 @@ impl Gic {
             cpu_base_addr,
             max_interrupts: max_interrupts.min(MAX_INTERRUPTS),
             max_cpus: max_cpus.min(MAX_CPUS),
-            last_iar: [0; MAX_CPUS as usize],
+            last_iar: core::array::from_fn(|_| AtomicU32::new(0)),
         }
     }
 
@@ -277,11 +278,7 @@ impl ExternalInterruptController for Gic {
         Ok(())
     }
 
-    fn enable_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()> {
+    fn enable_interrupt(&self, interrupt_id: InterruptId, cpu_id: CpuId) -> InterruptResult<()> {
         self.validate_interrupt_id(interrupt_id)?;
         self.validate_cpu_id(cpu_id)?;
 
@@ -313,11 +310,7 @@ impl ExternalInterruptController for Gic {
         Ok(())
     }
 
-    fn disable_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        _cpu_id: CpuId,
-    ) -> InterruptResult<()> {
+    fn disable_interrupt(&self, interrupt_id: InterruptId, _cpu_id: CpuId) -> InterruptResult<()> {
         self.validate_interrupt_id(interrupt_id)?;
 
         // Disable the interrupt
@@ -370,7 +363,7 @@ impl ExternalInterruptController for Gic {
         Ok(threshold as Priority)
     }
 
-    fn claim_interrupt(&mut self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>> {
+    fn claim_interrupt(&self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>> {
         self.validate_cpu_id(cpu_id)?;
 
         // Read interrupt acknowledge register
@@ -378,7 +371,7 @@ impl ExternalInterruptController for Gic {
         let iar = unsafe { mmio::read32(iar_addr) };
 
         // Remember the raw acknowledge value for correct EOI later.
-        self.last_iar[cpu_id as usize] = iar;
+        self.last_iar[cpu_id as usize].store(iar, Ordering::Relaxed);
 
         // Extract interrupt ID (bits 0-9)
         let interrupt_id = iar & 0x3FF;
@@ -397,11 +390,7 @@ impl ExternalInterruptController for Gic {
         }
     }
 
-    fn complete_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_id: InterruptId,
-    ) -> InterruptResult<()> {
+    fn complete_interrupt(&self, cpu_id: CpuId, interrupt_id: InterruptId) -> InterruptResult<()> {
         self.validate_interrupt_id(interrupt_id)?;
         self.validate_cpu_id(cpu_id)?;
 
@@ -409,12 +398,12 @@ impl ExternalInterruptController for Gic {
         let eoir_addr = self.cpu_reg_addr(cpu_id, GICC_EOIR);
         unsafe {
             // GICv2 expects the raw value read from GICC_IAR (includes CPUID bits).
-            let iar = self.last_iar[cpu_id as usize];
+            let iar = self.last_iar[cpu_id as usize].load(Ordering::Relaxed);
             let eoi_value = if iar != 0 { iar } else { interrupt_id };
             mmio::write32(eoir_addr, eoi_value);
         }
 
-        self.last_iar[cpu_id as usize] = 0;
+        self.last_iar[cpu_id as usize].store(0, Ordering::Relaxed);
 
         Ok(())
     }
@@ -441,11 +430,7 @@ impl ExternalInterruptController for Gic {
         self.max_cpus
     }
 
-    fn send_ipi(
-        &mut self,
-        target_cpu_id: CpuId,
-        ipi_type: LocalInterruptType,
-    ) -> InterruptResult<()> {
+    fn send_ipi(&self, target_cpu_id: CpuId, ipi_type: LocalInterruptType) -> InterruptResult<()> {
         self.send_ipi(target_cpu_id, ipi_type)
     }
 
@@ -528,13 +513,9 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
         max_cpus,
     ));
 
-    // Register with interrupt manager
-    InterruptManager::with_manager(|manager| {
-        manager
-            .register_external_controller(gic)
-            .map_err(|_| "Failed to register GIC")?;
-        Ok(())
-    })?;
+    crate::interrupt::InterruptManager::global()
+        .register_external_controller(gic)
+        .map_err(|_| "Failed to register GIC")?;
 
     crate::arch::interrupt::configure_timer_interrupt_route(
         crate::arch::interrupt::TimerInterruptRoute::ExternalControllerIrq,

--- a/kernel/src/drivers/pic/gicv3.rs
+++ b/kernel/src/drivers/pic/gicv3.rs
@@ -30,6 +30,9 @@ const MAX_INTERRUPTS: InterruptId = 1020;
 /// Maximum number of CPUs supported by this implementation.
 const MAX_CPUS: CpuId = 8;
 
+/// SGI used by the scheduler to request a reschedule on another CPU.
+const RESCHEDULE_SGI: u32 = 0;
+
 // Distributor register offsets (GICD)
 const GICD_CTLR: usize = 0x0000;
 const GICD_TYPER: usize = 0x0004;
@@ -250,6 +253,16 @@ impl GicV3 {
             // Group 1 for SGI/PPI.
             mmio::write32(self.redist_sgi_reg_addr(cpu_id, GICR_IGROUPR0), 0xFFFF_FFFF);
 
+            // Enable SGI 0 used by the scheduler as the reschedule IPI.
+            mmio::write8(
+                self.redist_sgi_reg_addr(cpu_id, GICR_IPRIORITYR) + RESCHEDULE_SGI as usize,
+                0x80,
+            );
+            mmio::write32(
+                self.redist_sgi_reg_addr(cpu_id, GICR_ISENABLER0),
+                1 << RESCHEDULE_SGI,
+            );
+
             // Set virtual timer PPI priority to 0x80.
             let timer_ppi = crate::drivers::pic::arm_generic_timer::timer_ppi_irq();
             mmio::write8(
@@ -448,7 +461,7 @@ impl ExternalInterruptController for GicV3 {
         self.validate_cpu_id(target_cpu_id)?;
 
         let intid = match ipi_type {
-            crate::interrupt::controllers::LocalInterruptType::Software => 0u64,
+            crate::interrupt::controllers::LocalInterruptType::Software => RESCHEDULE_SGI as u64,
             crate::interrupt::controllers::LocalInterruptType::External => 1u64,
             crate::interrupt::controllers::LocalInterruptType::Timer => {
                 crate::drivers::pic::arm_generic_timer::timer_ppi_irq() as u64
@@ -460,10 +473,10 @@ impl ExternalInterruptController for GicV3 {
         }
 
         // ICC_SGI1R_EL1 fields used here:
-        //   [27:24] Aff3, [23:16] Aff2, [15:4] INTID, [3:0] ignored when using RS/Aff1/TargetList,
-        //   [55:48] Aff1, [47:44] RS, [43:40] IRM, [39:32] TargetList.
-        // QEMU virt uses a flat affinity layout, so targeting by Aff1=0 and a 1-bit target mask
-        // for CPU IDs < 8 is sufficient for Scarlet's current environment.
+        //   [55:48] Aff3, [47:44] RS, [40] IRM, [39:32] Aff2,
+        //   [27:24] INTID, [23:16] Aff1, [15:0] TargetList.
+        // QEMU virt uses a flat affinity layout, so Aff1/2/3=0 and a
+        // 1-bit TargetList mask for CPU IDs < 8 is sufficient here.
         let target_mask = 1u64
             .checked_shl(target_cpu_id)
             .ok_or(InterruptError::InvalidCpuId)?;

--- a/kernel/src/drivers/pic/gicv3.rs
+++ b/kernel/src/drivers/pic/gicv3.rs
@@ -449,6 +449,12 @@ impl ExternalInterruptController for GicV3 {
     fn max_cpus(&self) -> CpuId {
         self.max_cpus
     }
+
+    fn init_for_cpu(&mut self, cpu_id: CpuId) -> InterruptResult<()> {
+        self.init_redistributor(cpu_id);
+        self.init_cpu_interface_sysregs();
+        Ok(())
+    }
 }
 
 unsafe impl Send for GicV3 {}
@@ -502,8 +508,7 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
     })?;
 
     let max_interrupts = gicd_max_interrupt_id(dist_base_addr);
-    // PlatformDeviceInfo doesn't expose CPU topology here; current bring-up is single-core.
-    let max_cpus = 1;
+    let max_cpus = crate::environment::MAX_NUM_CPUS as u32;
 
     crate::early_println!(
         "[interrupt] GICv3 selected: dist={:#x} redist={:#x} max_intid={} max_cpus={}",

--- a/kernel/src/drivers/pic/gicv3.rs
+++ b/kernel/src/drivers/pic/gicv3.rs
@@ -244,7 +244,7 @@ impl GicV3 {
             mmio::write32(self.redist_sgi_reg_addr(cpu_id, GICR_IGROUPR0), 0xFFFF_FFFF);
 
             // Set virtual timer PPI priority to 0x80.
-            let timer_ppi = crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ;
+            let timer_ppi = crate::drivers::pic::arm_generic_timer::timer_ppi_irq();
             mmio::write8(
                 self.redist_sgi_reg_addr(cpu_id, GICR_IPRIORITYR) + timer_ppi as usize,
                 0x80,
@@ -534,7 +534,7 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
 
     crate::arch::interrupt::configure_timer_interrupt_route(
         crate::arch::interrupt::TimerInterruptRoute::ExternalControllerIrq,
-        Some(crate::drivers::pic::arm_generic_timer::CNTV_PPI_IRQ),
+        Some(crate::drivers::pic::arm_generic_timer::timer_ppi_irq()),
     );
 
     Ok(())

--- a/kernel/src/drivers/pic/gicv3.rs
+++ b/kernel/src/drivers/pic/gicv3.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     early_initcall,
     interrupt::{
-        CpuId, InterruptError, InterruptId, InterruptManager, InterruptResult, Priority,
+        CpuId, InterruptError, InterruptId, InterruptResult, Priority,
         controllers::ExternalInterruptController,
     },
 };
@@ -307,11 +307,7 @@ impl ExternalInterruptController for GicV3 {
         Ok(())
     }
 
-    fn enable_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()> {
+    fn enable_interrupt(&self, interrupt_id: InterruptId, cpu_id: CpuId) -> InterruptResult<()> {
         self.validate_interrupt_id(interrupt_id)?;
         self.validate_cpu_id(cpu_id)?;
 
@@ -329,11 +325,7 @@ impl ExternalInterruptController for GicV3 {
         Ok(())
     }
 
-    fn disable_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()> {
+    fn disable_interrupt(&self, interrupt_id: InterruptId, cpu_id: CpuId) -> InterruptResult<()> {
         self.validate_interrupt_id(interrupt_id)?;
         self.validate_cpu_id(cpu_id)?;
 
@@ -396,7 +388,7 @@ impl ExternalInterruptController for GicV3 {
         Ok(0)
     }
 
-    fn claim_interrupt(&mut self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>> {
+    fn claim_interrupt(&self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>> {
         self.validate_cpu_id(cpu_id)?;
 
         let iar = read_icc_iar1_el1();
@@ -410,11 +402,7 @@ impl ExternalInterruptController for GicV3 {
         }
     }
 
-    fn complete_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_id: InterruptId,
-    ) -> InterruptResult<()> {
+    fn complete_interrupt(&self, cpu_id: CpuId, interrupt_id: InterruptId) -> InterruptResult<()> {
         self.validate_interrupt_id(interrupt_id)?;
         self.validate_cpu_id(cpu_id)?;
 
@@ -525,12 +513,9 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
         max_cpus,
     ));
 
-    InterruptManager::with_manager(|manager| {
-        manager
-            .register_external_controller(gic)
-            .map_err(|_| "Failed to register GICv3")?;
-        Ok(())
-    })?;
+    crate::interrupt::InterruptManager::global()
+        .register_external_controller(gic)
+        .map_err(|_| "Failed to register GICv3")?;
 
     crate::arch::interrupt::configure_timer_interrupt_route(
         crate::arch::interrupt::TimerInterruptRoute::ExternalControllerIrq,

--- a/kernel/src/drivers/pic/gicv3.rs
+++ b/kernel/src/drivers/pic/gicv3.rs
@@ -122,6 +122,13 @@ fn write_icc_igrpen1_el1(v: u64) {
 }
 
 #[inline]
+fn write_icc_sgi1r_el1(v: u64) {
+    unsafe {
+        asm!("msr ICC_SGI1R_EL1, {0}", "isb", in(reg) v, options(nostack));
+    }
+}
+
+#[inline]
 fn gicd_max_interrupt_id(dist_base_addr: usize) -> InterruptId {
     // GICD_TYPER.ITLinesNumber[4:0] gives (#interrupts / 32) - 1.
     // Convert this into a 0-based maximum interrupt ID.
@@ -430,6 +437,39 @@ impl ExternalInterruptController for GicV3 {
     fn init_for_cpu(&mut self, cpu_id: CpuId) -> InterruptResult<()> {
         self.init_redistributor(cpu_id);
         self.init_cpu_interface_sysregs();
+        Ok(())
+    }
+
+    fn send_ipi(
+        &self,
+        target_cpu_id: CpuId,
+        ipi_type: crate::interrupt::controllers::LocalInterruptType,
+    ) -> InterruptResult<()> {
+        self.validate_cpu_id(target_cpu_id)?;
+
+        let intid = match ipi_type {
+            crate::interrupt::controllers::LocalInterruptType::Software => 0u64,
+            crate::interrupt::controllers::LocalInterruptType::External => 1u64,
+            crate::interrupt::controllers::LocalInterruptType::Timer => {
+                crate::drivers::pic::arm_generic_timer::timer_ppi_irq() as u64
+            }
+        };
+
+        if intid >= 16 {
+            return Err(InterruptError::InvalidInterruptId);
+        }
+
+        // ICC_SGI1R_EL1 fields used here:
+        //   [27:24] Aff3, [23:16] Aff2, [15:4] INTID, [3:0] ignored when using RS/Aff1/TargetList,
+        //   [55:48] Aff1, [47:44] RS, [43:40] IRM, [39:32] TargetList.
+        // QEMU virt uses a flat affinity layout, so targeting by Aff1=0 and a 1-bit target mask
+        // for CPU IDs < 8 is sufficient for Scarlet's current environment.
+        let target_mask = 1u64
+            .checked_shl(target_cpu_id)
+            .ok_or(InterruptError::InvalidCpuId)?;
+        let sgi1r = (intid << 24) | target_mask;
+        write_icc_sgi1r_el1(sgi1r);
+
         Ok(())
     }
 }

--- a/kernel/src/drivers/pic/gicv3.rs
+++ b/kernel/src/drivers/pic/gicv3.rs
@@ -292,18 +292,7 @@ impl ExternalInterruptController for GicV3 {
             self.dist_base_addr,
             self.redist_base_addr
         );
-        // Configure distributor + redistributor for CPU0.
-
-        crate::early_println!("[interrupt] GICv3 init: distributor...");
         self.init_distributor();
-
-        crate::early_println!("[interrupt] GICv3 init: redistributor...");
-        self.init_redistributor(0);
-
-        crate::early_println!("[interrupt] GICv3 init: sysregs...");
-        self.init_cpu_interface_sysregs();
-
-        crate::early_println!("[interrupt] GICv3 init: done");
         Ok(())
     }
 

--- a/kernel/src/drivers/pic/plic.rs
+++ b/kernel/src/drivers/pic/plic.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     early_initcall,
     interrupt::{
-        CpuId, InterruptError, InterruptId, InterruptManager, InterruptResult, Priority,
+        CpuId, InterruptError, InterruptId, InterruptResult, Priority,
         controllers::ExternalInterruptController,
     },
 };
@@ -212,11 +212,7 @@ impl ExternalInterruptController for Plic {
     }
 
     /// Enable a specific interrupt for a CPU
-    fn enable_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()> {
+    fn enable_interrupt(&self, interrupt_id: InterruptId, cpu_id: CpuId) -> InterruptResult<()> {
         self.validate_interrupt_id(interrupt_id)?;
         self.validate_cpu_id(cpu_id)?;
 
@@ -247,11 +243,7 @@ impl ExternalInterruptController for Plic {
     }
 
     /// Disable a specific interrupt for a CPU
-    fn disable_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()> {
+    fn disable_interrupt(&self, interrupt_id: InterruptId, cpu_id: CpuId) -> InterruptResult<()> {
         self.validate_interrupt_id(interrupt_id)?;
         self.validate_cpu_id(cpu_id)?;
 
@@ -345,7 +337,7 @@ impl ExternalInterruptController for Plic {
     }
 
     /// Claim an interrupt (acknowledge and get the interrupt ID)
-    fn claim_interrupt(&mut self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>> {
+    fn claim_interrupt(&self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>> {
         self.validate_cpu_id(cpu_id)?;
 
         let addr = self.claim_addr(cpu_id);
@@ -359,11 +351,7 @@ impl ExternalInterruptController for Plic {
     }
 
     /// Complete an interrupt (signal that handling is finished)
-    fn complete_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_id: InterruptId,
-    ) -> InterruptResult<()> {
+    fn complete_interrupt(&self, cpu_id: CpuId, interrupt_id: InterruptId) -> InterruptResult<()> {
         self.validate_cpu_id(cpu_id)?;
         self.validate_interrupt_id(interrupt_id)?;
 
@@ -452,10 +440,7 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
             Box::new(Plic::new(base_addr, 1023, 4))
         };
 
-    match InterruptManager::global()
-        .lock()
-        .register_external_controller(controller)
-    {
+    match crate::interrupt::InterruptManager::global().register_external_controller(controller) {
         Ok(_) => {
             crate::early_println!(
                 "[interrupt] PLIC registered at base address: {:#x}",

--- a/kernel/src/drivers/pic/plic.rs
+++ b/kernel/src/drivers/pic/plic.rs
@@ -435,9 +435,13 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
         } else {
             // Fallback to hardcoded values (TCG-style: M+S per hart)
             crate::early_println!(
-                "[interrupt] PLIC: Using default config (1023 interrupts, 4 contexts)"
+                "[interrupt] PLIC: Using default config (1023 interrupts, MAX_NUM_CPUS contexts)"
             );
-            Box::new(Plic::new(base_addr, 1023, 4))
+            Box::new(Plic::new(
+                base_addr,
+                1023,
+                crate::environment::MAX_NUM_CPUS as CpuId,
+            ))
         };
 
     match crate::interrupt::InterruptManager::global().register_external_controller(controller) {

--- a/kernel/src/drivers/pic/plic.rs
+++ b/kernel/src/drivers/pic/plic.rs
@@ -174,41 +174,37 @@ impl ExternalInterruptController for Plic {
             self.s_mode_contexts
         );
 
-        // Establish a known baseline:
-        // - Disable all interrupts for all contexts first.
-        //   This prevents any firmware/previous-stage configuration from leaking into the kernel.
-        //   Device drivers will later enable only what they need.
-        let word_count = ((self.max_interrupts as usize) + 31) / 32;
-        for cpu_id in 0..self.max_cpus {
-            let context_id = self.context_id_for_cpu(cpu_id);
-            let context_offset = context_id * PLIC_ENABLE_CONTEXT_STRIDE;
-            for word in 0..word_count {
-                let addr = self.base_addr + PLIC_ENABLE_BASE + context_offset + (word * 4);
-                let verify = Self::mmio_write32_with_readback(addr, 0);
-                if verify != 0 {
-                    crate::early_println!(
-                        "PLIC init: clear enable verify failed: cpu={}, context={}, addr={:#x}, read={}",
-                        cpu_id,
-                        context_id,
-                        addr,
-                        verify
-                    );
-                    return Err(InterruptError::HardwareError);
-                }
-            }
-        }
-
-        // Set threshold to 0 for all CPUs (allow all priorities)
-        for cpu_id in 0..self.max_cpus {
-            self.set_threshold(cpu_id, 0)?;
-        }
-
         // Set all interrupt priorities to 1 (lowest non-zero priority)
         for interrupt_id in 1..=self.max_interrupts {
             self.set_priority(interrupt_id, 1)?;
         }
 
         Ok(())
+    }
+
+    fn init_for_cpu(&mut self, cpu_id: CpuId) -> InterruptResult<()> {
+        self.validate_cpu_id(cpu_id)?;
+
+        let word_count = ((self.max_interrupts as usize) + 31) / 32;
+        let context_id = self.context_id_for_cpu(cpu_id);
+        let context_offset = context_id * PLIC_ENABLE_CONTEXT_STRIDE;
+
+        for word in 0..word_count {
+            let addr = self.base_addr + PLIC_ENABLE_BASE + context_offset + (word * 4);
+            let verify = Self::mmio_write32_with_readback(addr, 0);
+            if verify != 0 {
+                crate::early_println!(
+                    "PLIC init_for_cpu: clear enable verify failed: cpu={}, context={}, addr={:#x}, read={}",
+                    cpu_id,
+                    context_id,
+                    addr,
+                    verify
+                );
+                return Err(InterruptError::HardwareError);
+            }
+        }
+
+        self.set_threshold(cpu_id, 0)
     }
 
     /// Enable a specific interrupt for a CPU

--- a/kernel/src/drivers/pic/sbi_clint.rs
+++ b/kernel/src/drivers/pic/sbi_clint.rs
@@ -181,7 +181,7 @@ fn register_driver() {
 
     // Create the SBI timer controller
     let mut controller = Box::new(SbiClint {
-        max_cpus: 4,
+        max_cpus: crate::environment::MAX_NUM_CPUS as usize,
         timebase_frequency_hz,
     });
 
@@ -194,9 +194,10 @@ fn register_driver() {
     }
 
     // Register with InterruptManager instead of DeviceManager
-    match crate::interrupt::InterruptManager::global()
-        .register_local_controller_for_range(controller, 0..4)
-    {
+    match crate::interrupt::InterruptManager::global().register_local_controller_for_range(
+        controller,
+        0..(crate::environment::MAX_NUM_CPUS as CpuId),
+    ) {
         Ok(_) => {}
         Err(e) => {
             crate::early_println!("[interrupt] Failed to register CLINT: {}", e);

--- a/kernel/src/drivers/pic/sbi_clint.rs
+++ b/kernel/src/drivers/pic/sbi_clint.rs
@@ -9,7 +9,7 @@ use alloc::boxed::Box;
 use crate::{
     early_initcall,
     interrupt::{
-        CpuId, InterruptError, InterruptManager, InterruptResult,
+        CpuId, InterruptError, InterruptResult,
         controllers::{LocalInterruptController, LocalInterruptType},
     },
 };
@@ -46,7 +46,7 @@ impl LocalInterruptController for SbiClint {
 
     /// Enable a specific local interrupt type for a CPU
     fn enable_interrupt(
-        &mut self,
+        &self,
         _cpu_id: CpuId,
         interrupt_type: LocalInterruptType,
     ) -> InterruptResult<()> {
@@ -70,7 +70,7 @@ impl LocalInterruptController for SbiClint {
 
     /// Disable a specific local interrupt type for a CPU
     fn disable_interrupt(
-        &mut self,
+        &self,
         cpu_id: CpuId,
         interrupt_type: LocalInterruptType,
     ) -> InterruptResult<()> {
@@ -80,8 +80,8 @@ impl LocalInterruptController for SbiClint {
                 self.set_timer(cpu_id, u64::MAX)
             }
             LocalInterruptType::Software => {
-                // Disable software interrupt by clearing MSIP
-                self.clear_software_interrupt(cpu_id)
+                self.validate_cpu_id(cpu_id)?;
+                Ok(())
             }
             LocalInterruptType::External => {
                 // External interrupts are not managed by CLINT
@@ -123,7 +123,7 @@ impl LocalInterruptController for SbiClint {
     }
 
     /// Send a software interrupt to a specific CPU
-    fn send_software_interrupt(&mut self, _target_cpu: CpuId) -> InterruptResult<()> {
+    fn send_software_interrupt(&self, _target_cpu: CpuId) -> InterruptResult<()> {
         Ok(())
     }
 
@@ -143,7 +143,7 @@ impl LocalInterruptController for SbiClint {
     }
 
     /// Set timer interrupt for a specific CPU
-    fn set_timer(&mut self, cpu_id: CpuId, time: u64) -> InterruptResult<()> {
+    fn set_timer(&self, cpu_id: CpuId, time: u64) -> InterruptResult<()> {
         self.validate_cpu_id(cpu_id)?;
 
         // Set the timer compare register to the specified time using SBI
@@ -194,8 +194,7 @@ fn register_driver() {
     }
 
     // Register with InterruptManager instead of DeviceManager
-    match InterruptManager::global()
-        .lock()
+    match crate::interrupt::InterruptManager::global()
         .register_local_controller_for_range(controller, 0..4)
     {
         Ok(_) => {}

--- a/kernel/src/drivers/uart/pl011.rs
+++ b/kernel/src/drivers/uart/pl011.rs
@@ -109,7 +109,7 @@ impl Pl011Uart {
 
         // Register interrupt with interrupt manager
         crate::interrupt::InterruptManager::global()
-            .enable_external_interrupt(interrupt_id, 0)
+            .enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
             .map_err(|_| "Failed to enable interrupt")?;
 
         Ok(())

--- a/kernel/src/drivers/uart/pl011.rs
+++ b/kernel/src/drivers/uart/pl011.rs
@@ -21,7 +21,7 @@ use crate::{
         },
     },
     driver_initcall,
-    interrupt::{InterruptId, InterruptManager},
+    interrupt::InterruptId,
     object::capability::{ControlOps, MemoryMappingOps, Selectable},
     traits::serial::Serial,
 };
@@ -108,10 +108,9 @@ impl Pl011Uart {
         self.reg_write(UARTIMSC, IMSC_RXIM);
 
         // Register interrupt with interrupt manager
-        InterruptManager::with_manager(|mgr| {
-            mgr.enable_external_interrupt(interrupt_id, 0) // Enable for CPU 0
-        })
-        .map_err(|_| "Failed to enable interrupt")?;
+        crate::interrupt::InterruptManager::global()
+            .enable_external_interrupt(interrupt_id, 0)
+            .map_err(|_| "Failed to enable interrupt")?;
 
         Ok(())
     }
@@ -384,9 +383,9 @@ fn pl011_probe(device_info: &PlatformDeviceInfo) -> Result<(), &'static str> {
         } else {
             crate::early_println!("PL011 interrupts enabled (ID: {})", uart_interrupt_id);
 
-            if let Err(e) = InterruptManager::with_manager(|mgr| {
-                mgr.register_interrupt_device(uart_interrupt_id, uart.clone())
-            }) {
+            if let Err(e) = crate::interrupt::InterruptManager::global()
+                .register_interrupt_device(uart_interrupt_id, uart.clone())
+            {
                 crate::early_println!("Failed to register PL011 interrupt device: {}", e);
             } else {
                 crate::early_println!("PL011 interrupt device registered");

--- a/kernel/src/drivers/uart/virt.rs
+++ b/kernel/src/drivers/uart/virt.rs
@@ -98,7 +98,7 @@ impl Uart {
 
         // Register interrupt with interrupt manager
         crate::interrupt::InterruptManager::global()
-            .enable_external_interrupt(interrupt_id, 0)
+            .enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
             .map_err(|_| "Failed to enable interrupt")?;
 
         Ok(())

--- a/kernel/src/drivers/uart/virt.rs
+++ b/kernel/src/drivers/uart/virt.rs
@@ -19,7 +19,7 @@ use crate::{
         },
     },
     driver_initcall,
-    interrupt::{InterruptId, InterruptManager},
+    interrupt::InterruptId,
     object::capability::{ControlOps, MemoryMappingOps, Selectable},
     traits::serial::Serial,
 };
@@ -97,10 +97,9 @@ impl Uart {
         self.reg_write(IER_OFFSET, IER_RDA);
 
         // Register interrupt with interrupt manager
-        InterruptManager::with_manager(|mgr| {
-            mgr.enable_external_interrupt(interrupt_id, 0) // Enable for CPU 0
-        })
-        .map_err(|_| "Failed to enable interrupt")?;
+        crate::interrupt::InterruptManager::global()
+            .enable_external_interrupt(interrupt_id, 0)
+            .map_err(|_| "Failed to enable interrupt")?;
 
         Ok(())
     }
@@ -379,9 +378,9 @@ fn uart_probe(device_info: &PlatformDeviceInfo) -> Result<(), &'static str> {
             crate::early_println!("UART interrupts enabled (ID: {})", uart_interrupt_id);
 
             // Register interrupt handler
-            if let Err(e) = InterruptManager::with_manager(|mgr| {
-                mgr.register_interrupt_device(uart_interrupt_id, uart.clone())
-            }) {
+            if let Err(e) = crate::interrupt::InterruptManager::global()
+                .register_interrupt_device(uart_interrupt_id, uart.clone())
+            {
                 crate::early_println!("Failed to register UART interrupt device: {}", e);
             } else {
                 crate::early_println!("UART interrupt device registered");

--- a/kernel/src/drivers/uart/virt.rs
+++ b/kernel/src/drivers/uart/virt.rs
@@ -133,6 +133,16 @@ impl Uart {
     fn can_write(&self) -> bool {
         self.reg_read(LSR_OFFSET) & LSR_THRE != 0
     }
+
+    fn drain_rx(&self) {
+        // Drain all available RX bytes. Reading only one byte can leave the
+        // FIFO non-empty without producing a new edge, which loses interactive
+        // input such as "ls\n" after the first interrupt.
+        while self.can_read() {
+            let c = self.read_byte_internal();
+            self.emit_event(&InputEvent { data: c });
+        }
+    }
 }
 
 impl Serial for Uart {
@@ -283,21 +293,7 @@ impl EventCapableDevice for Uart {
 
 impl InterruptCapableDevice for Uart {
     fn handle_interrupt(&self) -> crate::interrupt::InterruptResult<()> {
-        // let inner = self.inner.lock();
-        // Check interrupt identification register
-        let iir = self.reg_read(IIR_OFFSET);
-
-        if iir & IIR_PENDING == 0 {
-            let c = self.read_byte_internal();
-            if c != 0 {
-                // Emit received character event
-                self.emit_event(&InputEvent { data: c as u8 });
-            } else {
-                // No data available, return Ok
-                return Ok(());
-            }
-        }
-
+        self.drain_rx();
         Ok(())
     }
 

--- a/kernel/src/drivers/usb/xhci/mod.rs
+++ b/kernel/src/drivers/usb/xhci/mod.rs
@@ -548,7 +548,7 @@ impl XhciController {
         }
 
         crate::interrupt::InterruptManager::global()
-            .enable_external_interrupt(interrupt_id, 0)
+            .enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
             .map_err(|_| "Failed to enable xHCI interrupt")
     }
 

--- a/kernel/src/drivers/usb/xhci/mod.rs
+++ b/kernel/src/drivers/usb/xhci/mod.rs
@@ -45,7 +45,7 @@ use crate::drivers::usb::xhci::registers::{RegisterSpace, capability, operationa
 use crate::drivers::usb::xhci::ring::{DmaTrbRing, EventRing};
 use crate::drivers::usb::xhci::trb::{Trb, TrbType};
 use crate::early_println;
-use crate::interrupt::{InterruptId, InterruptManager};
+use crate::interrupt::InterruptId;
 use crate::mem::page::ContiguousPages;
 use crate::timer::{TimerHandler, add_timer, get_tick, ms_to_ticks};
 use crate::vm;
@@ -547,7 +547,8 @@ impl XhciController {
             );
         }
 
-        InterruptManager::with_manager(|mgr| mgr.enable_external_interrupt(interrupt_id, 0))
+        crate::interrupt::InterruptManager::global()
+            .enable_external_interrupt(interrupt_id, 0)
             .map_err(|_| "Failed to enable xHCI interrupt")
     }
 
@@ -1457,10 +1458,9 @@ pub fn bind_xhci_mmio(
 
     if let Some(interrupt_id) = interrupt {
         controller.enable_interrupts(interrupt_id)?;
-        InterruptManager::with_manager(|mgr| {
-            mgr.register_interrupt_device(interrupt_id, controller.clone())
-        })
-        .map_err(|_| "Failed to register xHCI interrupt device")?;
+        crate::interrupt::InterruptManager::global()
+            .register_interrupt_device(interrupt_id, controller.clone())
+            .map_err(|_| "Failed to register xHCI interrupt device")?;
         early_println!("[xHCI] Registered IRQ {}", interrupt_id);
     } else {
         early_println!("[xHCI] No interrupt provided for platform controller");

--- a/kernel/src/drivers/virtio/device/mod.rs
+++ b/kernel/src/drivers/virtio/device/mod.rs
@@ -1024,9 +1024,9 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
 
                 if let Err(e) = dev.enable_interrupts(interrupt_id) {
                     crate::early_println!("[Virtio] Failed to enable net interrupts: {}", e);
-                } else if let Err(e) = crate::interrupt::InterruptManager::with_manager(|mgr| {
-                    mgr.register_interrupt_device(interrupt_id, dev.clone())
-                }) {
+                } else if let Err(e) = crate::interrupt::InterruptManager::global()
+                    .register_interrupt_device(interrupt_id, dev.clone())
+                {
                     crate::early_println!(
                         "[Virtio] Failed to register net interrupt device: {}",
                         e
@@ -1075,9 +1075,9 @@ fn probe_fn(device: &PlatformDeviceInfo) -> Result<(), &'static str> {
                     );
 
                     // Register interrupt handler
-                    if let Err(e) = crate::interrupt::InterruptManager::with_manager(|mgr| {
-                        mgr.register_interrupt_device(interrupt_id, dev.clone())
-                    }) {
+                    if let Err(e) = crate::interrupt::InterruptManager::global()
+                        .register_interrupt_device(interrupt_id, dev.clone())
+                    {
                         crate::early_println!(
                             "[Virtio] Failed to register input interrupt device: {}",
                             e

--- a/kernel/src/drivers/virtio_input.rs
+++ b/kernel/src/drivers/virtio_input.rs
@@ -418,7 +418,7 @@ impl VirtioInputDevice {
 
         // Enable interrupt in PLIC for CPU 0
         crate::interrupt::InterruptManager::global()
-            .enable_external_interrupt(interrupt_id, 0)
+            .enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
             .map_err(|_| "Failed to enable interrupt in PLIC")?;
 
         Ok(())

--- a/kernel/src/drivers/virtio_input.rs
+++ b/kernel/src/drivers/virtio_input.rs
@@ -417,10 +417,9 @@ impl VirtioInputDevice {
         }
 
         // Enable interrupt in PLIC for CPU 0
-        crate::interrupt::InterruptManager::with_manager(|mgr| {
-            mgr.enable_external_interrupt(interrupt_id, 0)
-        })
-        .map_err(|_| "Failed to enable interrupt in PLIC")?;
+        crate::interrupt::InterruptManager::global()
+            .enable_external_interrupt(interrupt_id, 0)
+            .map_err(|_| "Failed to enable interrupt in PLIC")?;
 
         Ok(())
     }

--- a/kernel/src/earlycon.rs
+++ b/kernel/src/earlycon.rs
@@ -22,7 +22,6 @@ macro_rules! early_println {
 }
 
 struct EarlyConsole;
-
 impl Write for EarlyConsole {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         for c in s.bytes() {

--- a/kernel/src/earlycon.rs
+++ b/kernel/src/earlycon.rs
@@ -21,7 +21,13 @@ macro_rules! early_println {
     ($fmt:expr, $($arg:tt)*) => ($crate::early_print!(concat!($fmt, "\n"), $($arg)*));
 }
 
-struct EarlyConsole;
+pub struct EarlyConsole;
+
+impl EarlyConsole {
+    pub const fn new() -> Self {
+        Self
+    }
+}
 impl Write for EarlyConsole {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         for c in s.bytes() {

--- a/kernel/src/environment/common.rs
+++ b/kernel/src/environment/common.rs
@@ -1,4 +1,4 @@
-pub const MAX_NUM_CPUS: usize = 2;
+pub const MAX_NUM_CPUS: usize = 16;
 
 pub const STACK_SIZE: usize = 0x80000; // 128KiB
 pub const PAGE_SIZE: usize = 0x1000; // 4KB

--- a/kernel/src/executor/tests.rs
+++ b/kernel/src/executor/tests.rs
@@ -8,21 +8,21 @@ use alloc::vec::Vec;
 
 use super::executor::TransparentExecutor;
 use crate::arch::Trapframe;
+use crate::sched::scheduler::{add_task, get_task_by_id, reset};
 use crate::task::new_user_task;
 
 /// Test that TransparentExecutor can backup and restore task state on exec failure
 #[test_case]
 fn test_exec_backup_restore() {
     // Reset scheduler state before test
-    let scheduler = crate::sched::scheduler::get_scheduler();
-    scheduler.reset();
+    reset();
 
     // Initialize task first, then add to scheduler
     let mut task = new_user_task("BackupTestTask".to_string(), 1001);
     task.init();
 
-    let task_id = scheduler.add_task(task, 0);
-    let mut task = scheduler.get_task_by_id(task_id).unwrap();
+    let task_id = add_task(task, 0);
+    let mut task = get_task_by_id(task_id).unwrap();
     let mut trapframe = Trapframe::new();
 
     // Record original state
@@ -89,15 +89,14 @@ fn test_exec_backup_restore() {
 #[test_case]
 fn test_exec_parameter_validation() {
     // Reset scheduler state before test
-    let scheduler = crate::sched::scheduler::get_scheduler();
-    scheduler.reset();
+    reset();
 
     // Initialize task first, then add to scheduler
     let task = new_user_task("ParamTestTask".to_string(), 1002);
     task.init();
 
-    let task_id = scheduler.add_task(task, 0);
-    let mut task = scheduler.get_task_by_id(task_id).unwrap();
+    let task_id = add_task(task, 0);
+    let mut task = get_task_by_id(task_id).unwrap();
     let mut trapframe = Trapframe::new();
 
     // Test with empty arguments
@@ -137,15 +136,14 @@ fn test_exec_parameter_validation() {
 #[test_case]
 fn test_argv_array_handling() {
     // Reset scheduler state before test
-    let scheduler = crate::sched::scheduler::get_scheduler();
-    scheduler.reset();
+    reset();
 
     // Initialize task first, then add to scheduler
     let mut task = new_user_task("ArgvTestTask".to_string(), 1003);
     task.init();
 
-    let task_id = scheduler.add_task(task, 0);
-    let mut task = scheduler.get_task_by_id(task_id).unwrap();
+    let task_id = add_task(task, 0);
+    let mut task = get_task_by_id(task_id).unwrap();
     let mut trapframe = Trapframe::new();
 
     // Test with different argument patterns
@@ -180,15 +178,14 @@ fn test_argv_array_handling() {
 #[test_case]
 fn test_envp_array_handling() {
     // Reset scheduler state before test
-    let scheduler = crate::sched::scheduler::get_scheduler();
-    scheduler.reset();
+    reset();
 
     // Initialize task first, then add to scheduler
     let mut task = new_user_task("EnvpTestTask".to_string(), 1004);
     task.init();
 
-    let task_id = scheduler.add_task(task, 0);
-    let mut task = scheduler.get_task_by_id(task_id).unwrap();
+    let task_id = add_task(task, 0);
+    let mut task = get_task_by_id(task_id).unwrap();
     let mut trapframe = Trapframe::new();
 
     // Test with different environment variable patterns

--- a/kernel/src/interrupt/controllers.rs
+++ b/kernel/src/interrupt/controllers.rs
@@ -17,14 +17,14 @@ pub trait LocalInterruptController: Send + Sync {
 
     /// Enable a specific local interrupt type for a CPU
     fn enable_interrupt(
-        &mut self,
+        &self,
         cpu_id: CpuId,
         interrupt_type: LocalInterruptType,
     ) -> InterruptResult<()>;
 
     /// Disable a specific local interrupt type for a CPU
     fn disable_interrupt(
-        &mut self,
+        &self,
         cpu_id: CpuId,
         interrupt_type: LocalInterruptType,
     ) -> InterruptResult<()>;
@@ -40,13 +40,13 @@ pub trait LocalInterruptController: Send + Sync {
     ) -> InterruptResult<()>;
 
     /// Send a software interrupt to a specific CPU
-    fn send_software_interrupt(&mut self, target_cpu: CpuId) -> InterruptResult<()>;
+    fn send_software_interrupt(&self, target_cpu: CpuId) -> InterruptResult<()>;
 
     /// Clear a software interrupt for a specific CPU
     fn clear_software_interrupt(&mut self, cpu_id: CpuId) -> InterruptResult<()>;
 
     /// Set timer interrupt for a specific CPU
-    fn set_timer(&mut self, cpu_id: CpuId, time: u64) -> InterruptResult<()>;
+    fn set_timer(&self, cpu_id: CpuId, time: u64) -> InterruptResult<()>;
 
     /// Get current timer value
     fn get_time(&self) -> u64;
@@ -64,15 +64,10 @@ pub trait ExternalInterruptController: Send + Sync {
     fn init(&mut self) -> InterruptResult<()>;
 
     /// Enable a specific interrupt for a CPU
-    fn enable_interrupt(&mut self, interrupt_id: InterruptId, cpu_id: CpuId)
-    -> InterruptResult<()>;
+    fn enable_interrupt(&self, interrupt_id: InterruptId, cpu_id: CpuId) -> InterruptResult<()>;
 
     /// Disable a specific interrupt for a CPU
-    fn disable_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()>;
+    fn disable_interrupt(&self, interrupt_id: InterruptId, cpu_id: CpuId) -> InterruptResult<()>;
 
     /// Set priority for a specific interrupt
     fn set_priority(
@@ -91,14 +86,10 @@ pub trait ExternalInterruptController: Send + Sync {
     fn get_threshold(&self, cpu_id: CpuId) -> InterruptResult<Priority>;
 
     /// Claim an interrupt (acknowledge and get the interrupt ID)
-    fn claim_interrupt(&mut self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>>;
+    fn claim_interrupt(&self, cpu_id: CpuId) -> InterruptResult<Option<InterruptId>>;
 
     /// Complete an interrupt (signal that handling is finished)
-    fn complete_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_id: InterruptId,
-    ) -> InterruptResult<()>;
+    fn complete_interrupt(&self, cpu_id: CpuId, interrupt_id: InterruptId) -> InterruptResult<()>;
 
     /// Check if a specific interrupt is pending
     fn is_pending(&self, interrupt_id: InterruptId) -> bool;
@@ -109,11 +100,7 @@ pub trait ExternalInterruptController: Send + Sync {
     /// Get the number of CPUs supported
     fn max_cpus(&self) -> CpuId;
 
-    fn send_ipi(
-        &mut self,
-        target_cpu_id: CpuId,
-        ipi_type: LocalInterruptType,
-    ) -> InterruptResult<()> {
+    fn send_ipi(&self, target_cpu_id: CpuId, ipi_type: LocalInterruptType) -> InterruptResult<()> {
         let _ = (target_cpu_id, ipi_type);
         Err(InterruptError::NotSupported)
     }
@@ -207,17 +194,16 @@ impl InterruptControllers {
     }
 
     /// Get a reference to the local interrupt controller for a specific CPU
-    pub fn local_controller_for_cpu(
-        &self,
-        cpu_id: CpuId,
-    ) -> Option<&Box<dyn LocalInterruptController>> {
+    pub fn local_controller_for_cpu(&self, cpu_id: CpuId) -> Option<&dyn LocalInterruptController> {
         let controller_index = self.cpu_to_local_controller.get(&cpu_id)?;
-        self.local_controllers.get(*controller_index)
+        self.local_controllers
+            .get(*controller_index)
+            .map(Box::as_ref)
     }
 
     /// Get a reference to a specific local interrupt controller by index
-    pub fn local_controller(&self, index: usize) -> Option<&Box<dyn LocalInterruptController>> {
-        self.local_controllers.get(index)
+    pub fn local_controller(&self, index: usize) -> Option<&dyn LocalInterruptController> {
+        self.local_controllers.get(index).map(Box::as_ref)
     }
 
     /// Get a mutable reference to the local interrupt controller for a specific CPU
@@ -240,6 +226,11 @@ impl InterruptControllers {
     /// Get a mutable reference to the external interrupt controller
     pub fn external_controller_mut(&mut self) -> Option<&mut Box<dyn ExternalInterruptController>> {
         self.external_controller.as_mut()
+    }
+
+    /// Get a shared reference to the external interrupt controller
+    pub fn external_controller(&self) -> Option<&dyn ExternalInterruptController> {
+        self.external_controller.as_deref()
     }
 
     /// Initialize all local controllers for their respective CPUs

--- a/kernel/src/interrupt/controllers.rs
+++ b/kernel/src/interrupt/controllers.rs
@@ -108,6 +108,15 @@ pub trait ExternalInterruptController: Send + Sync {
 
     /// Get the number of CPUs supported
     fn max_cpus(&self) -> CpuId;
+
+    fn send_ipi(
+        &mut self,
+        target_cpu_id: CpuId,
+        ipi_type: LocalInterruptType,
+    ) -> InterruptResult<()> {
+        let _ = (target_cpu_id, ipi_type);
+        Err(InterruptError::NotSupported)
+    }
 }
 
 /// Types of local interrupts

--- a/kernel/src/interrupt/controllers.rs
+++ b/kernel/src/interrupt/controllers.rs
@@ -117,6 +117,10 @@ pub trait ExternalInterruptController: Send + Sync {
         let _ = (target_cpu_id, ipi_type);
         Err(InterruptError::NotSupported)
     }
+
+    fn init_for_cpu(&mut self, _cpu_id: CpuId) -> InterruptResult<()> {
+        Ok(())
+    }
 }
 
 /// Types of local interrupts

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -476,10 +476,19 @@ pub fn are_interrupts_enabled() -> bool {
     arch::interrupt::are_interrupts_enabled()
 }
 
+/// Enable software interrupt reception at CPU level.
+///
+/// RISC-V uses this for SSIE (reschedule IPIs). AArch64 SGIs are GIC-backed and
+/// do not require a separate architectural CPU bit beyond the IRQ mask.
+pub fn enable_software_interrupts() {
+    arch::interrupt::enable_software_interrupts();
+}
+
 /// Enable CPU interrupt reception (stage 2).
 ///
 /// This should run after device drivers have registered their handlers and
 /// enabled the desired interrupt lines in the controller.
 pub fn enable_cpu_interrupts() {
     enable_external_interrupts();
+    enable_software_interrupts();
 }

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -56,20 +56,9 @@ impl InterruptManager {
     }
 
     pub fn init_controllers(&self) {
-        disable_interrupts();
-        crate::early_println!("[interrupt] init: local controllers...");
-
-        let mut controllers = self.controllers().lock();
-        match controllers.init_local_controllers() {
-            Ok(()) => {}
-            Err(e) => {
-                crate::early_println!("Failed to initialize local controllers: {}", e);
-            }
-        }
-
-        crate::early_println!("[interrupt] init: local controllers done");
         crate::early_println!("[interrupt] init: external controller...");
 
+        let mut controllers = self.controllers().lock();
         match controllers.init_external_controller() {
             Ok(()) => {}
             Err(e) => {

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -237,6 +237,30 @@ impl InterruptManager {
         crate::early_println!("[interrupt] init: external controller done");
     }
 
+    pub fn init_controllers_for_cpu(&mut self, cpu_id: CpuId) {
+        disable_interrupts();
+
+        if let Some(controller) = self.controllers.local_controller_mut_for_cpu(cpu_id) {
+            if let Err(e) = controller.init(cpu_id) {
+                crate::early_println!(
+                    "[interrupt] AP {}: failed to init local controller: {}",
+                    cpu_id,
+                    e
+                );
+            }
+        }
+
+        if let Some(controller) = self.controllers.external_controller_mut() {
+            if let Err(e) = controller.init_for_cpu(cpu_id) {
+                crate::early_println!(
+                    "[interrupt] AP {}: failed to init external controller: {}",
+                    cpu_id,
+                    e
+                );
+            }
+        }
+    }
+
     /// Enable CPU interrupt reception (stage 2).
     ///
     /// This should run after device drivers have registered their handlers and

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -497,6 +497,18 @@ impl InterruptManager {
     pub fn has_external_controller(&self) -> bool {
         self.controllers.has_external_controller()
     }
+
+    pub fn send_ipi(
+        &mut self,
+        target_cpu_id: CpuId,
+        ipi_type: controllers::LocalInterruptType,
+    ) -> InterruptResult<()> {
+        if let Some(ref mut controller) = self.controllers.external_controller_mut() {
+            controller.send_ipi(target_cpu_id, ipi_type)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
 }
 
 /// Handler function type for external interrupts

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -3,12 +3,15 @@
 //! This module provides a comprehensive interrupt management system for the Scarlet kernel.
 //! It supports both local interrupts (via CLINT) and external interrupts (via PLIC) on RISC-V architecture.
 
+use alloc::sync::Arc;
 use core::fmt;
 use hashbrown::HashMap;
 
 use crate::arch::{self, interrupt::enable_external_interrupts};
 
 pub mod controllers;
+
+static INTERRUPT_MANAGER: spin::Once<InterruptManager> = spin::Once::new();
 
 /// Interrupt ID type
 pub type InterruptId = u32;
@@ -19,29 +22,356 @@ pub type CpuId = u32;
 /// Priority level for interrupts
 pub type Priority = u32;
 
+/// Handler function type for external interrupts
+pub type ExternalInterruptHandler = fn(&mut InterruptHandle) -> InterruptResult<()>;
+
+/// Handler function type for local interrupts (timer, software)
+pub type LocalInterruptHandler =
+    fn(cpu_id: CpuId, interrupt_type: controllers::LocalInterruptType) -> InterruptResult<()>;
+
+pub struct InterruptManager {
+    controllers: spin::Once<spin::Mutex<controllers::InterruptControllers>>,
+    external_handlers: spin::Lazy<spin::Mutex<HashMap<InterruptId, ExternalInterruptHandler>>>,
+    interrupt_devices: spin::Lazy<
+        spin::Mutex<HashMap<InterruptId, Arc<dyn crate::device::events::InterruptCapableDevice>>>,
+    >,
+}
+
+impl InterruptManager {
+    pub fn new() -> Self {
+        Self {
+            controllers: spin::Once::new(),
+            external_handlers: spin::Lazy::new(|| spin::Mutex::new(HashMap::new())),
+            interrupt_devices: spin::Lazy::new(|| spin::Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn global() -> &'static InterruptManager {
+        INTERRUPT_MANAGER.call_once(Self::new)
+    }
+
+    fn controllers(&self) -> &spin::Mutex<controllers::InterruptControllers> {
+        self.controllers
+            .call_once(|| spin::Mutex::new(controllers::InterruptControllers::new()))
+    }
+
+    pub fn init_controllers(&self) {
+        disable_interrupts();
+        crate::early_println!("[interrupt] init: local controllers...");
+
+        let mut controllers = self.controllers().lock();
+        match controllers.init_local_controllers() {
+            Ok(()) => {}
+            Err(e) => {
+                crate::early_println!("Failed to initialize local controllers: {}", e);
+            }
+        }
+
+        crate::early_println!("[interrupt] init: local controllers done");
+        crate::early_println!("[interrupt] init: external controller...");
+
+        match controllers.init_external_controller() {
+            Ok(()) => {}
+            Err(e) => {
+                crate::early_println!("Failed to initialize external controller: {}", e);
+            }
+        }
+
+        crate::early_println!("[interrupt] init: external controller done");
+    }
+
+    pub fn init_controllers_for_cpu(&self, cpu_id: CpuId) {
+        disable_interrupts();
+
+        let mut controllers = self.controllers().lock();
+
+        if let Some(controller) = controllers.local_controller_mut_for_cpu(cpu_id) {
+            if let Err(e) = controller.init(cpu_id) {
+                crate::early_println!(
+                    "[interrupt] AP {}: failed to init local controller: {}",
+                    cpu_id,
+                    e
+                );
+            }
+        }
+
+        if let Some(controller) = controllers.external_controller_mut() {
+            if let Err(e) = controller.init_for_cpu(cpu_id) {
+                crate::early_println!(
+                    "[interrupt] AP {}: failed to init external controller: {}",
+                    cpu_id,
+                    e
+                );
+            }
+        }
+    }
+
+    pub fn handle_external_interrupt(
+        &self,
+        interrupt_id: InterruptId,
+        cpu_id: CpuId,
+    ) -> InterruptResult<()> {
+        let device = {
+            let devices = self.interrupt_devices.lock();
+            devices.get(&interrupt_id).cloned()
+        };
+
+        if let Some(device) = device {
+            device.handle_interrupt()?;
+            self.complete_external_interrupt(cpu_id, interrupt_id)
+        } else {
+            let handler = {
+                let handlers = self.external_handlers.lock();
+                handlers.get(&interrupt_id).copied()
+            };
+
+            if let Some(handler_fn) = handler {
+                let mut handle = InterruptHandle::new(interrupt_id, cpu_id);
+                handler_fn(&mut handle)
+            } else {
+                self.complete_external_interrupt(cpu_id, interrupt_id)
+            }
+        }
+    }
+
+    pub fn claim_and_handle_external_interrupt(
+        &self,
+        cpu_id: CpuId,
+    ) -> InterruptResult<Option<InterruptId>> {
+        let interrupt_id = {
+            let controllers = self.controllers().lock();
+            if let Some(controller) = controllers.external_controller() {
+                controller.claim_interrupt(cpu_id)?
+            } else {
+                return Err(InterruptError::ControllerNotFound);
+            }
+        };
+
+        if let Some(id) = interrupt_id {
+            self.handle_external_interrupt(id, cpu_id)?;
+            Ok(Some(id))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn enable_local_interrupt(
+        &self,
+        cpu_id: CpuId,
+        interrupt_type: controllers::LocalInterruptType,
+    ) -> InterruptResult<()> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.local_controller_for_cpu(cpu_id) {
+            controller.enable_interrupt(cpu_id, interrupt_type)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn disable_local_interrupt(
+        &self,
+        cpu_id: CpuId,
+        interrupt_type: controllers::LocalInterruptType,
+    ) -> InterruptResult<()> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.local_controller_for_cpu(cpu_id) {
+            controller.disable_interrupt(cpu_id, interrupt_type)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn send_software_interrupt(&self, target_cpu: CpuId) -> InterruptResult<()> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.local_controller_for_cpu(target_cpu) {
+            controller.send_software_interrupt(target_cpu)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn set_timer(&self, cpu_id: CpuId, time: u64) -> InterruptResult<()> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.local_controller_for_cpu(cpu_id) {
+            controller.set_timer(cpu_id, time)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn get_time(&self, cpu_id: CpuId) -> InterruptResult<u64> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.local_controller_for_cpu(cpu_id) {
+            Ok(controller.get_time())
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn get_timer_frequency_hz(&self, cpu_id: CpuId) -> InterruptResult<u64> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.local_controller_for_cpu(cpu_id) {
+            Ok(controller.get_timer_frequency_hz())
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn is_local_interrupt_pending(
+        &self,
+        cpu_id: CpuId,
+        interrupt_type: controllers::LocalInterruptType,
+    ) -> bool {
+        let controllers = self.controllers().lock();
+        controllers
+            .local_controller_for_cpu(cpu_id)
+            .map(|controller| controller.is_pending(cpu_id, interrupt_type))
+            .unwrap_or(false)
+    }
+
+    pub fn register_local_controller(
+        &self,
+        controller: alloc::boxed::Box<dyn controllers::LocalInterruptController>,
+        cpu_ids: &[CpuId],
+    ) -> InterruptResult<usize> {
+        let mut controllers = self.controllers().lock();
+        Ok(controllers.register_local_controller(controller, cpu_ids))
+    }
+
+    pub fn register_local_controller_for_range(
+        &self,
+        controller: alloc::boxed::Box<dyn controllers::LocalInterruptController>,
+        cpu_range: core::ops::Range<CpuId>,
+    ) -> InterruptResult<usize> {
+        let mut controllers = self.controllers().lock();
+        Ok(controllers.register_local_controller_for_range(controller, cpu_range))
+    }
+
+    pub fn register_local_controller_for_cpu(
+        &self,
+        controller: alloc::boxed::Box<dyn controllers::LocalInterruptController>,
+        cpu_id: CpuId,
+    ) -> InterruptResult<usize> {
+        let mut controllers = self.controllers().lock();
+        Ok(controllers.register_local_controller_for_cpu(controller, cpu_id))
+    }
+
+    pub fn register_external_controller(
+        &self,
+        controller: alloc::boxed::Box<dyn controllers::ExternalInterruptController>,
+    ) -> InterruptResult<()> {
+        let mut controllers = self.controllers().lock();
+        if controllers.has_external_controller() {
+            return Err(InterruptError::HardwareError);
+        }
+        controllers.register_external_controller(controller);
+        Ok(())
+    }
+
+    pub fn register_external_handler(
+        &self,
+        interrupt_id: InterruptId,
+        handler: ExternalInterruptHandler,
+    ) -> InterruptResult<()> {
+        let mut handlers = self.external_handlers.lock();
+        if handlers.contains_key(&interrupt_id) {
+            return Err(InterruptError::HandlerAlreadyRegistered);
+        }
+        handlers.insert(interrupt_id, handler);
+        Ok(())
+    }
+
+    pub fn register_interrupt_device(
+        &self,
+        interrupt_id: InterruptId,
+        device: Arc<dyn crate::device::events::InterruptCapableDevice>,
+    ) -> InterruptResult<()> {
+        let mut devices = self.interrupt_devices.lock();
+        if devices.contains_key(&interrupt_id) {
+            return Err(InterruptError::HandlerAlreadyRegistered);
+        }
+        devices.insert(interrupt_id, device);
+        Ok(())
+    }
+
+    pub fn complete_external_interrupt(
+        &self,
+        cpu_id: CpuId,
+        interrupt_id: InterruptId,
+    ) -> InterruptResult<()> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.external_controller() {
+            controller.complete_interrupt(cpu_id, interrupt_id)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn enable_external_interrupt(
+        &self,
+        interrupt_id: InterruptId,
+        cpu_id: CpuId,
+    ) -> InterruptResult<()> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.external_controller() {
+            controller.enable_interrupt(interrupt_id, cpu_id)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn disable_external_interrupt(
+        &self,
+        interrupt_id: InterruptId,
+        cpu_id: CpuId,
+    ) -> InterruptResult<()> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.external_controller() {
+            controller.disable_interrupt(interrupt_id, cpu_id)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+
+    pub fn has_local_controller(&self) -> bool {
+        self.controllers().lock().has_local_controller()
+    }
+
+    pub fn has_external_controller(&self) -> bool {
+        self.controllers().lock().has_external_controller()
+    }
+
+    pub fn send_ipi(
+        &self,
+        target_cpu_id: CpuId,
+        ipi_type: controllers::LocalInterruptType,
+    ) -> InterruptResult<()> {
+        let controllers = self.controllers().lock();
+        if let Some(controller) = controllers.external_controller() {
+            controller.send_ipi(target_cpu_id, ipi_type)
+        } else {
+            Err(InterruptError::ControllerNotFound)
+        }
+    }
+}
+
 /// Handle for managing interrupt processing
 ///
 /// This provides a safe interface for interrupt handlers to interact with
 /// the interrupt controller without direct access.
-pub struct InterruptHandle<'a> {
+pub struct InterruptHandle {
     interrupt_id: InterruptId,
     cpu_id: CpuId,
     completed: bool,
-    manager: &'a mut InterruptManager,
 }
 
-impl<'a> InterruptHandle<'a> {
+impl InterruptHandle {
     /// Create a new interrupt handle
-    pub fn new(
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-        manager: &'a mut InterruptManager,
-    ) -> Self {
+    pub fn new(interrupt_id: InterruptId, cpu_id: CpuId) -> Self {
         Self {
             interrupt_id,
             cpu_id,
             completed: false,
-            manager,
         }
     }
 
@@ -63,8 +393,7 @@ impl<'a> InterruptHandle<'a> {
             return Err(InterruptError::InvalidOperation);
         }
 
-        self.manager
-            .complete_external_interrupt(self.cpu_id, self.interrupt_id)?;
+        InterruptManager::global().complete_external_interrupt(self.cpu_id, self.interrupt_id)?;
         self.completed = true;
         Ok(())
     }
@@ -75,22 +404,19 @@ impl<'a> InterruptHandle<'a> {
     }
 
     /// Enable another interrupt
-    pub fn enable_interrupt(&mut self, target_interrupt: InterruptId) -> InterruptResult<()> {
-        self.manager
-            .enable_external_interrupt(target_interrupt, self.cpu_id)
+    pub fn enable_interrupt(&self, target_interrupt: InterruptId) -> InterruptResult<()> {
+        InterruptManager::global().enable_external_interrupt(target_interrupt, self.cpu_id)
     }
 
     /// Disable another interrupt
-    pub fn disable_interrupt(&mut self, target_interrupt: InterruptId) -> InterruptResult<()> {
-        self.manager
-            .disable_external_interrupt(target_interrupt, self.cpu_id)
+    pub fn disable_interrupt(&self, target_interrupt: InterruptId) -> InterruptResult<()> {
+        InterruptManager::global().disable_external_interrupt(target_interrupt, self.cpu_id)
     }
 }
 
-impl<'a> Drop for InterruptHandle<'a> {
+impl Drop for InterruptHandle {
     fn drop(&mut self) {
         if !self.completed {
-            // Auto-complete if not manually completed
             let _ = self.complete();
         }
     }
@@ -161,383 +487,10 @@ pub fn are_interrupts_enabled() -> bool {
     arch::interrupt::are_interrupts_enabled()
 }
 
-/// Unified interrupt manager
+/// Enable CPU interrupt reception (stage 2).
 ///
-/// This manages both local and external interrupts in a single structure.
-pub struct InterruptManager {
-    controllers: controllers::InterruptControllers,
-    external_handlers: spin::Mutex<HashMap<InterruptId, ExternalInterruptHandler>>,
-    interrupt_devices: spin::Mutex<
-        HashMap<InterruptId, alloc::sync::Arc<dyn crate::device::events::InterruptCapableDevice>>,
-    >,
+/// This should run after device drivers have registered their handlers and
+/// enabled the desired interrupt lines in the controller.
+pub fn enable_cpu_interrupts() {
+    enable_external_interrupts();
 }
-
-impl InterruptManager {
-    /// Create a new interrupt manager
-    pub fn new() -> Self {
-        Self {
-            controllers: controllers::InterruptControllers::new(),
-            external_handlers: spin::Mutex::new(HashMap::new()),
-            interrupt_devices: spin::Mutex::new(HashMap::new()),
-        }
-    }
-
-    /// Get a reference to the global interrupt manager
-    pub fn global() -> &'static spin::Mutex<InterruptManager> {
-        static INTERRUPT_MANAGER: spin::Once<spin::Mutex<InterruptManager>> = spin::Once::new();
-        INTERRUPT_MANAGER.call_once(|| spin::Mutex::new(InterruptManager::new()))
-    }
-
-    /// Get a mutable reference to the global interrupt manager (convenience method)
-    ///
-    /// This method locks the global manager and returns a guard.
-    /// Use this when you need to perform multiple operations atomically.
-    pub fn get_manager() -> spin::MutexGuard<'static, InterruptManager> {
-        Self::global().lock()
-    }
-
-    /// Execute a closure with mutable access to the global interrupt manager
-    ///
-    /// This is a convenience method that automatically handles locking and unlocking.
-    pub fn with_manager<F, R>(f: F) -> R
-    where
-        F: FnOnce(&mut InterruptManager) -> R,
-    {
-        f(&mut Self::global().lock())
-    }
-
-    /// Initialize interrupt controllers only (stage 1).
-    ///
-    /// This is intended to run after interrupt controller drivers (e.g., CLINT/PLIC)
-    /// are discovered/registered, but before other device drivers start enabling
-    /// per-device interrupts.
-    pub fn init_controllers(&mut self) {
-        // Disable interrupts during initialization
-        disable_interrupts();
-        crate::early_println!("[interrupt] init: local controllers...");
-
-        // Initialize local controllers (e.g., CLINT)
-        match self.controllers.init_local_controllers() {
-            Ok(()) => {}
-            Err(e) => {
-                crate::early_println!("Failed to initialize local controllers: {}", e);
-            }
-        }
-
-        crate::early_println!("[interrupt] init: local controllers done");
-
-        crate::early_println!("[interrupt] init: external controller...");
-        // Initialize external controller (e.g., PLIC)
-        match self.controllers.init_external_controller() {
-            Ok(()) => {}
-            Err(e) => {
-                crate::early_println!("Failed to initialize external controller: {}", e);
-            }
-        }
-        crate::early_println!("[interrupt] init: external controller done");
-    }
-
-    pub fn init_controllers_for_cpu(&mut self, cpu_id: CpuId) {
-        disable_interrupts();
-
-        if let Some(controller) = self.controllers.local_controller_mut_for_cpu(cpu_id) {
-            if let Err(e) = controller.init(cpu_id) {
-                crate::early_println!(
-                    "[interrupt] AP {}: failed to init local controller: {}",
-                    cpu_id,
-                    e
-                );
-            }
-        }
-
-        if let Some(controller) = self.controllers.external_controller_mut() {
-            if let Err(e) = controller.init_for_cpu(cpu_id) {
-                crate::early_println!(
-                    "[interrupt] AP {}: failed to init external controller: {}",
-                    cpu_id,
-                    e
-                );
-            }
-        }
-    }
-
-    /// Enable CPU interrupt reception (stage 2).
-    ///
-    /// This should run after device drivers have registered their handlers and
-    /// enabled the desired interrupt lines in the controller.
-    pub fn enable_cpu_interrupts(&mut self) {
-        enable_external_interrupts(); // Enable external interrupts
-        // Timer interrupts are disabled by default, enable them if needed by scheduler or other components
-    }
-
-    // Note: We intentionally do not provide a one-shot `init()` here.
-    // The kernel boot sequence uses a strict two-stage bring-up to avoid
-    // device drivers enabling interrupts before controllers are initialized.
-
-    /// Handle an external interrupt
-    pub fn handle_external_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()> {
-        // First, check for device-based handlers
-        let device = {
-            let devices = self.interrupt_devices.lock();
-            devices.get(&interrupt_id).cloned()
-        };
-
-        if let Some(device) = device {
-            // Call device's interrupt handler
-            device.handle_interrupt()?;
-            self.complete_external_interrupt(cpu_id, interrupt_id)
-        } else {
-            // Fall back to function-based handlers
-            let handler = {
-                let handlers = self.external_handlers.lock();
-                handlers.get(&interrupt_id).copied()
-            };
-
-            if let Some(handler_fn) = handler {
-                let mut handle = InterruptHandle::new(interrupt_id, cpu_id, self);
-                handler_fn(&mut handle)
-            } else {
-                // No handler registered - just complete the interrupt
-                self.complete_external_interrupt(cpu_id, interrupt_id)
-            }
-        }
-    }
-
-    /// Claim and handle the next pending external interrupt
-    pub fn claim_and_handle_external_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-    ) -> InterruptResult<Option<InterruptId>> {
-        let interrupt_id =
-            if let Some(ref mut controller) = self.controllers.external_controller_mut() {
-                controller.claim_interrupt(cpu_id)?
-            } else {
-                return Err(InterruptError::ControllerNotFound);
-            };
-
-        if let Some(id) = interrupt_id {
-            self.handle_external_interrupt(id, cpu_id)?;
-            Ok(Some(id))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Enable a local interrupt type for a CPU
-    pub fn enable_local_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_type: controllers::LocalInterruptType,
-    ) -> InterruptResult<()> {
-        if let Some(ref mut controller) = self.controllers.local_controller_mut_for_cpu(cpu_id) {
-            controller.enable_interrupt(cpu_id, interrupt_type)
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    /// Disable a local interrupt type for a CPU
-    pub fn disable_local_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_type: controllers::LocalInterruptType,
-    ) -> InterruptResult<()> {
-        if let Some(ref mut controller) = self.controllers.local_controller_mut_for_cpu(cpu_id) {
-            controller.disable_interrupt(cpu_id, interrupt_type)
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    /// Send a software interrupt to a specific CPU
-    pub fn send_software_interrupt(&mut self, target_cpu: CpuId) -> InterruptResult<()> {
-        if let Some(ref mut controller) = self.controllers.local_controller_mut_for_cpu(target_cpu)
-        {
-            controller.send_software_interrupt(target_cpu)
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    /// Set timer interrupt for a specific CPU
-    pub fn set_timer(&mut self, cpu_id: CpuId, time: u64) -> InterruptResult<()> {
-        if let Some(ref mut controller) = self.controllers.local_controller_mut_for_cpu(cpu_id) {
-            controller.set_timer(cpu_id, time)
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    pub fn get_time(&self, cpu_id: CpuId) -> InterruptResult<u64> {
-        if let Some(ref controller) = self.controllers.local_controller_for_cpu(cpu_id) {
-            Ok(controller.get_time())
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    /// Get timer frequency (Hz) for a specific CPU
-    pub fn get_timer_frequency_hz(&self, cpu_id: CpuId) -> InterruptResult<u64> {
-        if let Some(controller) = self.controllers.local_controller_for_cpu(cpu_id) {
-            Ok(controller.get_timer_frequency_hz())
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    pub fn is_local_interrupt_pending(
-        &self,
-        cpu_id: CpuId,
-        interrupt_type: controllers::LocalInterruptType,
-    ) -> bool {
-        self.controllers
-            .local_controller_for_cpu(cpu_id)
-            .map(|controller| controller.is_pending(cpu_id, interrupt_type))
-            .unwrap_or(false)
-    }
-
-    /// Register a local interrupt controller (e.g., CLINT) for specific CPUs
-    pub fn register_local_controller(
-        &mut self,
-        controller: alloc::boxed::Box<dyn controllers::LocalInterruptController>,
-        cpu_ids: &[CpuId],
-    ) -> InterruptResult<usize> {
-        Ok(self
-            .controllers
-            .register_local_controller(controller, cpu_ids))
-    }
-
-    /// Register a local interrupt controller for a CPU range
-    pub fn register_local_controller_for_range(
-        &mut self,
-        controller: alloc::boxed::Box<dyn controllers::LocalInterruptController>,
-        cpu_range: core::ops::Range<CpuId>,
-    ) -> InterruptResult<usize> {
-        Ok(self
-            .controllers
-            .register_local_controller_for_range(controller, cpu_range))
-    }
-
-    /// Register a local interrupt controller for a single CPU
-    pub fn register_local_controller_for_cpu(
-        &mut self,
-        controller: alloc::boxed::Box<dyn controllers::LocalInterruptController>,
-        cpu_id: CpuId,
-    ) -> InterruptResult<usize> {
-        Ok(self
-            .controllers
-            .register_local_controller_for_cpu(controller, cpu_id))
-    }
-
-    /// Register an external interrupt controller (e.g., PLIC)
-    pub fn register_external_controller(
-        &mut self,
-        controller: alloc::boxed::Box<dyn controllers::ExternalInterruptController>,
-    ) -> InterruptResult<()> {
-        if self.controllers.has_external_controller() {
-            return Err(InterruptError::HardwareError);
-        }
-        self.controllers.register_external_controller(controller);
-        Ok(())
-    }
-
-    /// Register a handler for a specific external interrupt
-    pub fn register_external_handler(
-        &mut self,
-        interrupt_id: InterruptId,
-        handler: ExternalInterruptHandler,
-    ) -> InterruptResult<()> {
-        let mut handlers = self.external_handlers.lock();
-        if handlers.contains_key(&interrupt_id) {
-            return Err(InterruptError::HandlerAlreadyRegistered);
-        }
-        handlers.insert(interrupt_id, handler);
-        Ok(())
-    }
-
-    /// Register a device-based handler for a specific external interrupt
-    pub fn register_interrupt_device(
-        &mut self,
-        interrupt_id: InterruptId,
-        device: alloc::sync::Arc<dyn crate::device::events::InterruptCapableDevice>,
-    ) -> InterruptResult<()> {
-        let mut devices = self.interrupt_devices.lock();
-        if devices.contains_key(&interrupt_id) {
-            return Err(InterruptError::HandlerAlreadyRegistered);
-        }
-        devices.insert(interrupt_id, device);
-        Ok(())
-    }
-
-    /// Complete an external interrupt
-    pub fn complete_external_interrupt(
-        &mut self,
-        cpu_id: CpuId,
-        interrupt_id: InterruptId,
-    ) -> InterruptResult<()> {
-        if let Some(ref mut controller) = self.controllers.external_controller_mut() {
-            controller.complete_interrupt(cpu_id, interrupt_id)
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    /// Enable an external interrupt for a specific CPU
-    pub fn enable_external_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()> {
-        if let Some(ref mut controller) = self.controllers.external_controller_mut() {
-            controller.enable_interrupt(interrupt_id, cpu_id)
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    /// Disable an external interrupt for a specific CPU
-    pub fn disable_external_interrupt(
-        &mut self,
-        interrupt_id: InterruptId,
-        cpu_id: CpuId,
-    ) -> InterruptResult<()> {
-        if let Some(ref mut controller) = self.controllers.external_controller_mut() {
-            controller.disable_interrupt(interrupt_id, cpu_id)
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-
-    /// Check if local interrupt controller is registered
-    pub fn has_local_controller(&self) -> bool {
-        self.controllers.has_local_controller()
-    }
-
-    /// Check if external interrupt controller is registered
-    pub fn has_external_controller(&self) -> bool {
-        self.controllers.has_external_controller()
-    }
-
-    pub fn send_ipi(
-        &mut self,
-        target_cpu_id: CpuId,
-        ipi_type: controllers::LocalInterruptType,
-    ) -> InterruptResult<()> {
-        if let Some(ref mut controller) = self.controllers.external_controller_mut() {
-            controller.send_ipi(target_cpu_id, ipi_type)
-        } else {
-            Err(InterruptError::ControllerNotFound)
-        }
-    }
-}
-
-/// Handler function type for external interrupts
-pub type ExternalInterruptHandler = fn(&mut InterruptHandle) -> InterruptResult<()>;
-
-/// Handler function type for local interrupts (timer, software)
-pub type LocalInterruptHandler =
-    fn(cpu_id: CpuId, interrupt_type: controllers::LocalInterruptType) -> InterruptResult<()>;

--- a/kernel/src/ipc/counter.rs
+++ b/kernel/src/ipc/counter.rs
@@ -16,6 +16,7 @@ use crate::object::capability::selectable::{
     ReadyInterest, ReadySet, SelectWaitOutcome, Selectable,
 };
 use crate::object::capability::{CloneOps, StreamError, StreamOps};
+use crate::sched::scheduler::current_task_id;
 use crate::sync::waker::Waker;
 
 /// Internal state of a counter
@@ -263,9 +264,8 @@ impl Selectable for Counter {
 
         let task_id = {
             use crate::arch::get_cpu;
-            use crate::sched::scheduler::get_scheduler;
             let cpu_id = get_cpu().get_cpuid();
-            get_scheduler().get_current_task_id(cpu_id).unwrap_or(0)
+            current_task_id(cpu_id).unwrap_or(0)
         };
 
         let woke = if interest.read {

--- a/kernel/src/ipc/event.rs
+++ b/kernel/src/ipc/event.rs
@@ -597,8 +597,7 @@ impl EventManager {
         {
             let cpu = crate::arch::get_cpu();
             let cpu_id = cpu.get_cpuid();
-            let sched = crate::sched::scheduler::get_scheduler();
-            if let Some(task) = sched.get_current_task(cpu_id) {
+            if let Some(task) = crate::sched::scheduler::current_task(cpu_id) {
                 return Some(task.get_id() as u32);
             }
             None
@@ -1008,9 +1007,7 @@ impl EventManager {
                 }
             }
             GroupTarget::AllTasks => {
-                let sched = crate::sched::scheduler::get_scheduler();
-                let all_ids: alloc::vec::Vec<u32> = sched
-                    .get_all_task_ids()
+                let all_ids: alloc::vec::Vec<u32> = crate::sched::scheduler::get_all_task_ids()
                     .into_iter()
                     .map(|x| x as u32)
                     .collect();
@@ -1062,9 +1059,7 @@ impl EventManager {
         _reliable: bool,
     ) -> Result<(), EventError> {
         // broadcast to every task in the system
-        let sched = crate::sched::scheduler::get_scheduler();
-        let all_ids: alloc::vec::Vec<u32> = sched
-            .get_all_task_ids()
+        let all_ids: alloc::vec::Vec<u32> = crate::sched::scheduler::get_all_task_ids()
             .into_iter()
             .map(|x| x as u32)
             .collect();
@@ -1095,9 +1090,7 @@ impl EventManager {
         drop(task_filters); // Release the lock early
 
         // Get the task and deliver event to its local queue
-        if let Some(task) =
-            crate::sched::scheduler::get_scheduler().get_task_by_id(task_id as usize)
-        {
+        if let Some(task) = crate::sched::scheduler::get_task_by_id(task_id as usize) {
             // Enforce buffer size from the target task's config
             let cfg = self.get_task_config_or_default(task_id);
             let mut queue = task.event_queue.lock();
@@ -1122,9 +1115,7 @@ impl EventManager {
     /// This method is deprecated - tasks now process events directly via process_pending_events()
     #[deprecated(note = "Use Task.process_pending_events() instead")]
     pub fn dequeue_event_for_task(&self, task_id: u32) -> Option<Event> {
-        if let Some(task) =
-            crate::sched::scheduler::get_scheduler().get_task_by_id(task_id as usize)
-        {
+        if let Some(task) = crate::sched::scheduler::get_task_by_id(task_id as usize) {
             let mut queue = task.event_queue.lock();
             queue.dequeue()
         } else {
@@ -1134,9 +1125,7 @@ impl EventManager {
 
     /// Get the number of pending events for a task
     pub fn get_pending_event_count(&self, task_id: u32) -> usize {
-        if let Some(task) =
-            crate::sched::scheduler::get_scheduler().get_task_by_id(task_id as usize)
-        {
+        if let Some(task) = crate::sched::scheduler::get_task_by_id(task_id as usize) {
             let queue = task.event_queue.lock();
             queue.len()
         } else {
@@ -1146,9 +1135,7 @@ impl EventManager {
 
     /// Check if a task has any pending events
     pub fn has_pending_events(&self, task_id: u32) -> bool {
-        if let Some(task) =
-            crate::sched::scheduler::get_scheduler().get_task_by_id(task_id as usize)
-        {
+        if let Some(task) = crate::sched::scheduler::get_task_by_id(task_id as usize) {
             let queue = task.event_queue.lock();
             !queue.is_empty()
         } else {
@@ -1482,9 +1469,7 @@ impl crate::object::capability::EventReceiver for EventChannelObject {
         // Check if any subscriber task has pending events for THIS channel specifically
         let subscriber_ids = self.get_subscribers();
         for tid in subscriber_ids {
-            if let Some(task) =
-                crate::sched::scheduler::get_scheduler().get_task_by_id(tid as usize)
-            {
+            if let Some(task) = crate::sched::scheduler::get_task_by_id(tid as usize) {
                 let queue = task.event_queue.lock();
                 for (_prio, q) in queue.events.iter() {
                     for ev in q.iter() {
@@ -1504,9 +1489,7 @@ impl crate::object::capability::EventReceiver for EventChannelObject {
 impl crate::object::capability::EventReceiver for EventSubscriptionObject {
     fn has_pending_events(&self) -> bool {
         // Only consider events delivered to this subscription's channel and matching its local filters
-        if let Some(task) =
-            crate::sched::scheduler::get_scheduler().get_task_by_id(self.task_id as usize)
-        {
+        if let Some(task) = crate::sched::scheduler::get_task_by_id(self.task_id as usize) {
             let queue = task.event_queue.lock();
             let channel_name = self.channel_name.as_str();
             // Take a snapshot of local filters
@@ -2296,7 +2279,7 @@ mod tests {
         for i in 0..2 {
             let task =
                 crate::task::Task::new(format!("g_sess_{}", i), 1, crate::task::TaskType::Kernel);
-            crate::sched::scheduler::get_scheduler().add_task(task, 0);
+            crate::sched::scheduler::add_task(task, 0);
         }
 
         // For tests, get_current_task_id() returns Some(1), so join operations will add task 1

--- a/kernel/src/ipc/event.rs
+++ b/kernel/src/ipc/event.rs
@@ -2279,7 +2279,7 @@ mod tests {
         for i in 0..2 {
             let task =
                 crate::task::Task::new(format!("g_sess_{}", i), 1, crate::task::TaskType::Kernel);
-            crate::sched::scheduler::add_task(task, 0);
+            crate::sched::scheduler::add_task(task, crate::sched::scheduler::select_cpu());
         }
 
         // For tests, get_current_task_id() returns Some(1), so join operations will add task 1

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -922,8 +922,14 @@ pub extern "C" fn start_ap(cpu_id: usize) -> ! {
         crate::hypervisor::init_hv_per_cpu(cpu_id);
     }
 
-    println!("[Scarlet Kernel] AP {}: entering idle", cpu_id);
+    let next_task_id = crate::sched::scheduler::start_scheduler();
+    if let Some(next_task_id) = next_task_id {
+        let next_task = crate::sched::scheduler::get_task_by_id(next_task_id)
+            .expect("AP: first runnable task must exist");
+        crate::arch::first_switch_to_user(next_task);
+    }
 
+    println!("[Scarlet Kernel] AP {}: idle", cpu_id);
     loop {
         crate::arch::instruction::idle();
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -319,7 +319,7 @@ use vm::{
 fn panic(info: &core::panic::PanicInfo) -> ! {
     use arch::instruction::idle;
 
-    crate::println!("[Scarlet Kernel] panic: {}", info);
+    crate::early_println!("[Scarlet Kernel] panic: {}", info);
 
     // if let Some(task) = get_scheduler().get_current_task(get_cpu().get_cpuid()) {
     //     task.exit(1); // Exit the task with error code 1
@@ -870,6 +870,9 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     fence(Ordering::SeqCst); // Ensure task is added to scheduler before proceeding
     println!("[Scarlet Kernel] Fence complete; about to print scheduler start...");
 
+    crate::sched::scheduler::register_online_cpu(cpu_id);
+    crate::sched::scheduler::spawn_idle_task(cpu_id);
+
     if let Some(hook) = boot_info.start_secondary_cpus_hook {
         hook();
         fence(Ordering::SeqCst);
@@ -907,7 +910,6 @@ pub fn wait_for_ap_release() {
 #[unsafe(no_mangle)]
 pub extern "C" fn start_ap(cpu_id: usize) -> ! {
     use core::sync::atomic::Ordering;
-
     crate::arch::vm::switch_to_kernel_page_table();
 
     println!("[Scarlet Kernel] AP {}: initializing...", cpu_id);
@@ -924,6 +926,9 @@ pub extern "C" fn start_ap(cpu_id: usize) -> ! {
     }
 
     crate::arch::vm::register_trampoline_for_ap();
+
+    crate::sched::scheduler::register_online_cpu(cpu_id);
+    crate::sched::scheduler::spawn_idle_task(cpu_id);
 
     let next_task_id = crate::sched::scheduler::start_scheduler();
     if let Some(next_task_id) = next_task_id {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -777,6 +777,7 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     println!("[boot] Initializing timer...");
     // Initialize timer for the boot CPU (from BootInfo)
     get_kernel_timer().init(boot_info.cpu_id);
+    timer::set_global_timekeeper(boot_info.cpu_id);
 
     fence(Ordering::SeqCst); // Ensure timer is initialized before proceeding
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -936,7 +936,6 @@ pub extern "C" fn start_ap(cpu_id: usize) -> ! {
 
     crate::arch::vm::register_trampoline_for_ap();
 
-    crate::sched::scheduler::register_online_cpu(cpu_id);
     crate::sched::scheduler::spawn_idle_task(cpu_id);
 
     let next_task_id = crate::sched::scheduler::start_scheduler();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -300,7 +300,6 @@ use crate::{
     device::graphics::manager::GraphicsManager,
     executor::executor::TransparentExecutor,
     fs::{drivers::initramfs::init_initramfs, vfs_v2::manager::init_global_vfs_manager},
-    interrupt::InterruptManager,
 };
 use arch::get_cpu;
 use core::sync::atomic::{Ordering, compiler_fence, fence};
@@ -669,7 +668,7 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
 
     /* Initialize interrupt controllers (stage 1) */
     early_println!("[Scarlet Kernel] Initializing interrupt controllers...");
-    InterruptManager::get_manager().init_controllers();
+    crate::interrupt::InterruptManager::global().init_controllers();
 
     fence(Ordering::SeqCst); // Ensure interrupt controllers are initialized before proceeding
 
@@ -768,7 +767,7 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
 
     /* Enable CPU interrupt reception (stage 2) */
     println!("[Scarlet Kernel] Enabling CPU interrupts...");
-    InterruptManager::get_manager().enable_cpu_interrupts();
+    crate::interrupt::enable_cpu_interrupts();
 
     fence(Ordering::SeqCst); // Ensure interrupt manager is initialized before proceeding
 
@@ -916,8 +915,8 @@ pub extern "C" fn start_ap(cpu_id: usize) -> ! {
 
     crate::arch::init_ap_cpu(cpu_id);
 
-    crate::interrupt::InterruptManager::get_manager().init_controllers_for_cpu(cpu_id as u32);
-    crate::interrupt::InterruptManager::get_manager().enable_cpu_interrupts();
+    crate::interrupt::InterruptManager::global().init_controllers_for_cpu(cpu_id as u32);
+    crate::interrupt::enable_cpu_interrupts();
     fence(Ordering::SeqCst);
 
     #[cfg(feature = "hypervisor")]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -305,7 +305,7 @@ use crate::{
 use arch::get_cpu;
 use core::sync::atomic::{Ordering, compiler_fence, fence};
 use mem::allocator::init_heap;
-use sched::scheduler::get_scheduler;
+use sched::scheduler::{add_task, get_task_by_id, start_scheduler};
 use task::new_user_task;
 use timer::get_kernel_timer;
 use vm::{
@@ -772,7 +772,6 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
 
     /* Initialize scheduler */
     println!("[boot] Initializing scheduler...");
-    let scheduler = get_scheduler();
     fence(Ordering::SeqCst); // Ensure scheduler is initialized before proceeding
 
     /* Initialize global VFS */
@@ -852,7 +851,7 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
             println!("[Scarlet Kernel] Adding init task to scheduler...");
             let cpu_id = get_cpu().get_cpuid();
             println!("[Scarlet Kernel] cpu_id for init task: {}", cpu_id);
-            get_scheduler().add_task(task, cpu_id);
+            add_task(task, cpu_id);
             println!("[Scarlet Kernel] Init task added to scheduler");
         }
         Err(e) => println!("[Scarlet Kernel] Error loading ELF into task: {:?}", e),
@@ -866,11 +865,9 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     println!("[Scarlet Kernel] Scheduler will start...");
     println!("[Scarlet Kernel] Calling start_scheduler()...");
 
-    let next_task_id = scheduler.start_scheduler();
+    let next_task_id = start_scheduler();
     if let Some(next_task_id) = next_task_id {
-        let next_task = scheduler
-            .get_task_by_id(next_task_id)
-            .expect("First runnable task must exist");
+        let next_task = get_task_by_id(next_task_id).expect("First runnable task must exist");
         crate::arch::first_switch_to_user(next_task);
     }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -914,6 +914,7 @@ pub extern "C" fn start_ap(cpu_id: usize) -> ! {
 
     crate::arch::init_ap_cpu(cpu_id);
 
+    crate::interrupt::InterruptManager::get_manager().init_controllers_for_cpu(cpu_id as u32);
     crate::interrupt::InterruptManager::get_manager().enable_cpu_interrupts();
     fence(Ordering::SeqCst);
 
@@ -921,6 +922,8 @@ pub extern "C" fn start_ap(cpu_id: usize) -> ! {
     {
         crate::hypervisor::init_hv_per_cpu(cpu_id);
     }
+
+    crate::arch::vm::register_trampoline_for_ap();
 
     let next_task_id = crate::sched::scheduler::start_scheduler();
     if let Some(next_task_id) = next_task_id {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -669,6 +669,8 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     /* Initialize interrupt controllers (stage 1) */
     early_println!("[Scarlet Kernel] Initializing interrupt controllers...");
     crate::interrupt::InterruptManager::global().init_controllers();
+    crate::interrupt::InterruptManager::global()
+        .init_controllers_for_cpu(get_cpu().get_cpuid() as u32);
 
     fence(Ordering::SeqCst); // Ensure interrupt controllers are initialized before proceeding
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -875,19 +875,27 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     crate::sched::scheduler::register_online_cpu(cpu_id);
     crate::sched::scheduler::spawn_idle_task(cpu_id);
 
-    if let Some(hook) = boot_info.start_secondary_cpus_hook {
-        hook();
-        fence(Ordering::SeqCst);
-    }
-
     // Use println here to avoid any potential console lock issues.
     println!("[Scarlet Kernel] Scheduler will start...");
     println!("[Scarlet Kernel] Calling start_scheduler()...");
 
     let next_task_id = start_scheduler();
+    // Keep APs behind the release barrier until the BSP has claimed the
+    // first runnable task. Otherwise a fast AP can steal the init task from
+    // the BSP's ready queue before the boot CPU enters it, which makes early
+    // userspace startup nondeterministic on SMP systems. The BSP is not
+    // assumed to have CPU ID 0.
+    if let Some(hook) = boot_info.start_secondary_cpus_hook {
+        hook();
+        fence(Ordering::SeqCst);
+    }
     if let Some(next_task_id) = next_task_id {
         let next_task = get_task_by_id(next_task_id).expect("First runnable task must exist");
-        crate::arch::first_switch_to_user(next_task);
+        if next_task.task_type == crate::task::TaskType::Kernel {
+            crate::sched::scheduler::first_switch_to_kernel_task(next_task_id);
+        } else {
+            crate::arch::first_switch_to_user(next_task);
+        }
     }
 
     println!("[Scarlet Kernel] No runnable task; entering idle loop");
@@ -913,10 +921,9 @@ pub fn wait_for_ap_release() {
 pub extern "C" fn start_ap(cpu_id: usize) -> ! {
     use core::sync::atomic::Ordering;
     crate::arch::vm::switch_to_kernel_page_table();
+    crate::arch::init_ap_cpu(cpu_id);
 
     println!("[Scarlet Kernel] AP {}: initializing...", cpu_id);
-
-    crate::arch::init_ap_cpu(cpu_id);
 
     crate::interrupt::InterruptManager::global().init_controllers_for_cpu(cpu_id as u32);
     crate::interrupt::enable_cpu_interrupts();
@@ -936,7 +943,11 @@ pub extern "C" fn start_ap(cpu_id: usize) -> ! {
     if let Some(next_task_id) = next_task_id {
         let next_task = crate::sched::scheduler::get_task_by_id(next_task_id)
             .expect("AP: first runnable task must exist");
-        crate::arch::first_switch_to_user(next_task);
+        if next_task.task_type == crate::task::TaskType::Kernel {
+            crate::sched::scheduler::first_switch_to_kernel_task(next_task_id);
+        } else {
+            crate::arch::first_switch_to_user(next_task);
+        }
     }
 
     println!("[Scarlet Kernel] AP {}: idle", cpu_id);

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -319,7 +319,7 @@ use vm::{
 fn panic(info: &core::panic::PanicInfo) -> ! {
     use arch::instruction::idle;
 
-    crate::early_println!("[Scarlet Kernel] panic: {}", info);
+    crate::println!("[Scarlet Kernel] panic: {}", info);
 
     // if let Some(task) = get_scheduler().get_current_task(get_cpu().get_cpuid()) {
     //     task.exit(1); // Exit the task with error code 1
@@ -403,6 +403,13 @@ pub struct BootInfo {
     /// Optional framebuffer physical memory area
     /// Used for early console output before graphics subsystem initialization
     pub framebuffer_paddr: Option<MemoryArea>,
+    /// Optional BSP hook to start secondary CPUs.
+    ///
+    /// Called by `start_kernel()` after all global one-time init is complete.
+    /// The BSP implementation wakes each secondary CPU and makes it call
+    /// `start_ap()` with the appropriate CPU ID. `None` for single-CPU or
+    /// test configurations.
+    pub start_secondary_cpus_hook: Option<fn()>,
 }
 
 impl BootInfo {
@@ -432,6 +439,7 @@ impl BootInfo {
         cmdline: Option<&'static str>,
         device_source: DeviceSource,
         framebuffer_paddr: Option<MemoryArea>,
+        start_secondary_cpus_hook: Option<fn()>,
     ) -> Self {
         Self {
             cpu_id,
@@ -443,6 +451,7 @@ impl BootInfo {
             cmdline,
             device_source,
             framebuffer_paddr,
+            start_secondary_cpus_hook,
         }
     }
 
@@ -861,6 +870,11 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     fence(Ordering::SeqCst); // Ensure task is added to scheduler before proceeding
     println!("[Scarlet Kernel] Fence complete; about to print scheduler start...");
 
+    if let Some(hook) = boot_info.start_secondary_cpus_hook {
+        hook();
+        fence(Ordering::SeqCst);
+    }
+
     // Use println here to avoid any potential console lock issues.
     println!("[Scarlet Kernel] Scheduler will start...");
     println!("[Scarlet Kernel] Calling start_scheduler()...");
@@ -877,14 +891,40 @@ pub extern "C" fn start_kernel(boot_info: &BootInfo) -> ! {
     }
 }
 
+use core::sync::atomic::AtomicBool;
+static AP_BARRIER: AtomicBool = AtomicBool::new(false);
+
+pub fn release_aps() {
+    AP_BARRIER.store(true, core::sync::atomic::Ordering::Release);
+}
+
+pub fn wait_for_ap_release() {
+    while !AP_BARRIER.load(core::sync::atomic::Ordering::Acquire) {
+        core::hint::spin_loop();
+    }
+}
+
 #[unsafe(no_mangle)]
-pub extern "C" fn start_ap(cpu_id: usize) {
-    println!("[Scarlet Kernel] CPU {} is up and running", cpu_id);
+pub extern "C" fn start_ap(cpu_id: usize) -> ! {
+    use core::sync::atomic::Ordering;
+
+    crate::arch::vm::switch_to_kernel_page_table();
+
+    println!("[Scarlet Kernel] AP {}: initializing...", cpu_id);
+
+    crate::arch::init_ap_cpu(cpu_id);
+
+    crate::interrupt::InterruptManager::get_manager().enable_cpu_interrupts();
+    fence(Ordering::SeqCst);
 
     #[cfg(feature = "hypervisor")]
     {
         crate::hypervisor::init_hv_per_cpu(cpu_id);
     }
 
-    loop {}
+    println!("[Scarlet Kernel] AP {}: entering idle", cpu_id);
+
+    loop {
+        crate::arch::instruction::idle();
+    }
 }

--- a/kernel/src/library/std/print.rs
+++ b/kernel/src/library/std/print.rs
@@ -53,10 +53,14 @@ macro_rules! println {
     ($fmt:expr, $($arg:tt)*) => ($crate::print!(concat!($fmt, "\n"), $($arg)*));
 }
 
+static WRITE_LOCK: spin::Mutex<()> = spin::Mutex::new(());
+
 pub fn _print(args: fmt::Arguments) {
     struct LogWriter;
+
     impl fmt::Write for LogWriter {
         fn write_str(&mut self, s: &str) -> fmt::Result {
+            let _lock = WRITE_LOCK.lock();
             for &b in s.as_bytes() {
                 crate::log::write_byte(b);
             }
@@ -72,6 +76,8 @@ pub fn _print(args: fmt::Arguments) {
     struct CharDeviceWriter<'a>(&'a dyn CharDevice);
     impl<'a> fmt::Write for CharDeviceWriter<'a> {
         fn write_str(&mut self, s: &str) -> fmt::Result {
+            let _lock = WRITE_LOCK.lock();
+
             for byte in s.bytes() {
                 if self.0.write_byte(byte).is_err() {
                     return Err(fmt::Error);

--- a/kernel/src/library/std/print.rs
+++ b/kernel/src/library/std/print.rs
@@ -53,14 +53,13 @@ macro_rules! println {
     ($fmt:expr, $($arg:tt)*) => ($crate::print!(concat!($fmt, "\n"), $($arg)*));
 }
 
-static WRITE_LOCK: spin::Mutex<()> = spin::Mutex::new(());
-
 pub fn _print(args: fmt::Arguments) {
+    let _guard = crate::log::PrintGuard::acquire();
+
     struct LogWriter;
 
     impl fmt::Write for LogWriter {
         fn write_str(&mut self, s: &str) -> fmt::Result {
-            let _lock = WRITE_LOCK.lock();
             for &b in s.as_bytes() {
                 crate::log::write_byte(b);
             }
@@ -76,8 +75,6 @@ pub fn _print(args: fmt::Arguments) {
     struct CharDeviceWriter<'a>(&'a dyn CharDevice);
     impl<'a> fmt::Write for CharDeviceWriter<'a> {
         fn write_str(&mut self, s: &str) -> fmt::Result {
-            let _lock = WRITE_LOCK.lock();
-
             for byte in s.bytes() {
                 if self.0.write_byte(byte).is_err() {
                     return Err(fmt::Error);
@@ -121,6 +118,9 @@ pub fn _print(args: fmt::Arguments) {
         }
     }
 
-    // Final fallback: early console
-    early_println!("[print] No usable character device found; using early console");
+    // Final fallback: write directly to the early console while still holding
+    // the global print guard. Calling early_println! here would re-enter the
+    // same print lock and deadlock.
+    let mut early = crate::earlycon::EarlyConsole::new();
+    let _ = early.write_fmt(args);
 }

--- a/kernel/src/log.rs
+++ b/kernel/src/log.rs
@@ -20,6 +20,24 @@ static TAIL: AtomicUsize = AtomicUsize::new(0);
 
 pub static READER_WAKER: Waker = Waker::new_interruptible("kmsg");
 
+static PRINT_LOCK: spin::Mutex<()> = spin::Mutex::new(());
+
+pub struct PrintGuard {
+    _irq_guard: crate::sync::irq_guard::IrqGuard,
+    _lock: spin::MutexGuard<'static, ()>,
+}
+
+impl PrintGuard {
+    pub fn acquire() -> Self {
+        let irq_guard = crate::sync::irq_guard::IrqGuard::new();
+        let lock = PRINT_LOCK.lock();
+        Self {
+            _irq_guard: irq_guard,
+            _lock: lock,
+        }
+    }
+}
+
 pub fn write_bytes(data: &[u8]) {
     let head = HEAD.load(Ordering::Relaxed);
     let mut pos = head;

--- a/kernel/src/log.rs
+++ b/kernel/src/log.rs
@@ -59,7 +59,7 @@ pub fn write_bytes(data: &[u8]) {
 pub fn write_byte(b: u8) {
     let pos = HEAD.fetch_add(1, Ordering::Relaxed);
     BUF[pos % LOG_BUF_SIZE].store(b, Ordering::Relaxed);
-    READER_WAKER.wake_all();
+    // READER_WAKER.wake_all();
 
     let tail = TAIL.load(Ordering::Relaxed);
     if pos + 1 - tail > LOG_BUF_SIZE {

--- a/kernel/src/network/local.rs
+++ b/kernel/src/network/local.rs
@@ -27,6 +27,8 @@ use alloc::{
 use core::any::Any;
 use spin::RwLock;
 
+use crate::sched::scheduler::current_task_id;
+
 use super::{
     LocalSocketAddress, NetworkManager, ShutdownHow, SocketAddress, SocketControl, SocketDomain,
     SocketError, SocketObject, SocketProtocol, SocketState, SocketType,
@@ -1033,9 +1035,8 @@ impl Selectable for LocalSocket {
 
         let task_id = {
             use crate::arch::get_cpu;
-            use crate::sched::scheduler::get_scheduler;
             let cpu_id = get_cpu().get_cpuid();
-            get_scheduler().get_current_task_id(cpu_id).unwrap_or(0)
+            current_task_id(cpu_id).unwrap_or(0)
         };
 
         let woke = match state {

--- a/kernel/src/network/tcp.rs
+++ b/kernel/src/network/tcp.rs
@@ -17,6 +17,7 @@ use crate::network::socket::SocketError;
 use crate::network::socket::{
     Inet4SocketAddress, SocketAddress, SocketControl, SocketObject, SocketState,
 };
+use crate::sched::scheduler::current_task_id;
 
 /// TCP connection states
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1792,9 +1793,8 @@ impl crate::object::capability::Selectable for TcpSocket {
 
         let task_id = {
             use crate::arch::get_cpu;
-            use crate::sched::scheduler::get_scheduler;
             let cpu_id = get_cpu().get_cpuid();
-            get_scheduler().get_current_task_id(cpu_id).unwrap_or(0)
+            current_task_id(cpu_id).unwrap_or(0)
         };
 
         let woke = if interest.read {

--- a/kernel/src/network/udp.rs
+++ b/kernel/src/network/udp.rs
@@ -18,6 +18,7 @@ use crate::network::socket::{
     SocketState, SocketType,
 };
 use crate::object::capability::selectable::Selectable;
+use crate::sched::scheduler::current_task_id;
 
 /// Helper function to get local IP address bytes from the default interface
 fn get_local_ip_bytes() -> [u8; 4] {
@@ -433,9 +434,8 @@ impl crate::object::capability::Selectable for UdpSocket {
 
         let task_id = {
             use crate::arch::get_cpu;
-            use crate::sched::scheduler::get_scheduler;
             let cpu_id = get_cpu().get_cpuid();
-            get_scheduler().get_current_task_id(cpu_id).unwrap_or(0)
+            current_task_id(cpu_id).unwrap_or(0)
         };
 
         let woke = if interest.read {

--- a/kernel/src/object/handle/tests/task_integration.rs
+++ b/kernel/src/object/handle/tests/task_integration.rs
@@ -2,6 +2,7 @@ use super::super::*;
 use super::mock::MockTaskFileObject;
 use crate::fs::{FileType, SeekFrom};
 use crate::object::handle::HandleTable;
+use crate::sched::scheduler::{add_task, get_task_by_id, reset};
 use crate::task::{CloneFlags, new_user_task};
 use alloc::format;
 use alloc::string::ToString;
@@ -165,15 +166,14 @@ fn test_task_handle_table_error_conditions() {
 #[test_case]
 fn test_task_handle_table_clone_behavior() {
     // Reset scheduler state before test
-    let scheduler = crate::sched::scheduler::get_scheduler();
-    scheduler.reset();
+    reset();
 
     // Initialize parent task first, then add to scheduler
     let mut parent_task = new_user_task("ParentTask".to_string(), 1);
     parent_task.init();
 
-    let parent_id = scheduler.add_task(parent_task, 0);
-    let mut parent_task = scheduler.get_task_by_id(parent_id).unwrap();
+    let parent_id = crate::sched::scheduler::add_task(parent_task, 0);
+    let mut parent_task = get_task_by_id(parent_id).unwrap();
 
     // Open some files in parent
     let mock_file1 = Arc::new(MockTaskFileObject::new(b"parent_file_1".to_vec()));
@@ -246,15 +246,14 @@ fn test_task_handle_table_clone_behavior() {
 #[test_case]
 fn test_task_handle_table_memory_efficiency() {
     // Reset scheduler state before test
-    let scheduler = crate::sched::scheduler::get_scheduler();
-    scheduler.reset();
+    reset();
 
     // Initialize task first, then add to scheduler
     let mut task = new_user_task("MemoryTask".to_string(), 1);
     task.init();
 
-    let task_id = scheduler.add_task(task, 0);
-    let mut task = scheduler.get_task_by_id(task_id).unwrap();
+    let task_id = crate::sched::scheduler::add_task(task, 0);
+    let mut task = get_task_by_id(task_id).unwrap();
 
     // Test that repeated allocation/deallocation doesn't cause memory leaks
     for iteration in 0..50 {
@@ -291,15 +290,14 @@ fn test_task_handle_table_memory_efficiency() {
 #[test_case]
 fn test_task_handle_table_capability_access() {
     // Reset scheduler state before test
-    let scheduler = crate::sched::scheduler::get_scheduler();
-    scheduler.reset();
+    reset();
 
     // Initialize task first, then add to scheduler
     let mut task = new_user_task("CapabilityTask".to_string(), 1);
     task.init();
 
-    let task_id = scheduler.add_task(task, 0);
-    let mut task = scheduler.get_task_by_id(task_id).unwrap();
+    let task_id = crate::sched::scheduler::add_task(task, 0);
+    let mut task = get_task_by_id(task_id).unwrap();
 
     // Test accessing different capabilities through handles
     let mock_file = Arc::new(MockTaskFileObject::new(b"capability_test_data".to_vec()));

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -576,6 +576,10 @@ pub fn get_task_by_id(task_id: usize) -> Option<&'static mut Task> {
 }
 
 pub fn wake_task(task_id: usize) -> bool {
+    wake_task_on(task_id, get_cpu().get_cpuid())
+}
+
+pub fn wake_task_on(task_id: usize, target_cpu: usize) -> bool {
     let _irq_guard = IrqGuard::new();
     let Some(task) = TaskPool::get_task_mut(task_id) else {
         return false;
@@ -589,7 +593,11 @@ pub fn wake_task(task_id: usize) -> bool {
     core::sync::atomic::fence(Ordering::SeqCst);
 
     if !ready_queue_contains(task_id) {
-        push_ready_task(get_cpu().get_cpuid(), task_id);
+        push_ready_task(target_cpu, task_id);
+    }
+
+    if target_cpu != get_cpu().get_cpuid() {
+        crate::arch::send_reschedule_ipi(target_cpu);
     }
 
     true

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -34,6 +34,7 @@
 extern crate alloc;
 
 use core::panic;
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use alloc::{boxed::Box, collections::vec_deque::VecDeque, string::ToString};
 
@@ -50,6 +51,7 @@ use crate::{
         trap::user::arch_switch_to_user,
     },
     environment::MAX_NUM_CPUS,
+    sync::{CpuLocal, IrqGuard},
     task::{TaskState, new_kernel_task, wake_parent_waiters, wake_task_waiters},
     timer::get_kernel_timer,
 };
@@ -97,7 +99,7 @@ pub fn get_task_pool() -> &'static TaskPool {
 /// **IMPORTANT**: Do NOT directly access the `tasks` array. Always use:
 /// - `TaskPool::get_task()` for immutable references
 /// - `TaskPool::get_task_mut()` for mutable references
-/// - `Scheduler::get_task_by_id()` which is the preferred public API
+/// - `get_task_by_id()` which is the preferred public API
 ///
 /// Direct array access could violate safety assumptions and cause undefined behavior.
 ///
@@ -353,705 +355,400 @@ impl TaskPool {
     }
 }
 
-static mut SCHEDULER: Option<Scheduler> = None;
+static CURRENT_TASK_IDS: [AtomicUsize; MAX_NUM_CPUS] =
+    [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
+static READY_QUEUES: [spin::Mutex<VecDeque<usize>>; MAX_NUM_CPUS] =
+    [const { spin::Mutex::new(VecDeque::new()) }; MAX_NUM_CPUS];
+static ZOMBIE_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::new());
+static DEBUG_TICK: AtomicU64 = AtomicU64::new(0);
 
-pub fn get_scheduler() -> &'static mut Scheduler {
-    unsafe {
-        match SCHEDULER {
-            Some(ref mut s) => s,
-            None => {
-                SCHEDULER = Some(Scheduler::new());
-                get_scheduler()
+#[inline]
+fn assert_valid_cpu_id(cpu_id: usize) {
+    debug_assert!(cpu_id < CpuLocal::<usize>::cpu_count());
+}
+
+#[inline]
+fn encode_task_id(task_id: Option<usize>) -> usize {
+    task_id.unwrap_or(0)
+}
+
+#[inline]
+fn decode_task_id(task_id: usize) -> Option<usize> {
+    if task_id == 0 { None } else { Some(task_id) }
+}
+
+#[inline]
+fn ready_queue(cpu_id: usize) -> &'static spin::Mutex<VecDeque<usize>> {
+    assert_valid_cpu_id(cpu_id);
+    &READY_QUEUES[cpu_id]
+}
+
+#[inline]
+fn set_current_task_id(cpu_id: usize, task_id: Option<usize>) {
+    assert_valid_cpu_id(cpu_id);
+    CURRENT_TASK_IDS[cpu_id].store(encode_task_id(task_id), Ordering::SeqCst);
+}
+
+#[inline]
+fn push_ready_task(cpu_id: usize, task_id: usize) {
+    let mut queue = ready_queue(cpu_id).lock();
+    if !queue.contains(&task_id) {
+        queue.push_back(task_id);
+    }
+}
+
+fn ready_queue_contains(task_id: usize) -> bool {
+    for cpu_id in 0..MAX_NUM_CPUS {
+        if ready_queue(cpu_id).lock().contains(&task_id) {
+            return true;
+        }
+    }
+    false
+}
+
+fn finalize_zombie(task_id: usize, parent_id: Option<usize>) {
+    {
+        let mut zombie_queue = ZOMBIE_QUEUE.lock();
+        if !zombie_queue.contains(&task_id) {
+            zombie_queue.push_back(task_id);
+        }
+    }
+    wake_task_waiters(task_id);
+    if let Some(parent_id) = parent_id {
+        wake_parent_waiters(parent_id);
+    }
+}
+
+fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
+    let _irq_guard = IrqGuard::new();
+    let cpu_id = cpu.get_cpuid();
+    let old_current_task_id = current_task_id(cpu_id);
+
+    if let Some(current_id) = old_current_task_id {
+        if let Some(task) = TaskPool::get_task_mut(current_id) {
+            match task.state.load(Ordering::SeqCst) {
+                TaskState::Ready => push_ready_task(cpu_id, current_id),
+                TaskState::Running => {
+                    task.state.store(TaskState::Ready, Ordering::SeqCst);
+                    push_ready_task(cpu_id, current_id);
+                }
+                TaskState::Zombie => finalize_zombie(current_id, task.get_parent_id()),
+                TaskState::Terminated | TaskState::Blocked(_) | TaskState::NotInitialized => {}
             }
         }
     }
-}
 
-pub struct Scheduler {
-    /// Queue for ready-to-run task IDs
-    ready_queue: [VecDeque<usize>; MAX_NUM_CPUS],
-    /// Queue for blocked task IDs (waiting for I/O, etc.)
-    blocked_queue: [VecDeque<usize>; MAX_NUM_CPUS],
-    /// Queue for zombie task IDs (finished but not yet cleaned up)
-    zombie_queue: [VecDeque<usize>; MAX_NUM_CPUS],
-    current_task_id: [Option<usize>; MAX_NUM_CPUS],
-}
+    loop {
+        let task_id = { ready_queue(cpu_id).lock().pop_front() };
 
-impl Scheduler {
-    pub fn new() -> Self {
-        Scheduler {
-            ready_queue: [const { VecDeque::new() }; MAX_NUM_CPUS],
-            blocked_queue: [const { VecDeque::new() }; MAX_NUM_CPUS],
-            zombie_queue: [const { VecDeque::new() }; MAX_NUM_CPUS],
-            current_task_id: [const { None }; MAX_NUM_CPUS],
-        }
-    }
-
-    pub fn add_task(&mut self, task: Task, cpu_id: usize) -> usize {
-        // Add task to the global task pool and get the allocated ID
-        let task_id = match get_task_pool().add_task(task) {
-            Ok(id) => id,
-            Err(e) => panic!("Failed to add task: {}", e),
+        let Some(task_id) = task_id else {
+            set_current_task_id(cpu_id, None);
+            return (old_current_task_id, None);
         };
-        // Add task state info to ready queue
-        self.ready_queue[cpu_id].push_back(task_id);
-        task_id
-    }
 
-    /// Determines the next task to run and returns current and next task IDs
-    ///
-    /// This method performs the core scheduling algorithm and task state management
-    /// without performing actual context switches or hardware setup.
-    ///
-    /// # Arguments
-    /// * `cpu` - The CPU architecture state (for CPU ID)
-    ///
-    /// # Returns
-    /// * `(old_task_id, new_task_id)` - Tuple of old and new task IDs
-    fn run(&mut self, cpu: &Arch) -> (Option<usize>, Option<usize>) {
-        let cpu_id = cpu.get_cpuid();
-        let old_current_task_id = self.current_task_id[cpu_id];
+        let Some(task) = TaskPool::get_task_mut(task_id) else {
+            continue;
+        };
 
-        // IMPORTANT: If there's a current running task, re-queue it BEFORE scheduling
-        // This ensures it's available as a fallback if no other tasks are ready
-        if let Some(current_id) = old_current_task_id {
-            // Check if current task is still in ready_queue (it shouldn't be if it's running)
-            if !self.ready_queue[cpu_id].iter().any(|&id| id == current_id) {
-                // Current task is not in ready_queue (it's running), add it back
-                // Only add if the task is in a valid state to be scheduled
-                if let Some(task) = self.get_task_by_id(current_id) {
-                    match task.state.load(core::sync::atomic::Ordering::SeqCst) {
-                        TaskState::Ready | TaskState::Running => {
-                            self.ready_queue[cpu_id].push_back(current_id);
-                        }
-                        _ => {
-                            // Task is in Zombie, Terminated, Blocked, or NotInitialized state
-                            // Don't re-queue it
-                        }
-                    }
-                }
+        match task.state.load(Ordering::SeqCst) {
+            TaskState::NotInitialized => panic!("Task must be initialized before scheduling"),
+            TaskState::Zombie => {
+                finalize_zombie(task.get_id(), task.get_parent_id());
+                continue;
             }
-        }
-
-        // Continue trying to find a suitable task to run
-        loop {
-            let task_id = self.ready_queue[cpu_id].pop_front();
-
-            /* If there are no subsequent tasks */
-            if self.ready_queue[cpu_id].is_empty() {
-                match task_id {
-                    Some(task_id) => {
-                        let t = self
-                            .get_task_by_id(task_id)
-                            .expect("Task must exist in task pool");
-                        match t.state.load(core::sync::atomic::Ordering::SeqCst) {
-                            TaskState::NotInitialized => {
-                                panic!("Task must be initialized before scheduling");
-                            }
-                            TaskState::Zombie => {
-                                let task_id = t.get_id();
-                                let parent_id = t.get_parent_id();
-                                self.zombie_queue[cpu_id].push_back(task_id);
-                                self.current_task_id[cpu_id] = None;
-                                // Wake up any processes waiting for this specific task
-                                wake_task_waiters(task_id);
-                                // Also wake up parent process for waitpid(-1)
-                                if let Some(parent_id) = parent_id {
-                                    wake_parent_waiters(parent_id);
-                                }
-                                continue;
-                            }
-                            TaskState::Terminated => {
-                                panic!("At least one task must be scheduled");
-                            }
-                            TaskState::Blocked(_) => {
-                                // Reset current_task_id since this task is no longer current
-                                if self.current_task_id[cpu_id] == Some(task_id) {
-                                    self.current_task_id[cpu_id] = None;
-                                }
-                                // Put blocked task to blocked queue without running it
-                                self.blocked_queue[cpu_id].push_back(task_id);
-                                continue;
-                            }
-                            TaskState::Ready | TaskState::Running => {
-                                t.state.store(
-                                    TaskState::Running,
-                                    core::sync::atomic::Ordering::SeqCst,
-                                );
-                                // Task is ready to run
-                                t.time_slice.store(
-                                    t.default_time_slice
-                                        .load(core::sync::atomic::Ordering::SeqCst),
-                                    core::sync::atomic::Ordering::SeqCst,
-                                );
-                                let next_task_id = t.get_id();
-                                self.current_task_id[cpu_id] = Some(next_task_id);
-                                self.ready_queue[cpu_id].push_back(task_id);
-                                return (old_current_task_id, Some(next_task_id));
-                            }
-                        }
-                    }
-                    // If no tasks are ready, create an idle task
-                    None => {
-                        panic!("At least one task must be scheduled");
-                    }
-                }
-            } else {
-                match task_id {
-                    Some(task_id) => {
-                        let t = self
-                            .get_task_by_id(task_id)
-                            .expect("Task must exist in task pool");
-                        match t.state.load(core::sync::atomic::Ordering::SeqCst) {
-                            TaskState::NotInitialized => {
-                                panic!("Task must be initialized before scheduling");
-                            }
-                            TaskState::Zombie => {
-                                let task_id = t.get_id();
-                                let parent_id = t.get_parent_id();
-                                self.zombie_queue[cpu_id].push_back(task_id);
-                                // Wake up any processes waiting for this specific task
-                                wake_task_waiters(task_id);
-                                // Also wake up parent process for waitpid(-1)
-                                if let Some(parent_id) = parent_id {
-                                    wake_parent_waiters(parent_id);
-                                }
-                                continue;
-                            }
-                            TaskState::Terminated => {
-                                get_task_pool().remove_task(task_id);
-                                continue;
-                            }
-                            TaskState::Blocked(_) => {
-                                // Reset current_task_id since this task is no longer current
-                                if self.current_task_id[cpu_id] == Some(task_id) {
-                                    self.current_task_id[cpu_id] = None;
-                                }
-                                // Put blocked task back to the end of queue without running it
-                                self.blocked_queue[cpu_id].push_back(task_id);
-                                continue;
-                            }
-                            TaskState::Ready | TaskState::Running => {
-                                t.time_slice.store(
-                                    t.default_time_slice
-                                        .load(core::sync::atomic::Ordering::SeqCst),
-                                    core::sync::atomic::Ordering::SeqCst,
-                                );
-                                let next_task_id = t.get_id();
-                                self.current_task_id[cpu_id] = Some(next_task_id);
-                                self.ready_queue[cpu_id].push_back(task_id);
-                                return (old_current_task_id, Some(next_task_id));
-                            }
-                        }
-                    }
-                    None => return (old_current_task_id, self.current_task_id[cpu_id]),
-                }
+            TaskState::Terminated => {
+                let _ = get_task_pool().remove_task(task_id);
+                continue;
+            }
+            TaskState::Blocked(_) => continue,
+            TaskState::Ready | TaskState::Running => {
+                task.state.store(TaskState::Running, Ordering::SeqCst);
+                task.time_slice.store(
+                    task.default_time_slice.load(Ordering::SeqCst),
+                    Ordering::SeqCst,
+                );
+                let next_task_id = task.get_id();
+                set_current_task_id(cpu_id, Some(next_task_id));
+                push_ready_task(cpu_id, next_task_id);
+                return (old_current_task_id, Some(next_task_id));
             }
         }
     }
+}
 
-    /// Called every timer tick. Decrements the current task's time_slice.
-    /// If time_slice reaches 0, triggers a reschedule.
-    pub fn on_tick(&mut self, cpu_id: usize, trapframe: &mut Trapframe) {
-        static DEBUG_TICK: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
-        let tick = DEBUG_TICK.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-        // if tick % 1000 == 0 {
-        //     fn state_str(s: TaskState) -> &'static str {
-        //         match s {
-        //             TaskState::NotInitialized => "Init",
-        //             TaskState::Ready => "Rdy",
-        //             TaskState::Running => "Run",
-        //             TaskState::Blocked(_) => "Blk",
-        //             TaskState::Zombie => "Zom",
-        //             TaskState::Terminated => "Trm",
-        //         }
-        //     }
+pub fn add_task(task: Task, cpu_id: usize) -> usize {
+    let _irq_guard = IrqGuard::new();
+    let task_id = match get_task_pool().add_task(task) {
+        Ok(id) => id,
+        Err(e) => panic!("Failed to add task: {}", e),
+    };
+    push_ready_task(cpu_id, task_id);
+    task_id
+}
 
-        //     let mut dump_queue = |queue: &VecDeque<usize>, label: &str| {
-        //         for &id in queue {
-        //             if let Some(t) = TaskPool::get_task(id) {
-        //                 let st = state_str(t.state.load(core::sync::atomic::Ordering::SeqCst));
-        //                 crate::print!("[{}]:{}({}) ", label, t.name.read(), st);
-        //             }
-        //         }
-        //     };
+/// Called every timer tick. Decrements the current task's time_slice.
+/// If time_slice reaches 0, triggers a reschedule.
+pub fn sched_on_tick(cpu_id: usize, trapframe: &mut Trapframe) {
+    let _tick = DEBUG_TICK.fetch_add(1, Ordering::Relaxed);
 
-        //     let rq_len = self.ready_queue[cpu_id].len();
-        //     let bq_len = self.blocked_queue[cpu_id].len();
-        //     let zq_len = self.zombie_queue[cpu_id].len();
-
-        //     crate::print!(
-        //         "[SCHED] tick={} R={}/B={}/Z={}: ",
-        //         tick,
-        //         rq_len,
-        //         bq_len,
-        //         zq_len
-        //     );
-        //     dump_queue(&self.ready_queue[cpu_id], "R");
-        //     dump_queue(&self.blocked_queue[cpu_id], "B");
-        //     dump_queue(&self.zombie_queue[cpu_id], "Z");
-        //     crate::print!("\n");
-        // }
-
-        if let Some(task_id) = self.get_current_task_id(cpu_id) {
-            if let Some(task) = TaskPool::get_task_mut(task_id) {
-                let current_slice = task.time_slice.load(core::sync::atomic::Ordering::SeqCst);
-                if current_slice > 0 {
-                    task.time_slice
-                        .store(current_slice - 1, core::sync::atomic::Ordering::SeqCst);
-                }
-                let new_slice = task.time_slice.load(core::sync::atomic::Ordering::SeqCst);
-                if new_slice == 0 {
-                    // crate::println!(
-                    //     "[SCHED] CPU{}: Time slice expired for Task {}",
-                    //     cpu_id,
-                    //     task_id
-                    // );
-                    // Time slice expired, trigger reschedule
-                    self.schedule(trapframe);
-                }
+    if let Some(task_id) = current_task_id(cpu_id) {
+        if let Some(task) = TaskPool::get_task_mut(task_id) {
+            let current_slice = task.time_slice.load(Ordering::SeqCst);
+            if current_slice > 0 {
+                task.time_slice.store(current_slice - 1, Ordering::SeqCst);
             }
-        } else {
-            self.schedule(trapframe);
+            if task.time_slice.load(Ordering::SeqCst) == 0 {
+                schedule(trapframe);
+            }
         }
+    } else {
+        schedule(trapframe);
     }
+}
 
-    /// Schedule tasks on the CPU with kernel context switching
-    ///
-    /// This function performs cooperative scheduling by switching between task
-    /// kernel contexts. It returns to the caller, allowing the trap handler
-    /// to handle user space return.
-    ///
-    /// # Arguments
-    /// * `cpu` - The CPU architecture state
-    pub fn schedule(&mut self, trapframe: &mut Trapframe) {
-        let cpu = get_cpu();
-        let cpu_id = cpu.get_cpuid();
+/// Schedule tasks on the CPU with kernel context switching.
+pub fn schedule(trapframe: &mut Trapframe) {
+    let cpu = get_cpu();
+    let cpu_id = cpu.get_cpuid();
+    let (current_task_id, next_task_id) = pick_next(cpu);
 
-        // Step 1: Run scheduling algorithm to get current and next task IDs
-        let (current_task_id, next_task_id) = self.run(cpu);
-
-        // Debug output for monitoring scheduler behavior
-        // if let Some(current_id) = current_task_id {
-        //     if let Some(next_id) = next_task_id {
-        //         if current_id != next_id {
-        //             crate::println!("[SCHED] CPU{}: Task {} -> Task {}", cpu_id, current_id, next_id);
-        //         }
-        //     } else {
-        //         crate::println!("[SCHED] CPU{}: Task {} -> idle", cpu_id, current_id);
-        //     }
-        // } else if let Some(next_id) = next_task_id {
-        //     crate::println!("[SCHED] CPU{}: idle -> Task {}", cpu_id, next_id);
-        // }
-
-        // Step 2: Check if a context switch is needed
-        if next_task_id.is_some() && current_task_id != next_task_id {
-            let next_task_id = next_task_id.expect("Next task ID should be valid");
-
-            // Store current task's user state to VCPU
+    if let Some(next_task_id) = next_task_id {
+        if current_task_id != Some(next_task_id) {
             if let Some(current_task_id) = current_task_id {
-                let current_task = self.get_task_by_id(current_task_id).unwrap();
+                let current_task = get_task_by_id(current_task_id).unwrap();
                 current_task.vcpu.lock().store(trapframe);
 
                 #[cfg(all(feature = "hypervisor", target_arch = "riscv64"))]
                 {
-                    // let (guest_vcpu_switch_data, hypervisor_switch_data) =
-                    //     match current_task.vcpu.lock().get_mode() {
-                    //         crate::arch::Mode::GuestKernel | crate::arch::Mode::GuestUser => {
-                    //             use crate::arch::hv::switch::HypervisorSwitchData;
-                    //             use crate::arch::hv::switch::VcpuSwitchData;
-
-                    //             (
-                    //                 Some(VcpuSwitchData::save()),
-                    //                 Some(HypervisorSwitchData::save()),
-                    //             )
-                    //         }
-                    //         _ => (None, None),
-                    //     };
-
                     use crate::arch::hv::switch::{HypervisorSwitchData, VcpuSwitchData};
 
-                    // Perform kernel context switch
-                    self.kernel_context_switch(cpu_id, current_task_id, next_task_id);
-                    // NOTE: After this point, the current task will not execute until it is scheduled again
-
-                    // if let Some(guest_vcpu_switch_data) = guest_vcpu_switch_data.as_ref() {
-                    //     guest_vcpu_switch_data.restore();
-                    // }
-                    // if let Some(hypervisor_switch_data) = hypervisor_switch_data.as_ref() {
-                    //     hypervisor_switch_data.restore();
-                    // }
+                    kernel_context_switch(cpu_id, current_task_id, next_task_id);
                 }
                 #[cfg(not(all(feature = "hypervisor", target_arch = "riscv64")))]
                 {
-                    // Perform kernel context switch
-                    self.kernel_context_switch(cpu_id, current_task_id, next_task_id);
-                    // NOTE: After this point, the current task will not execute until it is scheduled again
+                    kernel_context_switch(cpu_id, current_task_id, next_task_id);
                 }
 
-                // Restore vcpu state and set mode
-                let current_task = self.get_task_by_id(current_task_id).unwrap();
-                // let trapframe = current_task.get_trapframe();
+                let current_task = get_task_by_id(current_task_id).unwrap();
                 current_task.vcpu.lock().switch(trapframe);
                 set_next_mode(current_task.vcpu.lock().get_mode());
             } else {
-                // No current task (e.g., first scheduling), just switch to next task
-                let next_task = self.get_task_by_id(next_task_id).unwrap();
-                // crate::println!("[SCHED] Setting up task {} for execution", next_task_id);
-                Self::setup_task_execution(get_cpu(), next_task);
-                arch_switch_to_user(next_task.get_trapframe()); // Force switch to user / guest space
+                let next_task = get_task_by_id(next_task_id).unwrap();
+                setup_task_execution(get_cpu(), next_task);
+                arch_switch_to_user(next_task.get_trapframe());
+            }
+        }
+    }
+
+    if let Some(current_task) = current_task(cpu_id) {
+        let _ = current_task.process_pending_events();
+    }
+}
+
+/// Start the scheduler and return the first runnable task ID (if any).
+pub fn start_scheduler() -> Option<usize> {
+    let cpu = get_cpu();
+    let cpu_id = cpu.get_cpuid();
+    let timer = get_kernel_timer();
+    timer.stop(cpu_id);
+    timer.set_interval_us(cpu_id, crate::timer::TICK_INTERVAL_US);
+    timer.start(cpu_id);
+
+    let (_current_task_id, next_task_id) = pick_next(cpu);
+    next_task_id
+}
+
+pub fn current_task(cpu_id: usize) -> Option<&'static Task> {
+    current_task_id(cpu_id).and_then(TaskPool::get_task)
+}
+
+pub fn current_task_mut(cpu_id: usize) -> Option<&'static mut Task> {
+    current_task_id(cpu_id).and_then(TaskPool::get_task_mut)
+}
+
+pub fn current_task_id(cpu_id: usize) -> Option<usize> {
+    assert_valid_cpu_id(cpu_id);
+    decode_task_id(CURRENT_TASK_IDS[cpu_id].load(Ordering::SeqCst))
+}
+
+pub fn get_task_by_id(task_id: usize) -> Option<&'static mut Task> {
+    TaskPool::get_task_mut(task_id)
+}
+
+pub fn wake_task(task_id: usize) -> bool {
+    let _irq_guard = IrqGuard::new();
+    let Some(task) = TaskPool::get_task_mut(task_id) else {
+        return false;
+    };
+
+    if !matches!(task.state.load(Ordering::SeqCst), TaskState::Blocked(_)) {
+        return false;
+    }
+
+    task.state.store(TaskState::Running, Ordering::SeqCst);
+    core::sync::atomic::fence(Ordering::SeqCst);
+
+    if !ready_queue_contains(task_id) {
+        push_ready_task(get_cpu().get_cpuid(), task_id);
+    }
+
+    true
+}
+
+pub fn cleanup_zombie(task_id: usize) {
+    {
+        let mut zombie_queue = ZOMBIE_QUEUE.lock();
+        if let Some(pos) = zombie_queue.iter().position(|&id| id == task_id) {
+            zombie_queue.remove(pos);
+            crate::println!("[Scheduler] Removed task {} from zombie_queue", task_id);
+        }
+    }
+
+    if let Some(_task) = get_task_pool().remove_task(task_id) {
+        crate::println!("[Scheduler] Cleaned up zombie task {}", task_id);
+    }
+}
+
+pub fn remove_task_from_queues(task_id: usize) {
+    let _irq_guard = IrqGuard::new();
+
+    for cpu_id in 0..MAX_NUM_CPUS {
+        let mut queue = ready_queue(cpu_id).lock();
+        while let Some(pos) = queue.iter().position(|&id| id == task_id) {
+            queue.remove(pos);
+        }
+
+        if current_task_id(cpu_id) == Some(task_id) {
+            set_current_task_id(cpu_id, None);
+        }
+    }
+
+    let mut zombie_queue = ZOMBIE_QUEUE.lock();
+    while let Some(pos) = zombie_queue.iter().position(|&id| id == task_id) {
+        zombie_queue.remove(pos);
+    }
+}
+
+/// Get IDs of all tasks across scheduler-visible queues/state.
+pub fn get_all_task_ids() -> alloc::vec::Vec<usize> {
+    let mut ids = alloc::vec::Vec::new();
+
+    for cpu_id in 0..MAX_NUM_CPUS {
+        if let Some(task_id) = current_task_id(cpu_id) {
+            if !ids.contains(&task_id) {
+                ids.push(task_id);
             }
         }
 
-        // Step 3: Setup task execution and process events (after context switch)
-        if let Some(current_task) = self.get_current_task(cpu_id) {
-            // Process pending events before dispatching task
-            let _ = current_task.process_pending_events();
-        }
-        // Schedule returns - trap handler will call arch_switch_to_user()
-    }
-
-    /// Start the scheduler and return the first runnable task ID (if any).
-    ///
-    /// This function intentionally avoids performing the initial user-mode transition.
-    /// The very first switch is architecture-specific and should be performed by
-    /// `crate::arch::first_switch_to_user()` from the boot path.
-    pub fn start_scheduler(&mut self) -> Option<usize> {
-        let cpu = get_cpu();
-        let cpu_id = cpu.get_cpuid();
-        let timer = get_kernel_timer();
-        timer.stop(cpu_id);
-
-        // Program the periodic timer, but do not force/require the first switch via IRQ.
-        timer.set_interval_us(cpu_id, crate::timer::TICK_INTERVAL_US);
-        timer.start(cpu_id);
-
-        let (_current_task_id, next_task_id) = self.run(cpu);
-        next_task_id
-    }
-
-    pub fn get_current_task(&mut self, cpu_id: usize) -> Option<&Task> {
-        match self.current_task_id[cpu_id] {
-            Some(task_id) => TaskPool::get_task(task_id),
-            None => None,
+        let queue = ready_queue(cpu_id).lock();
+        for &task_id in queue.iter() {
+            if !ids.contains(&task_id) {
+                ids.push(task_id);
+            }
         }
     }
 
-    /// Get a mutable reference to the current task on the specified CPU
-    ///
-    /// # Safety
-    /// This function returns a mutable reference to the current task,
-    /// which can lead to undefined behavior if misused. The caller must ensure:
-    /// - No other references (mutable or immutable) to the same task exist
-    /// - The task is not concurrently accessed from other contexts
-    /// - The scheduler's invariants are maintained
-    ///
-    pub unsafe fn get_current_task_mut(&mut self, cpu_id: usize) -> Option<&mut Task> {
-        match self.current_task_id[cpu_id] {
-            Some(task_id) => TaskPool::get_task_mut(task_id),
-            None => None,
+    let zombie_queue = ZOMBIE_QUEUE.lock();
+    for &task_id in zombie_queue.iter() {
+        if !ids.contains(&task_id) {
+            ids.push(task_id);
         }
     }
 
-    pub fn get_current_task_id(&self, cpu_id: usize) -> Option<usize> {
-        self.current_task_id[cpu_id]
-    }
+    ids
+}
 
-    /// Returns a mutable reference to the task with the specified ID, if found.
-    ///
-    /// This method searches the TaskPool to find the task with the specified ID.
-    /// This is needed for Waker integration.
-    ///
-    /// # Arguments
-    /// * `task_id` - The ID of the task to search for.
-    ///
-    /// # Returns
-    /// A mutable reference to the task if found, or None otherwise.
-    pub fn get_task_by_id(&mut self, task_id: usize) -> Option<&mut Task> {
-        TaskPool::get_task_mut(task_id)
-    }
+/// Perform kernel context switch between tasks.
+fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) {
+    if from_task_id != to_task_id {
+        let mut from_ctx_ptr: *mut crate::arch::context::KernelContext = core::ptr::null_mut();
+        let mut to_ctx_ptr: *const crate::arch::context::KernelContext = core::ptr::null();
 
-    /// Move a task from blocked queue to ready queue when it's woken up
-    ///
-    /// This method is called by Waker when a blocked task needs to be woken up.
-    ///
-    /// # Arguments
-    /// * `task_id` - The ID of the task to move to ready queue
-    ///
-    /// # Returns
-    /// true if the task was found and moved, false otherwise
-    pub fn wake_task(&mut self, task_id: usize) -> bool {
-        // Search for the task in blocked queues
-        for cpu_id in 0..self.blocked_queue.len() {
-            if let Some(pos) = self.blocked_queue[cpu_id]
-                .iter()
-                .position(|&id| id == task_id)
+        {
+            if let Some(from_task) = TaskPool::get_task_mut(from_task_id) {
+                from_ctx_ptr = &mut *from_task.kernel_context.lock();
+
+                #[cfg(feature = "user-fpu")]
+                crate::arch::fpu::kernel_switch_out_user_fpu(&mut *from_task.vcpu.lock());
+
+                #[cfg(feature = "user-vector")]
+                crate::arch::fpu::kernel_switch_out_user_vector(
+                    cpu_id,
+                    from_task_id,
+                    &mut *from_task.vcpu.lock(),
+                );
+            }
+            if let Some(to_task) = TaskPool::get_task_mut(to_task_id) {
+                to_ctx_ptr = &*to_task.kernel_context.lock();
+            }
+        }
+
+        if !from_ctx_ptr.is_null() && !to_ctx_ptr.is_null() {
+            let cpu = get_cpu();
+            let saved_arch_cpu_state = ArchCpuState::save(cpu);
+            let saved_trapvector = get_trapvector();
+
+            #[cfg(feature = "hypervisor")]
+            let guest_vcpu_switch_data = crate::arch::hv::switch::VcpuSwitchData::save();
+            #[cfg(feature = "hypervisor")]
+            let hypervisor_switch_data = crate::arch::hv::switch::HypervisorSwitchData::save();
+
+            unsafe {
+                crate::arch::switch::switch_to(from_ctx_ptr, to_ctx_ptr);
+            }
+
+            #[cfg(feature = "hypervisor")]
             {
-                // Remove from blocked queue
-                self.blocked_queue[cpu_id].remove(pos);
-
-                // Get task from TaskPool and set state to Running
-                if let Some(task) = TaskPool::get_task_mut(task_id) {
-                    task.state
-                        .store(TaskState::Running, core::sync::atomic::Ordering::SeqCst);
-                    // Memory barrier to ensure state change is visible
-                    core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
-                    // Move to ready queue
-                    self.ready_queue[cpu_id].push_back(task_id);
-                    return true;
-                }
+                guest_vcpu_switch_data.restore();
+                hypervisor_switch_data.restore();
             }
-        }
-        // Not found in blocked queues. This can happen if a wake occurs between
-        // a task marking itself Blocked and the scheduler moving it to the
-        // blocked_queue. In that case, ensure the task state is set back to
-        // Running so that the scheduler does not park it.
-        if let Some(task) = TaskPool::get_task_mut(task_id) {
-            let task_state = task.state.load(core::sync::atomic::Ordering::SeqCst);
-            if let TaskState::Blocked(_) = task_state {
-                task.state
-                    .store(TaskState::Running, core::sync::atomic::Ordering::SeqCst);
-                // Memory barrier to ensure state change is visible
-                core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
-                // CRITICAL FIX: Check if task is in ready_queue, add if not
-                // This prevents tasks from being permanently unscheduled
-                let cpu_id = if let Some(current_id) = self.current_task_id[0] {
-                    if current_id == task_id {
-                        0 // Current task, no need to enqueue
-                    } else {
-                        // Find which CPU's ready_queue should contain this task
-                        // For simplicity, use CPU 0 (can be improved for multi-CPU)
-                        0
-                    }
-                } else {
-                    0 // Default to CPU 0
-                };
 
-                // Only add if not already in ready_queue to avoid duplicates
-                if !self.ready_queue[cpu_id].contains(&task_id) {
-                    self.ready_queue[cpu_id].push_back(task_id);
-                }
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Clean up a zombie task after it has been waited on
-    ///
-    /// This removes the task from zombie_queue and task_pool, freeing all resources.
-    /// Should only be called from Task::wait() after confirming the task is a zombie.
-    ///
-    /// # Arguments
-    /// * `task_id` - The ID of the zombie task to clean up
-    pub fn cleanup_zombie_task(&mut self, task_id: usize) {
-        // Remove from zombie queue
-        for cpu_id in 0..MAX_NUM_CPUS {
-            if let Some(pos) = self.zombie_queue[cpu_id]
-                .iter()
-                .position(|&id| id == task_id)
-            {
-                self.zombie_queue[cpu_id].remove(pos);
-                crate::println!("[Scheduler] Removed task {} from zombie_queue", task_id);
-                break;
-            }
-        }
-
-        // Remove from task pool (this frees all task resources)
-        if let Some(_task) = get_task_pool().remove_task(task_id) {
-            crate::println!("[Scheduler] Cleaned up zombie task {}", task_id);
-        }
-    }
-
-    pub fn remove_task_from_queues(&mut self, task_id: usize) {
-        for cpu_id in 0..MAX_NUM_CPUS {
-            if let Some(pos) = self.ready_queue[cpu_id]
-                .iter()
-                .position(|&id| id == task_id)
-            {
-                self.ready_queue[cpu_id].remove(pos);
-            }
-            if let Some(pos) = self.blocked_queue[cpu_id]
-                .iter()
-                .position(|&id| id == task_id)
-            {
-                self.blocked_queue[cpu_id].remove(pos);
-            }
-            if let Some(pos) = self.zombie_queue[cpu_id]
-                .iter()
-                .position(|&id| id == task_id)
-            {
-                self.zombie_queue[cpu_id].remove(pos);
+            let cpu = get_cpu();
+            saved_arch_cpu_state.restore(cpu);
+            set_trapvector(saved_trapvector);
+            if let Some(from_task) = TaskPool::get_task_mut(from_task_id) {
+                #[cfg(feature = "user-fpu")]
+                crate::arch::fpu::kernel_switch_in_user_fpu(&mut *from_task.vcpu.lock());
             }
         }
     }
+}
 
-    /// Get IDs of all tasks across ready, blocked, and zombie queues
-    ///
-    /// This helper is used by subsystems (e.g., event broadcast) that need
-    /// to target every task in the system without holding a mutable
-    /// reference to the scheduler during delivery.
-    pub fn get_all_task_ids(&self) -> alloc::vec::Vec<usize> {
-        let mut ids = alloc::vec::Vec::new();
-        // Ready tasks
-        for q in &self.ready_queue {
-            for t in q.iter() {
-                ids.push(*t);
-            }
-        }
-        // Blocked tasks
-        for q in &self.blocked_queue {
-            for t in q.iter() {
-                ids.push(*t);
-            }
-        }
-        // Zombie tasks
-        for q in &self.zombie_queue {
-            for t in q.iter() {
-                ids.push(*t);
-            }
-        }
-        ids
+/// Setup task execution by configuring hardware and user context.
+pub fn setup_task_execution(cpu: &mut Arch, task: &mut Task) {
+    let sp = if let Some((_slot, base)) = task.get_kernel_stack_window_base() {
+        (base + crate::environment::PAGE_SIZE + crate::environment::TASK_KERNEL_STACK_SIZE) as u64
+    } else {
+        task.get_kernel_stack_bottom_paddr()
+    };
+
+    cpu.set_kernel_stack(sp);
+
+    let task_ptr = task as *mut Task;
+    unsafe {
+        let trapframe = (*task_ptr).get_trapframe();
+        (*task_ptr).vcpu.lock().switch(trapframe);
     }
 
-    /// Perform kernel context switch between tasks
-    ///
-    /// This function handles the low-level kernel context switching between
-    /// the current task and the next selected task. It also saves/restores
-    /// FPU/SIMD/Vector context for user-space tasks.
-    ///
-    /// # Arguments
-    /// * `cpu_id` - The CPU ID
-    /// * `from_task_id` - Current task ID
-    /// * `to_task_id` - Next task ID
-    fn kernel_context_switch(&mut self, cpu_id: usize, from_task_id: usize, to_task_id: usize) {
-        // crate::println!("[SCHED] CPU{}: Switching kernel context from Task {} to Task {}", cpu_id, from_task_id, to_task_id);
-        if from_task_id != to_task_id {
-            // Find tasks in all queues (ready, blocked, zombie)
-            let mut from_ctx_ptr: *mut crate::arch::context::KernelContext = core::ptr::null_mut();
-            let mut to_ctx_ptr: *const crate::arch::context::KernelContext = core::ptr::null();
+    cpu.set_trap_handler(get_user_trap_handler());
+    cpu.set_next_address_space(task.vm_manager.get_asid());
+    set_next_mode(task.vcpu.lock().get_mode());
+    set_trapvector(get_trampoline_trap_vector());
+}
 
-            {
-                if let Some(from_task) = TaskPool::get_task_mut(from_task_id) {
-                    from_ctx_ptr = &mut *from_task.kernel_context.lock();
-
-                    #[cfg(feature = "user-fpu")]
-                    crate::arch::fpu::kernel_switch_out_user_fpu(&mut *from_task.vcpu.lock());
-
-                    #[cfg(feature = "user-vector")]
-                    crate::arch::fpu::kernel_switch_out_user_vector(
-                        cpu_id,
-                        from_task_id,
-                        &mut *from_task.vcpu.lock(),
-                    );
-                }
-                if let Some(to_task) = TaskPool::get_task_mut(to_task_id) {
-                    to_ctx_ptr = &*to_task.kernel_context.lock();
-                }
-            }
-
-            if !from_ctx_ptr.is_null() && !to_ctx_ptr.is_null() {
-                let cpu = get_cpu();
-                let saved_arch_cpu_state = ArchCpuState::save(cpu);
-                let saved_trapvector = get_trapvector();
-
-                #[cfg(feature = "hypervisor")]
-                let guest_vcpu_switch_data = crate::arch::hv::switch::VcpuSwitchData::save();
-                #[cfg(feature = "hypervisor")]
-                let hypervisor_switch_data = crate::arch::hv::switch::HypervisorSwitchData::save();
-
-                unsafe {
-                    crate::arch::switch::switch_to(from_ctx_ptr, to_ctx_ptr);
-                }
-
-                #[cfg(feature = "hypervisor")]
-                {
-                    guest_vcpu_switch_data.restore();
-                    hypervisor_switch_data.restore();
-                }
-
-                let cpu = get_cpu();
-                saved_arch_cpu_state.restore(cpu);
-                set_trapvector(saved_trapvector);
-                // Execution resumes here when this task is rescheduled
-                if let Some(from_task) = TaskPool::get_task_mut(from_task_id) {
-                    #[cfg(feature = "user-fpu")]
-                    crate::arch::fpu::kernel_switch_in_user_fpu(&mut *from_task.vcpu.lock());
-                }
-            } else {
-                // crate::println!("[SCHED] ERROR: Context pointers not found - from: {:p}, to: {:p}", from_ctx_ptr, to_ctx_ptr);
-            }
-        }
+/// Reset the scheduler to initial state (test-only).
+#[cfg(test)]
+pub fn reset() {
+    for cpu_id in 0..MAX_NUM_CPUS {
+        ready_queue(cpu_id).lock().clear();
+        set_current_task_id(cpu_id, None);
     }
-
-    /// Setup task execution by configuring hardware and user context
-    ///
-    /// This replaces the old dispatcher functionality with a more direct approach.
-    ///
-    /// # Arguments
-    /// * `cpu` - The CPU architecture state
-    /// * `task` - The task to setup for execution
-    pub fn setup_task_execution(cpu: &mut Arch, task: &mut Task) {
-        // crate::println!("[SCHED] Setting up Task {} for execution", task.get_id());
-        // crate::println!("[SCHED]   before CPU {:#x?}", cpu);
-        // let trapframe = cpu.get_trapframe();
-        // crate::println!("[SCHED]   before Trapframe {:#x?}", trapframe);
-
-        // Prefer the high-VA kernel stack window if available
-        let sp = if let Some((_slot, base)) = task.get_kernel_stack_window_base() {
-            // top = base + guard + TASK_KERNEL_STACK_SIZE
-            (base + crate::environment::PAGE_SIZE + crate::environment::TASK_KERNEL_STACK_SIZE)
-                as u64
-        } else {
-            task.get_kernel_stack_bottom_paddr()
-        };
-
-        // crate::println!("[SCHED]   Setting kernel stack to {:#x}", sp);
-        cpu.set_kernel_stack(sp);
-
-        // Handle trapframe and vcpu switching - use raw pointer to avoid borrow checker issues
-        // This is safe because we're accessing different fields of the same struct
-        let task_ptr = task as *mut Task;
-        unsafe {
-            let trapframe = (*task_ptr).get_trapframe();
-            (*task_ptr).vcpu.lock().switch(trapframe);
-        }
-
-        cpu.set_trap_handler(get_user_trap_handler());
-        cpu.set_next_address_space(task.vm_manager.get_asid());
-        let next_mode = task.vcpu.lock().get_mode();
-        set_next_mode(next_mode);
-
-        set_trapvector(get_trampoline_trap_vector());
-
-        // crate::println!("[SCHED]   after  CPU {:#x?}", cpu);
-        // crate::println!("[SCHED]   after  Trapframe {:#x?}", cpu.get_trapframe());
-
-        // Note: User context (VCPU) will be restored in schedule() after run() returns
-    }
-
-    /// Reset the scheduler to initial state (test-only)
-    ///
-    /// Clears all queues, resets current task IDs, and resets the task pool.
-    /// This should ONLY be called in tests to clean up state between test cases.
-    #[cfg(test)]
-    pub fn reset(&mut self) {
-        // Clear all queues
-        for cpu_id in 0..MAX_NUM_CPUS {
-            self.ready_queue[cpu_id].clear();
-            self.blocked_queue[cpu_id].clear();
-            self.zombie_queue[cpu_id].clear();
-            self.current_task_id[cpu_id] = None;
-        }
-
-        // Reset the task pool
-        get_task_pool().reset();
-    }
+    ZOMBIE_QUEUE.lock().clear();
+    get_task_pool().reset();
 }
 
 pub fn make_test_tasks() {
     println!("Making test tasks...");
-    let sched = get_scheduler();
     let mut task0 = new_kernel_task("Task0".to_string(), 0, || {
         println!("Task0");
         let mut counter: usize = 0;
@@ -1072,7 +769,7 @@ pub fn make_test_tasks() {
         idle();
     });
     task0.init();
-    sched.add_task(task0, 0);
+    add_task(task0, 0);
 
     let mut task1 = new_kernel_task("Task1".to_string(), 0, || {
         println!("Task1");
@@ -1091,7 +788,7 @@ pub fn make_test_tasks() {
         idle();
     });
     task1.init();
-    sched.add_task(task1, 0);
+    add_task(task1, 0);
 
     let mut task2 = new_kernel_task("Task2".to_string(), 0, || {
         println!("Task2");
@@ -1115,7 +812,7 @@ pub fn make_test_tasks() {
         idle();
     });
     task2.init();
-    sched.add_task(task2, 0);
+    add_task(task2, 0);
 }
 
 // late_initcall!(make_test_tasks);
@@ -1128,9 +825,9 @@ mod tests {
 
     #[test_case]
     fn test_add_task() {
-        let mut scheduler = Scheduler::new();
+        reset();
         let task = Task::new("TestTask".to_string(), 1, TaskType::Kernel);
-        scheduler.add_task(task, 0);
-        assert_eq!(scheduler.ready_queue[0].len(), 1);
+        add_task(task, 0);
+        assert_eq!(READY_QUEUES[0].lock().len(), 1);
     }
 }

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -464,7 +464,8 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
         let task_id = match task_id {
             Some(id) => id,
             None => {
-                // Work stealing: try to take a task from another CPU's queue
+                // Work stealing: try to take a task from another CPU's queue,
+                // but skip tasks currently running on that CPU.
                 let mut stolen = None;
                 for remote_cpu in 0..MAX_NUM_CPUS {
                     if remote_cpu == cpu_id {
@@ -472,6 +473,10 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                     }
                     let mut remote_q = ready_queue(remote_cpu).lock();
                     if let Some(remote_id) = remote_q.pop_front() {
+                        if current_task_id(remote_cpu) == Some(remote_id) {
+                            remote_q.push_back(remote_id);
+                            continue;
+                        }
                         stolen = Some(remote_id);
                         break;
                     }

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -354,8 +354,36 @@ static ZOMBIE_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::n
 static BLOCKED_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::new());
 static ONLINE_CPUS: spin::Mutex<alloc::vec::Vec<usize>> = spin::Mutex::new(alloc::vec::Vec::new());
 static IDLE_TASK_IDS: [AtomicUsize; MAX_NUM_CPUS] = [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
+static PENDING_IDLE_TO_USER_TRAP_TASK: [AtomicUsize; MAX_NUM_CPUS] =
+    [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
+
+pub fn note_idle_to_user_handoff(cpu_id: usize, task_id: usize) {
+    if cpu_id < MAX_NUM_CPUS {
+        PENDING_IDLE_TO_USER_TRAP_TASK[cpu_id].store(task_id, Ordering::SeqCst);
+    }
+}
+
+pub fn take_idle_to_user_handoff(cpu_id: usize, current_task_id: usize) -> bool {
+    if cpu_id >= MAX_NUM_CPUS {
+        return false;
+    }
+
+    PENDING_IDLE_TO_USER_TRAP_TASK[cpu_id]
+        .compare_exchange(current_task_id, 0, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+}
 static DEBUG_TICK: AtomicU64 = AtomicU64::new(0);
 static NEXT_CPU: AtomicUsize = AtomicUsize::new(0);
+
+pub const DEBUG_SMP_TASK_FLOW: bool = false;
+
+static DEBUG_ENQUEUE_SEQ: AtomicUsize = AtomicUsize::new(0);
+static DEBUG_REMOTE_ENQUEUE_TASK: [AtomicUsize; MAX_NUM_CPUS] =
+    [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
+static DEBUG_REMOTE_ENQUEUE_FROM_CPU: [AtomicUsize; MAX_NUM_CPUS] =
+    [const { AtomicUsize::new(NO_CPU) }; MAX_NUM_CPUS];
+static DEBUG_REMOTE_ENQUEUE_SEQ: [AtomicUsize; MAX_NUM_CPUS] =
+    [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
 
 const NO_CPU: usize = usize::MAX;
 
@@ -363,6 +391,41 @@ const TASK_ID_MASK: usize = MAX_TASKS - 1;
 
 static SCHEDULE_PREV_TASK: [AtomicUsize; MAX_NUM_CPUS] =
     [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
+
+fn debug_remote_enqueue_snapshot(cpu_id: usize) -> (Option<usize>, usize, usize) {
+    let task_id = decode_task_id(DEBUG_REMOTE_ENQUEUE_TASK[cpu_id].load(Ordering::SeqCst));
+    let from_cpu = DEBUG_REMOTE_ENQUEUE_FROM_CPU[cpu_id].load(Ordering::SeqCst);
+    let seq = DEBUG_REMOTE_ENQUEUE_SEQ[cpu_id].load(Ordering::SeqCst);
+    (task_id, from_cpu, seq)
+}
+
+fn debug_task_name(task_id: usize) -> alloc::string::String {
+    TaskPool::get_task(task_id)
+        .map(|task| task.name.read().clone())
+        .unwrap_or_else(|| "<missing>".to_string())
+}
+
+pub fn debug_log_reschedule_ipi(cpu_id: usize, from_kernel: bool, can_schedule: bool) {
+    if !DEBUG_SMP_TASK_FLOW {
+        return;
+    }
+
+    let (expected_task, from_cpu, seq) = debug_remote_enqueue_snapshot(cpu_id);
+    println!(
+        "[SMPDBG ipi-recv] cpu={} from_kernel={} can_schedule={} current={:?} expected_task={:?} expected_name={} expected_from={} seq={} ready_len={}",
+        cpu_id,
+        from_kernel,
+        can_schedule,
+        current_task_id(cpu_id),
+        expected_task,
+        expected_task
+            .map(debug_task_name)
+            .unwrap_or_else(|| "<none>".to_string()),
+        from_cpu,
+        seq,
+        ready_queue(cpu_id).lock().len(),
+    );
+}
 
 fn release_deferred_prev(cpu_id: usize) {
     let prev = decode_prev_task(SCHEDULE_PREV_TASK[cpu_id].swap(0, Ordering::SeqCst));
@@ -377,6 +440,13 @@ fn release_deferred_prev(cpu_id: usize) {
         .compare_exchange(cpu_id, NO_CPU, Ordering::SeqCst, Ordering::SeqCst)
         .is_ok()
     {
+        // Idle tasks are never enqueued into the ready queue. They are
+        // selected by the fallback in pick_next() when the queue is empty.
+        let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+        if prev_id == idle_id {
+            task.state.store(TaskState::Ready, Ordering::SeqCst);
+            return;
+        }
         // Requeue the previous task on the CPU that just switched away from it.
         // This keeps kernel-context resume paths CPU-local. New task placement
         // and wakeups provide SMP distribution without stealing suspended
@@ -580,13 +650,34 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                         finalize_zombie(task.get_id(), task.get_parent_id());
                         continue;
                     }
-                    TaskState::Terminated => continue,
-                    TaskState::Blocked(_) => continue,
+                    TaskState::Terminated => {
+                        continue;
+                    }
+                    TaskState::Blocked(blocked) => {
+                        let _ = blocked;
+                        continue;
+                    }
                     TaskState::Ready | TaskState::Running => {
                         if task.running_cpu.load(Ordering::SeqCst) != NO_CPU {
                             continue;
                         }
                         if try_claim_ready_task(task, cpu_id) {
+                            if DEBUG_SMP_TASK_FLOW {
+                                let (expected_task, _from_cpu, seq) =
+                                    debug_remote_enqueue_snapshot(cpu_id);
+                                if expected_task.is_some() {
+                                    println!(
+                                        "[SMPDBG pick-selected] cpu={} old={:?} next={} next_name={} expected_task={:?} expected_match={} seq={}",
+                                        cpu_id,
+                                        old_id,
+                                        task_id,
+                                        task.name.read().as_str(),
+                                        expected_task,
+                                        expected_task == Some(task_id),
+                                        seq,
+                                    );
+                                }
+                            }
                             next_id = Some(task_id);
                             break 'outer;
                         }
@@ -657,20 +748,83 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
     }
 
     set_current_task_id(cpu_id, Some(next_id));
+    if DEBUG_SMP_TASK_FLOW {
+        let (expected_task, from_cpu, seq) = debug_remote_enqueue_snapshot(cpu_id);
+        if expected_task.is_some() && expected_task != Some(next_id) {
+            println!(
+                "[SMPDBG pick-mismatch] cpu={} old={:?} next={} next_name={} expected_task={:?} expected_from={} seq={}",
+                cpu_id,
+                old_id,
+                next_id,
+                debug_task_name(next_id),
+                expected_task,
+                from_cpu,
+                seq,
+            );
+        }
+    }
     (old_id, Some(next_id))
 }
 
 pub fn add_task(task: Task, cpu_id: usize) -> usize {
     let _irq_guard = IrqGuard::new();
+    let task_id = register_task(task);
+    enqueue_task(task_id, cpu_id);
+    task_id
+}
+
+/// Add a task to the global task pool without making it runnable yet.
+///
+/// This is useful for fork/clone paths that need the allocated task ID before
+/// finalizing parent/child relationships or ABI-specific setup.  The caller
+/// must eventually call [`enqueue_task`] to make the task visible to the
+/// scheduler.
+pub fn register_task(task: Task) -> usize {
     let task_id = match get_task_pool().add_task(task) {
         Ok(id) => id,
         Err(e) => panic!("Failed to add task: {}", e),
     };
+    task_id
+}
+
+/// Make a registered task runnable on the specified CPU.
+pub fn enqueue_task(task_id: usize, cpu_id: usize) {
+    let _irq_guard = IrqGuard::new();
+    let current_cpu = get_cpu().get_cpuid();
+    let seq = DEBUG_ENQUEUE_SEQ.fetch_add(1, Ordering::SeqCst) + 1;
+    if let Some(task) = TaskPool::get_task(task_id) {
+        task.last_cpu.store(cpu_id, Ordering::SeqCst);
+    }
     push_ready_task(cpu_id, task_id);
+    if DEBUG_SMP_TASK_FLOW {
+        println!(
+            "[SMPDBG enqueue] seq={} from_cpu={} target_cpu={} task={} name={} remote={} ready_len={}",
+            seq,
+            current_cpu,
+            cpu_id,
+            task_id,
+            debug_task_name(task_id),
+            cpu_id != current_cpu,
+            ready_queue(cpu_id).lock().len(),
+        );
+    }
     if is_cpu_online(cpu_id) && cpu_id != get_cpu().get_cpuid() {
+        DEBUG_REMOTE_ENQUEUE_TASK[cpu_id].store(encode_task_id(Some(task_id)), Ordering::SeqCst);
+        DEBUG_REMOTE_ENQUEUE_FROM_CPU[cpu_id].store(current_cpu, Ordering::SeqCst);
+        DEBUG_REMOTE_ENQUEUE_SEQ[cpu_id].store(seq, Ordering::SeqCst);
+        if DEBUG_SMP_TASK_FLOW {
+            println!(
+                "[SMPDBG ipi-send] seq={} from_cpu={} target_cpu={} task={} name={} ready_len={}",
+                seq,
+                current_cpu,
+                cpu_id,
+                task_id,
+                debug_task_name(task_id),
+                ready_queue(cpu_id).lock().len(),
+            );
+        }
         crate::arch::send_reschedule_ipi(cpu_id);
     }
-    task_id
 }
 
 /// Called every timer tick. Decrements the current task's time_slice.
@@ -698,9 +852,14 @@ pub fn schedule(trapframe: &mut Trapframe) {
     let cpu = get_cpu();
     let cpu_id = cpu.get_cpuid();
     let (current_task_id, next_task_id) = pick_next(cpu);
+    let idle_task_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
 
     if let Some(next_task_id) = next_task_id {
         if current_task_id != Some(next_task_id) {
+            if current_task_id == Some(idle_task_id) && next_task_id != idle_task_id {
+                note_idle_to_user_handoff(cpu_id, next_task_id);
+            }
+
             if let Some(current_task_id) = current_task_id {
                 if let Some(current_task) = TaskPool::get_task(current_task_id) {
                     current_task.last_cpu.store(cpu_id, Ordering::SeqCst);
@@ -739,6 +898,7 @@ fn idle_loop() -> ! {
 }
 
 fn idle_entry() {
+    register_online_cpu(get_cpu().get_cpuid());
     idle_loop()
 }
 
@@ -774,11 +934,13 @@ pub fn first_switch_to_kernel_task(task_id: usize) -> ! {
     };
 
     let mut boot_context = crate::arch::context::KernelContext::new();
-    let to_ctx_ptr = &*task.kernel_context.lock() as *const crate::arch::context::KernelContext;
+    let to_ctx_ptr = task.kernel_context.as_mut_ptr() as *const crate::arch::context::KernelContext;
 
     // SAFETY: `task_id` is the current runnable task selected by `start_scheduler`,
-    // and `to_ctx_ptr` points to its initialized kernel context. `boot_context`
-    // is a temporary save area for the boot/AP context and remains valid here.
+    // and `to_ctx_ptr` points to its initialized kernel context. The scheduler
+    // has claimed this task before the first switch, so no other CPU mutates the
+    // target context concurrently. `boot_context` is a temporary save area for
+    // the boot/AP context and remains valid here.
     unsafe {
         crate::arch::switch::switch_to(&mut boot_context as *mut _, to_ctx_ptr);
     }
@@ -845,7 +1007,9 @@ pub fn wake_task_on(task_id: usize, target_cpu: usize) -> bool {
     loop {
         match state {
             TaskState::Blocked(_) => {}
-            _ => return false,
+            _ => {
+                return false;
+            }
         }
         match task.state.compare_exchange(
             state,
@@ -859,9 +1023,34 @@ pub fn wake_task_on(task_id: usize, target_cpu: usize) -> bool {
     }
 
     unmark_blocked(task_id);
+    if DEBUG_SMP_TASK_FLOW {
+        println!(
+            "[SMPDBG wake-task-on] current_cpu={} target_cpu={} task={} name={} state=Ready enqueue",
+            get_cpu().get_cpuid(),
+            target_cpu,
+            task_id,
+            debug_task_name(task_id),
+        );
+    }
     push_ready_task(target_cpu, task_id);
 
     if target_cpu != get_cpu().get_cpuid() {
+        let seq = DEBUG_ENQUEUE_SEQ.fetch_add(1, Ordering::SeqCst) + 1;
+        DEBUG_REMOTE_ENQUEUE_TASK[target_cpu]
+            .store(encode_task_id(Some(task_id)), Ordering::SeqCst);
+        DEBUG_REMOTE_ENQUEUE_FROM_CPU[target_cpu].store(get_cpu().get_cpuid(), Ordering::SeqCst);
+        DEBUG_REMOTE_ENQUEUE_SEQ[target_cpu].store(seq, Ordering::SeqCst);
+        if DEBUG_SMP_TASK_FLOW {
+            println!(
+                "[SMPDBG wake-ipi-send] seq={} from_cpu={} target_cpu={} task={} name={} ready_len={}",
+                seq,
+                get_cpu().get_cpuid(),
+                target_cpu,
+                task_id,
+                debug_task_name(task_id),
+                ready_queue(target_cpu).lock().len(),
+            );
+        }
         crate::arch::send_reschedule_ipi(target_cpu);
     }
 
@@ -942,26 +1131,52 @@ pub fn get_all_task_ids() -> alloc::vec::Vec<usize> {
 /// Perform kernel context switch between tasks.
 fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) {
     if from_task_id != to_task_id {
+        if DEBUG_SMP_TASK_FLOW {
+            let (expected_task, from_cpu, seq) = debug_remote_enqueue_snapshot(cpu_id);
+            if expected_task.is_some() {
+                println!(
+                    "[SMPDBG kctx-enter] cpu={} from={} from_name={} to={} to_name={} expected_task={:?} expected_from={} expected_match={} seq={}",
+                    cpu_id,
+                    from_task_id,
+                    debug_task_name(from_task_id),
+                    to_task_id,
+                    debug_task_name(to_task_id),
+                    expected_task,
+                    from_cpu,
+                    expected_task == Some(to_task_id),
+                    seq,
+                );
+            }
+        }
         let mut from_ctx_ptr: *mut crate::arch::context::KernelContext = core::ptr::null_mut();
         let mut to_ctx_ptr: *const crate::arch::context::KernelContext = core::ptr::null();
 
-        {
-            if let Some(from_task) = TaskPool::get_task(from_task_id) {
-                from_ctx_ptr = &mut *from_task.kernel_context.lock();
+        if let Some(from_task) = TaskPool::get_task(from_task_id) {
+            // The currently running task is owned by this CPU, and its kernel
+            // context is the save target of the low-level switch code. Do not
+            // take `kernel_context`'s spin mutex here: a task can be switched
+            // out while code higher in its kernel stack still owns unrelated
+            // locks, and blocking in the scheduler makes SMP remote wakeups
+            // deadlock-prone. The `running_cpu` ownership token provides the
+            // required exclusion for context switching.
+            from_ctx_ptr = from_task.kernel_context.as_mut_ptr();
 
-                #[cfg(feature = "user-fpu")]
-                crate::arch::fpu::kernel_switch_out_user_fpu(&mut *from_task.vcpu.lock());
+            #[cfg(feature = "user-fpu")]
+            crate::arch::fpu::kernel_switch_out_user_fpu(&mut *from_task.vcpu.lock());
 
-                #[cfg(feature = "user-vector")]
-                crate::arch::fpu::kernel_switch_out_user_vector(
-                    cpu_id,
-                    from_task_id,
-                    &mut *from_task.vcpu.lock(),
-                );
-            }
-            if let Some(to_task) = TaskPool::get_task(to_task_id) {
-                to_ctx_ptr = &*to_task.kernel_context.lock();
-            }
+            #[cfg(feature = "user-vector")]
+            crate::arch::fpu::kernel_switch_out_user_vector(
+                cpu_id,
+                from_task_id,
+                &mut *from_task.vcpu.lock(),
+            );
+        }
+        if let Some(to_task) = TaskPool::get_task(to_task_id) {
+            // `pick_next()` successfully claimed `to_task.running_cpu` for this
+            // CPU before reaching this point, so no other CPU may save/restore
+            // this kernel context concurrently. Read it locklessly for the same
+            // reason as `from_ctx_ptr` above.
+            to_ctx_ptr = to_task.kernel_context.as_mut_ptr() as *const _;
         }
 
         if !from_ctx_ptr.is_null() && !to_ctx_ptr.is_null() {
@@ -975,7 +1190,37 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
             let hypervisor_switch_data = crate::arch::hv::switch::HypervisorSwitchData::save();
 
             unsafe {
+                if DEBUG_SMP_TASK_FLOW {
+                    let (expected_task, _from_cpu, seq) = debug_remote_enqueue_snapshot(cpu_id);
+                    if expected_task.is_some() {
+                        println!(
+                            "[SMPDBG kctx-switch-to] cpu={} from={} to={} to_name={} expected_task={:?} expected_match={} seq={}",
+                            cpu_id,
+                            from_task_id,
+                            to_task_id,
+                            debug_task_name(to_task_id),
+                            expected_task,
+                            expected_task == Some(to_task_id),
+                            seq,
+                        );
+                    }
+                }
                 crate::arch::switch::switch_to(from_ctx_ptr, to_ctx_ptr);
+            }
+
+            if DEBUG_SMP_TASK_FLOW {
+                let (expected_task, _from_cpu, seq) = debug_remote_enqueue_snapshot(cpu_id);
+                if expected_task.is_some() {
+                    println!(
+                        "[SMPDBG kctx-resume] cpu={} resumed={} resumed_name={} switched_from={} expected_task={:?} seq={}",
+                        cpu_id,
+                        from_task_id,
+                        debug_task_name(from_task_id),
+                        to_task_id,
+                        expected_task,
+                        seq,
+                    );
+                }
             }
 
             release_deferred_prev(cpu_id);
@@ -999,12 +1244,32 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
 
 /// Setup task execution by configuring hardware and user context.
 pub fn setup_task_execution(cpu: &mut Arch, task: &Task) {
+    if DEBUG_SMP_TASK_FLOW {
+        let cpu_id = cpu.get_cpuid();
+        let (expected_task, _from_cpu, seq) = debug_remote_enqueue_snapshot(cpu_id);
+        if expected_task.is_some() {
+            let vcpu = task.vcpu.lock();
+            println!(
+                "[SMPDBG setup-task-exec] cpu={} task={} name={} mode={:?} pc={:#x} expected_task={:?} expected_match={} seq={}",
+                cpu_id,
+                task.get_id(),
+                task.name.read().as_str(),
+                vcpu.get_mode(),
+                vcpu.get_pc(),
+                expected_task,
+                expected_task == Some(task.get_id()),
+                seq,
+            );
+        }
+    }
+
     let sp = if let Some((_slot, base)) = task.get_kernel_stack_window_base() {
         (base + crate::environment::PAGE_SIZE + crate::environment::TASK_KERNEL_STACK_SIZE) as u64
     } else {
         task.get_kernel_stack_bottom_paddr()
     };
 
+    crate::arch::set_arch(crate::vm::get_trampoline_arch(cpu.get_cpuid()));
     cpu.set_kernel_stack(sp);
 
     let task_mode = task.vcpu.lock().get_mode();

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -535,7 +535,7 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                         if old_current_runnable {
                             if let Some(current_id) = old_current_task_id {
                                 if let Some(task) = TaskPool::get_task_mut(current_id) {
-                                    task.state.store(TaskState::Running, Ordering::SeqCst);
+                                    task.state.store(TaskState::Ready, Ordering::SeqCst);
                                     task.time_slice.store(
                                         task.default_time_slice.load(Ordering::SeqCst),
                                         Ordering::SeqCst,

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -361,11 +361,57 @@ static READY_QUEUES: [spin::Mutex<VecDeque<usize>>; MAX_NUM_CPUS] =
     [const { spin::Mutex::new(VecDeque::new()) }; MAX_NUM_CPUS];
 static ZOMBIE_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::new());
 static BLOCKED_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::new());
+static ONLINE_CPUS: spin::Mutex<alloc::vec::Vec<usize>> = spin::Mutex::new(alloc::vec::Vec::new());
+static IDLE_TASK_IDS: [AtomicUsize; MAX_NUM_CPUS] = [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
 static DEBUG_TICK: AtomicU64 = AtomicU64::new(0);
 static NEXT_CPU: AtomicUsize = AtomicUsize::new(0);
 
+pub fn register_online_cpu(cpu_id: usize) {
+    let mut cpus = ONLINE_CPUS.lock();
+    if !cpus.contains(&cpu_id) {
+        cpus.push(cpu_id);
+    }
+}
+
+pub fn for_each_online_cpu<F: FnMut(usize)>(mut f: F) {
+    let cpus = ONLINE_CPUS.lock();
+    for &cpu_id in cpus.iter() {
+        f(cpu_id);
+    }
+}
+
+pub fn num_online_cpus() -> usize {
+    ONLINE_CPUS.lock().len()
+}
+
 pub fn select_cpu() -> usize {
-    NEXT_CPU.fetch_add(1, Ordering::Relaxed) % MAX_NUM_CPUS
+    let cpus = ONLINE_CPUS.lock();
+    if cpus.is_empty() {
+        return 0;
+    }
+    let idx = NEXT_CPU.fetch_add(1, Ordering::Relaxed) % cpus.len();
+    cpus[idx]
+}
+
+fn is_cpu_online(cpu_id: usize) -> bool {
+    ONLINE_CPUS.lock().contains(&cpu_id)
+}
+
+fn find_least_loaded_cpu() -> usize {
+    let cpus = ONLINE_CPUS.lock();
+    if cpus.is_empty() {
+        return 0;
+    }
+    let mut best_cpu = cpus[0];
+    let mut best_len = ready_queue(best_cpu).lock().len();
+    for &cpu_id in cpus.iter().skip(1) {
+        let len = ready_queue(cpu_id).lock().len();
+        if len < best_len {
+            best_len = len;
+            best_cpu = cpu_id;
+        }
+    }
+    best_cpu
 }
 
 #[inline]
@@ -404,12 +450,13 @@ pub fn push_ready_task(cpu_id: usize, task_id: usize) {
 }
 
 fn ready_queue_contains(task_id: usize) -> bool {
-    for cpu_id in 0..MAX_NUM_CPUS {
-        if ready_queue(cpu_id).lock().contains(&task_id) {
-            return true;
+    let mut found = false;
+    for_each_online_cpu(|cpu_id| {
+        if !found && ready_queue(cpu_id).lock().contains(&task_id) {
+            found = true;
         }
-    }
-    false
+    });
+    found
 }
 
 pub fn mark_blocked(task_id: usize) {
@@ -447,10 +494,8 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
     if let Some(current_id) = old_current_task_id {
         if let Some(task) = TaskPool::get_task_mut(current_id) {
             match task.state.load(Ordering::SeqCst) {
-                TaskState::Ready => push_ready_task(cpu_id, current_id),
-                TaskState::Running => {
+                TaskState::Ready | TaskState::Running => {
                     task.state.store(TaskState::Ready, Ordering::SeqCst);
-                    push_ready_task(cpu_id, current_id);
                 }
                 TaskState::Zombie => finalize_zombie(current_id, task.get_parent_id()),
                 TaskState::Terminated | TaskState::Blocked(_) | TaskState::NotInitialized => {}
@@ -458,32 +503,61 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
         }
     }
 
+    let old_current_runnable = old_current_task_id.is_some_and(|id| {
+        TaskPool::get_task(id)
+            .is_some_and(|t| t.state.load(Ordering::SeqCst) == TaskState::Ready)
+    });
+
     loop {
         let task_id = { ready_queue(cpu_id).lock().pop_front() };
 
         let task_id = match task_id {
             Some(id) => id,
             None => {
-                // Work stealing: try to take a task from another CPU's queue,
-                // but skip tasks currently running on that CPU.
                 let mut stolen = None;
-                for remote_cpu in 0..MAX_NUM_CPUS {
-                    if remote_cpu == cpu_id {
-                        continue;
+                for_each_online_cpu(|remote_cpu| {
+                    if stolen.is_some() || remote_cpu == cpu_id {
+                        return;
                     }
                     let mut remote_q = ready_queue(remote_cpu).lock();
                     if let Some(remote_id) = remote_q.pop_front() {
-                        if current_task_id(remote_cpu) == Some(remote_id) {
-                            remote_q.push_back(remote_id);
-                            continue;
+                        if let Some(task) = TaskPool::get_task(remote_id) {
+                            if task.pinned_cpu.is_some() {
+                                remote_q.push_back(remote_id);
+                                return;
+                            }
                         }
                         stolen = Some(remote_id);
-                        break;
                     }
-                }
+                });
                 match stolen {
                     Some(id) => id,
                     None => {
+                        if old_current_runnable {
+                            if let Some(current_id) = old_current_task_id {
+                                if let Some(task) = TaskPool::get_task_mut(current_id) {
+                                    task.state.store(TaskState::Running, Ordering::SeqCst);
+                                    task.time_slice.store(
+                                        task.default_time_slice.load(Ordering::SeqCst),
+                                        Ordering::SeqCst,
+                                    );
+                                }
+                                set_current_task_id(cpu_id, Some(current_id));
+                                return (old_current_task_id, Some(current_id));
+                            }
+                        }
+                        let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+                        if idle_id != 0 {
+                            if let Some(task) = TaskPool::get_task_mut(idle_id) {
+                                task.state.store(TaskState::Running, Ordering::SeqCst);
+                                task.time_slice.store(
+                                    task.default_time_slice.load(Ordering::SeqCst),
+                                    Ordering::SeqCst,
+                                );
+                            }
+                            set_current_task_id(cpu_id, Some(idle_id));
+                            return (old_current_task_id, Some(idle_id));
+                        }
                         set_current_task_id(cpu_id, None);
                         return (old_current_task_id, None);
                     }
@@ -513,8 +587,12 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                     Ordering::SeqCst,
                 );
                 let next_task_id = task.get_id();
+                if let Some(old_id) = old_current_task_id {
+                    if old_current_runnable && old_id != next_task_id {
+                        push_ready_task(cpu_id, old_id);
+                    }
+                }
                 set_current_task_id(cpu_id, Some(next_task_id));
-                push_ready_task(cpu_id, next_task_id);
                 return (old_current_task_id, Some(next_task_id));
             }
         }
@@ -561,6 +639,7 @@ pub fn schedule(trapframe: &mut Trapframe) {
         if current_task_id != Some(next_task_id) {
             if let Some(current_task_id) = current_task_id {
                 let current_task = get_task_by_id(current_task_id).unwrap();
+                current_task.last_cpu.store(cpu_id, Ordering::SeqCst);
                 current_task.vcpu.lock().store(trapframe);
 
                 #[cfg(all(feature = "hypervisor", target_arch = "riscv64"))]
@@ -591,6 +670,30 @@ pub fn schedule(trapframe: &mut Trapframe) {
 }
 
 /// Start the scheduler and return the first runnable task ID (if any).
+fn idle_loop() -> ! {
+    loop {
+        idle();
+    }
+}
+
+fn idle_entry() {
+    idle_loop()
+}
+
+pub fn spawn_idle_task(cpu_id: usize) -> usize {
+    let name = alloc::format!("idle{}", cpu_id);
+    let mut task = new_kernel_task(name, 0, idle_entry);
+    task.pinned_cpu = Some(cpu_id);
+    task.init();
+    // Idle task is used as a fallback in pick_next when no real tasks are available.
+    let task_id = match get_task_pool().add_task(task) {
+        Ok(id) => id,
+        Err(e) => panic!("Failed to add idle task: {}", e),
+    };
+    IDLE_TASK_IDS[cpu_id].store(task_id, Ordering::SeqCst);
+    task_id
+}
+
 pub fn start_scheduler() -> Option<usize> {
     let cpu = get_cpu();
     let cpu_id = cpu.get_cpuid();
@@ -621,7 +724,22 @@ pub fn get_task_by_id(task_id: usize) -> Option<&'static mut Task> {
 }
 
 pub fn wake_task(task_id: usize) -> bool {
-    wake_task_on(task_id, get_cpu().get_cpuid())
+    let target_cpu = {
+        let Some(task) = TaskPool::get_task(task_id) else {
+            return false;
+        };
+        if let Some(pinned) = task.pinned_cpu {
+            pinned
+        } else {
+            let last = task.last_cpu.load(Ordering::SeqCst);
+            if last > 0 && is_cpu_online(last) {
+                last
+            } else {
+                find_least_loaded_cpu()
+            }
+        }
+    };
+    wake_task_on(task_id, target_cpu)
 }
 
 pub fn wake_task_on(task_id: usize, target_cpu: usize) -> bool {
@@ -666,7 +784,7 @@ pub fn cleanup_zombie(task_id: usize) {
 pub fn remove_from_ready_queues(task_id: usize) {
     let _irq_guard = IrqGuard::new();
 
-    for cpu_id in 0..MAX_NUM_CPUS {
+    for_each_online_cpu(|cpu_id| {
         let mut queue = ready_queue(cpu_id).lock();
         while let Some(pos) = queue.iter().position(|&id| id == task_id) {
             queue.remove(pos);
@@ -675,7 +793,7 @@ pub fn remove_from_ready_queues(task_id: usize) {
         if current_task_id(cpu_id) == Some(task_id) {
             set_current_task_id(cpu_id, None);
         }
-    }
+    });
 }
 
 pub fn remove_from_zombie_queue(task_id: usize) {
@@ -695,7 +813,7 @@ pub fn remove_task_from_queues(task_id: usize) {
 pub fn get_all_task_ids() -> alloc::vec::Vec<usize> {
     let mut ids = alloc::vec::Vec::new();
 
-    for cpu_id in 0..MAX_NUM_CPUS {
+    for_each_online_cpu(|cpu_id| {
         if let Some(task_id) = current_task_id(cpu_id) {
             if !ids.contains(&task_id) {
                 ids.push(task_id);
@@ -708,7 +826,7 @@ pub fn get_all_task_ids() -> alloc::vec::Vec<usize> {
                 ids.push(task_id);
             }
         }
-    }
+    });
 
     let zombie_queue = ZOMBIE_QUEUE.lock();
     for &task_id in zombie_queue.iter() {
@@ -794,6 +912,7 @@ pub fn setup_task_execution(cpu: &mut Arch, task: &mut Task) {
     cpu.set_kernel_stack(sp);
 
     let task_ptr = task as *mut Task;
+    let task_mode = task.vcpu.lock().get_mode();
     unsafe {
         let trapframe = (*task_ptr).get_trapframe();
         (*task_ptr).vcpu.lock().switch(trapframe);
@@ -801,7 +920,7 @@ pub fn setup_task_execution(cpu: &mut Arch, task: &mut Task) {
 
     cpu.set_trap_handler(get_user_trap_handler());
     cpu.set_next_address_space(task.vm_manager.get_asid());
-    set_next_mode(task.vcpu.lock().get_mode());
+    set_next_mode(task_mode);
     set_trapvector(get_trampoline_trap_vector());
 }
 

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -360,6 +360,7 @@ static CURRENT_TASK_IDS: [AtomicUsize; MAX_NUM_CPUS] =
 static READY_QUEUES: [spin::Mutex<VecDeque<usize>>; MAX_NUM_CPUS] =
     [const { spin::Mutex::new(VecDeque::new()) }; MAX_NUM_CPUS];
 static ZOMBIE_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::new());
+static BLOCKED_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::new());
 static DEBUG_TICK: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
@@ -406,7 +407,21 @@ fn ready_queue_contains(task_id: usize) -> bool {
     false
 }
 
-fn finalize_zombie(task_id: usize, parent_id: Option<usize>) {
+pub fn mark_blocked(task_id: usize) {
+    let mut queue = BLOCKED_QUEUE.lock();
+    if !queue.contains(&task_id) {
+        queue.push_back(task_id);
+    }
+}
+
+pub fn unmark_blocked(task_id: usize) {
+    let mut queue = BLOCKED_QUEUE.lock();
+    if let Some(pos) = queue.iter().position(|&id| id == task_id) {
+        queue.remove(pos);
+    }
+}
+
+pub fn finalize_zombie(task_id: usize, parent_id: Option<usize>) {
     {
         let mut zombie_queue = ZOMBIE_QUEUE.lock();
         if !zombie_queue.contains(&task_id) {
@@ -591,6 +606,7 @@ pub fn wake_task_on(task_id: usize, target_cpu: usize) -> bool {
 
     task.state.store(TaskState::Running, Ordering::SeqCst);
     core::sync::atomic::fence(Ordering::SeqCst);
+    unmark_blocked(task_id);
 
     if !ready_queue_contains(task_id) {
         push_ready_task(target_cpu, task_id);
@@ -617,7 +633,7 @@ pub fn cleanup_zombie(task_id: usize) {
     }
 }
 
-pub fn remove_task_from_queues(task_id: usize) {
+pub fn remove_from_ready_queues(task_id: usize) {
     let _irq_guard = IrqGuard::new();
 
     for cpu_id in 0..MAX_NUM_CPUS {
@@ -630,11 +646,19 @@ pub fn remove_task_from_queues(task_id: usize) {
             set_current_task_id(cpu_id, None);
         }
     }
+}
 
+pub fn remove_from_zombie_queue(task_id: usize) {
     let mut zombie_queue = ZOMBIE_QUEUE.lock();
     while let Some(pos) = zombie_queue.iter().position(|&id| id == task_id) {
         zombie_queue.remove(pos);
     }
+}
+
+pub fn remove_task_from_queues(task_id: usize) {
+    remove_from_ready_queues(task_id);
+    remove_from_zombie_queue(task_id);
+    unmark_blocked(task_id);
 }
 
 /// Get IDs of all tasks across scheduler-visible queues/state.
@@ -658,6 +682,13 @@ pub fn get_all_task_ids() -> alloc::vec::Vec<usize> {
 
     let zombie_queue = ZOMBIE_QUEUE.lock();
     for &task_id in zombie_queue.iter() {
+        if !ids.contains(&task_id) {
+            ids.push(task_id);
+        }
+    }
+
+    let blocked_queue = BLOCKED_QUEUE.lock();
+    for &task_id in blocked_queue.iter() {
         if !ids.contains(&task_id) {
             ids.push(task_id);
         }
@@ -752,6 +783,7 @@ pub fn reset() {
         set_current_task_id(cpu_id, None);
     }
     ZOMBIE_QUEUE.lock().clear();
+    BLOCKED_QUEUE.lock().clear();
     get_task_pool().reset();
 }
 

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -377,18 +377,18 @@ fn release_deferred_prev(cpu_id: usize) {
         .compare_exchange(cpu_id, NO_CPU, Ordering::SeqCst, Ordering::SeqCst)
         .is_ok()
     {
-        // Now that ownership is released, enqueue the task so other CPUs
-        // (or this one) can claim it on the next pick_next round.
+        // Requeue the previous task on the CPU that just switched away from it.
+        // This keeps kernel-context resume paths CPU-local. New task placement
+        // and wakeups provide SMP distribution without stealing suspended
+        // kernel contexts from another CPU's ready queue.
         if matches!(task.state.load(Ordering::SeqCst), TaskState::Ready) {
-            let target = task.last_cpu.load(Ordering::SeqCst);
-            let target = if is_cpu_online(target) {
-                target
-            } else {
-                cpu_id
-            };
-            push_ready_task(target, prev_id);
+            push_ready_task(cpu_id, prev_id);
         }
     }
+}
+
+pub fn complete_deferred_context_switch(cpu_id: usize) {
+    release_deferred_prev(cpu_id);
 }
 
 fn try_claim_ready_task(task: &Task, cpu_id: usize) -> bool {
@@ -595,23 +595,7 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                 }
             }
             None => {
-                let mut stolen = None;
-                for_each_online_cpu(|remote_cpu| {
-                    if stolen.is_some() || remote_cpu == cpu_id {
-                        return;
-                    }
-                    let mut remote_q = ready_queue(remote_cpu).lock();
-                    if let Some(remote_id) = remote_q.pop_front() {
-                        stolen = Some(remote_id);
-                    }
-                });
-                match stolen {
-                    Some(id) => {
-                        push_ready_task(cpu_id, id);
-                        continue;
-                    }
-                    None => break 'outer,
-                }
+                break 'outer;
             }
         }
     }
@@ -683,6 +667,9 @@ pub fn add_task(task: Task, cpu_id: usize) -> usize {
         Err(e) => panic!("Failed to add task: {}", e),
     };
     push_ready_task(cpu_id, task_id);
+    if is_cpu_online(cpu_id) && cpu_id != get_cpu().get_cpuid() {
+        crate::arch::send_reschedule_ipi(cpu_id);
+    }
     task_id
 }
 
@@ -781,6 +768,26 @@ pub fn start_scheduler() -> Option<usize> {
     next_task_id
 }
 
+pub fn first_switch_to_kernel_task(task_id: usize) -> ! {
+    let Some(task) = TaskPool::get_task(task_id) else {
+        panic!("Kernel task {} not found", task_id);
+    };
+
+    let mut boot_context = crate::arch::context::KernelContext::new();
+    let to_ctx_ptr = &*task.kernel_context.lock() as *const crate::arch::context::KernelContext;
+
+    // SAFETY: `task_id` is the current runnable task selected by `start_scheduler`,
+    // and `to_ctx_ptr` points to its initialized kernel context. `boot_context`
+    // is a temporary save area for the boot/AP context and remains valid here.
+    unsafe {
+        crate::arch::switch::switch_to(&mut boot_context as *mut _, to_ctx_ptr);
+    }
+
+    loop {
+        idle();
+    }
+}
+
 pub fn current_task(cpu_id: usize) -> Option<&'static Task> {
     current_task_id(cpu_id).and_then(TaskPool::get_task)
 }
@@ -788,6 +795,16 @@ pub fn current_task(cpu_id: usize) -> Option<&'static Task> {
 pub fn current_task_id(cpu_id: usize) -> Option<usize> {
     assert_valid_cpu_id(cpu_id);
     decode_task_id(CURRENT_TASK_IDS[cpu_id].load(Ordering::SeqCst))
+}
+
+pub fn current_task_is_idle(cpu_id: usize) -> bool {
+    let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+    idle_id != 0 && current_task_id(cpu_id) == Some(idle_id)
+}
+
+pub fn has_ready_tasks(cpu_id: usize) -> bool {
+    assert_valid_cpu_id(cpu_id);
+    !READY_QUEUES[cpu_id].lock().is_empty()
 }
 
 pub fn get_task_by_id(task_id: usize) -> Option<&'static Task> {
@@ -806,7 +823,12 @@ pub fn wake_task(task_id: usize) -> bool {
             if is_cpu_online(last) {
                 last
             } else {
-                find_least_loaded_cpu()
+                let current = get_cpu().get_cpuid();
+                if is_cpu_online(current) {
+                    current
+                } else {
+                    find_least_loaded_cpu()
+                }
             }
         }
     };
@@ -955,6 +977,8 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
             unsafe {
                 crate::arch::switch::switch_to(from_ctx_ptr, to_ctx_ptr);
             }
+
+            release_deferred_prev(cpu_id);
 
             #[cfg(feature = "hypervisor")]
             {

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -20,7 +20,7 @@
 //! - **Direct Indexing**: task_id == index for O(1) access without hash lookup
 //! - **ID Recycling**: Free list reuses task IDs to avoid exhaustion
 //!
-//! The pool provides `get_task()` and `get_task_mut()` which return `&'static`
+//! The pool provides `get_task()` which returns `&'static`
 //! references using raw pointers. This is **unsafe but practical** because:
 //!
 //! 1. Tasks are stored at fixed addresses (task_id == index)
@@ -33,7 +33,6 @@
 
 extern crate alloc;
 
-use core::panic;
 use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use alloc::{boxed::Box, collections::vec_deque::VecDeque, string::ToString};
@@ -43,7 +42,6 @@ use crate::arch::get_trapvector;
 use crate::arch::set_next_mode;
 use crate::print;
 use crate::println;
-use crate::task::TaskType;
 use crate::{arch::set_trapvector, vm::get_trampoline_trap_vector};
 use crate::{
     arch::{
@@ -80,7 +78,7 @@ pub fn get_task_pool() -> &'static TaskPool {
 ///
 /// # Safety
 ///
-/// This struct provides unsafe access to tasks through `get_task()` and `get_task_mut()`
+/// This struct provides unsafe access to tasks through `get_task()`
 /// which return `&'static` references without holding locks. This is safe because:
 ///
 /// 1. **Stable Box Memory**: Tasks are stored in `Box<[Option<Task>; MAX_TASKS]>`.
@@ -98,7 +96,6 @@ pub fn get_task_pool() -> &'static TaskPool {
 ///
 /// **IMPORTANT**: Do NOT directly access the `tasks` array. Always use:
 /// - `TaskPool::get_task()` for immutable references
-/// - `TaskPool::get_task_mut()` for mutable references
 /// - `get_task_by_id()` which is the preferred public API
 ///
 /// Direct array access could violate safety assumptions and cause undefined behavior.
@@ -113,8 +110,13 @@ pub struct TaskPool {
     // Box-ed fixed-length array allocated on heap
     // Pointer is stable for the lifetime of the program
     //
-    // ⚠️ DO NOT ACCESS DIRECTLY - Use get_task() or get_task_mut() methods
+    // ⚠️ DO NOT ACCESS DIRECTLY - Use get_task() methods
     tasks: spin::Mutex<Box<[Option<Task>; MAX_TASKS]>>,
+
+    // Monotonically increasing generation for each task slot.
+    // Incremented every time a slot receives a new task so recycled IDs can
+    // be distinguished from stale deferred references.
+    slot_generations: Box<[AtomicUsize; MAX_TASKS]>,
 
     // Free list of recyclable task IDs
     // IDs are added here when tasks are removed
@@ -127,8 +129,6 @@ pub struct TaskPool {
 
 impl TaskPool {
     fn new() -> Self {
-        crate::println!("[SCHED] TaskPool::new() starting...");
-
         // Allocate uninitialized Box array directly on heap
         // No stack usage, no Vec overhead
         let mut tasks: Box<[core::mem::MaybeUninit<Option<Task>>; MAX_TASKS]> =
@@ -143,10 +143,9 @@ impl TaskPool {
         // SAFETY: All elements have been initialized with None
         let tasks: Box<[Option<Task>; MAX_TASKS]> = unsafe { core::mem::transmute(tasks) };
 
-        crate::println!("[SCHED] TaskPool created (heap allocation, stable pointers)");
-
         TaskPool {
             tasks: spin::Mutex::new(tasks),
+            slot_generations: Box::new([const { AtomicUsize::new(0) }; MAX_TASKS]),
             free_ids: spin::Mutex::new(VecDeque::new()),
             next_id: core::sync::atomic::AtomicUsize::new(1), // Start from 1, ID 0 is invalid
         }
@@ -202,8 +201,40 @@ impl TaskPool {
         task.set_id(task_id);
         task.set_namespace_id(namespace_id);
 
+        let generation = self.slot_generations[task_id]
+            .fetch_add(1, Ordering::SeqCst)
+            .wrapping_add(1);
+        debug_assert_ne!(generation, 0, "task slot generation wrapped to 0");
+
         tasks[task_id] = Some(task);
         Ok(task_id)
+    }
+
+    fn task_generation(&self, task_id: usize) -> Option<usize> {
+        if task_id >= MAX_TASKS {
+            return None;
+        }
+
+        let tasks = self.tasks.lock();
+        tasks[task_id].as_ref()?;
+        Some(self.slot_generations[task_id].load(Ordering::SeqCst))
+    }
+
+    fn get_task_if_generation(&self, task_id: usize, generation: usize) -> Option<&'static Task> {
+        if task_id >= MAX_TASKS || generation == 0 {
+            return None;
+        }
+
+        let tasks = self.tasks.lock();
+        let task = tasks[task_id].as_ref()?;
+        if self.slot_generations[task_id].load(Ordering::SeqCst) != generation {
+            return None;
+        }
+
+        // SAFETY: The Box<[T]> ensures the array pointer is stable.
+        // Once a Box is allocated, its underlying pointer never changes.
+        let ptr = task as *const Task;
+        Some(unsafe { &*ptr })
     }
 
     /// Get a task reference by ID
@@ -223,7 +254,7 @@ impl TaskPool {
     /// - The pointer remains valid for the lifetime of the program
     ///
     /// **Important**: Do NOT directly access `TaskPool::tasks` array.
-    /// Always use this method or `get_task_mut()` to ensure proper safety.
+    /// Always use this method to ensure proper safety.
     pub fn get_task(task_id: usize) -> Option<&'static Task> {
         if task_id >= MAX_TASKS {
             return None;
@@ -242,56 +273,12 @@ impl TaskPool {
         })
     }
 
-    /// Get a mutable task reference by ID
-    /// Returns a static mutable reference using raw pointer for lifetime extension
-    ///
-    /// # Safety
-    ///
-    /// This function is safe to use under the following conditions:
-    /// - The task must not be removed while the returned reference is in use
-    /// - In context switching scenarios, the currently running task is never removed
-    /// - Single-core execution ensures no concurrent access during context switch
-    ///
-    /// The returned reference points to a fixed location in the TaskPool's
-    /// Box-ed array (task_id == index), so the address is **stable**:
-    /// - Box guarantees the underlying array never moves
-    /// - Unlike Vec or HashMap, no reallocation can occur
-    /// - The pointer remains valid for the lifetime of the program
-    ///
-    /// **Important**: Do NOT directly access `TaskPool::tasks` array.
-    /// Always use this method or `get_task()` to ensure proper safety.
-    ///
-    /// # Note
-    /// This is technically UB in Rust (returning &'static mut without holding lock),
-    /// but safe in practice because:
-    /// - Box<[T]> provides stable memory location (pointer never changes)
-    /// - The scheduler ensures exclusive access during context switches
-    /// - Single-core execution prevents concurrent mutable access
-    /// - Currently running task is never removed
-    pub fn get_task_mut(task_id: usize) -> Option<&'static mut Task> {
-        if task_id >= MAX_TASKS {
-            return None;
-        }
-
-        let pool = get_task_pool();
-        let mut tasks = pool.tasks.lock();
-
-        // SAFETY: The Box<[T]> ensures the array pointer is stable.
-        // Once a Box is allocated, its underlying pointer never changes.
-        // Combined with scheduler guarantees (no removal of running task),
-        // this provides a de-facto &'static mut reference.
-        tasks[task_id].as_mut().map(|task| {
-            let ptr = task as *mut Task;
-            unsafe { &mut *ptr }
-        })
-    }
-
     /// Remove a task from the pool
     ///
     /// # Safety
     ///
     /// **CRITICAL**: This method invalidates all `&'static` references returned by
-    /// `get_task()` and `get_task_mut()` for this task_id. The scheduler must ensure:
+    /// `get_task()` for this task_id. The scheduler must ensure:
     ///
     /// 1. The task being removed is NOT currently running on any CPU
     /// 2. No context switch is in progress for this task
@@ -305,14 +292,17 @@ impl TaskPool {
         if task_id >= MAX_TASKS {
             return None;
         }
-
         let mut tasks = self.tasks.lock();
-        let task = tasks[task_id].take()?;
-
-        // Add ID to free list for reuse
+        let task = tasks[task_id].as_ref()?;
+        if task.running_cpu.load(Ordering::SeqCst) != NO_CPU {
+            return None;
+        }
+        if !matches!(task.state.load(Ordering::SeqCst), TaskState::Terminated) {
+            return None;
+        }
+        let task = tasks[task_id].take().unwrap();
         let mut free_ids = self.free_ids.lock();
         free_ids.push_back(task_id);
-
         Some(task)
     }
 
@@ -344,6 +334,7 @@ impl TaskPool {
         let mut tasks = self.tasks.lock();
         for i in 0..MAX_TASKS {
             tasks[i] = None;
+            self.slot_generations[i].store(0, Ordering::SeqCst);
         }
         drop(tasks);
 
@@ -365,6 +356,69 @@ static ONLINE_CPUS: spin::Mutex<alloc::vec::Vec<usize>> = spin::Mutex::new(alloc
 static IDLE_TASK_IDS: [AtomicUsize; MAX_NUM_CPUS] = [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
 static DEBUG_TICK: AtomicU64 = AtomicU64::new(0);
 static NEXT_CPU: AtomicUsize = AtomicUsize::new(0);
+
+const NO_CPU: usize = usize::MAX;
+
+const TASK_ID_MASK: usize = MAX_TASKS - 1;
+
+static SCHEDULE_PREV_TASK: [AtomicUsize; MAX_NUM_CPUS] =
+    [const { AtomicUsize::new(0) }; MAX_NUM_CPUS];
+
+fn release_deferred_prev(cpu_id: usize) {
+    let prev = decode_prev_task(SCHEDULE_PREV_TASK[cpu_id].swap(0, Ordering::SeqCst));
+    let Some((prev_id, prev_generation)) = prev else {
+        return;
+    };
+    let Some(task) = get_task_pool().get_task_if_generation(prev_id, prev_generation) else {
+        return;
+    };
+    if task
+        .running_cpu
+        .compare_exchange(cpu_id, NO_CPU, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        // Now that ownership is released, enqueue the task so other CPUs
+        // (or this one) can claim it on the next pick_next round.
+        if matches!(task.state.load(Ordering::SeqCst), TaskState::Ready) {
+            let target = task.last_cpu.load(Ordering::SeqCst);
+            let target = if is_cpu_online(target) {
+                target
+            } else {
+                cpu_id
+            };
+            push_ready_task(target, prev_id);
+        }
+    }
+}
+
+fn try_claim_ready_task(task: &Task, cpu_id: usize) -> bool {
+    if task
+        .running_cpu
+        .compare_exchange(NO_CPU, cpu_id, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return false;
+    }
+    if task
+        .state
+        .compare_exchange(
+            TaskState::Ready,
+            TaskState::Running,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        )
+        .is_err()
+    {
+        task.running_cpu.store(NO_CPU, Ordering::SeqCst);
+        return false;
+    }
+    task.last_cpu.store(cpu_id, Ordering::SeqCst);
+    task.time_slice.store(
+        task.default_time_slice.load(Ordering::SeqCst),
+        Ordering::SeqCst,
+    );
+    true
+}
 
 pub fn register_online_cpu(cpu_id: usize) {
     let mut cpus = ONLINE_CPUS.lock();
@@ -430,6 +484,28 @@ fn decode_task_id(task_id: usize) -> Option<usize> {
 }
 
 #[inline]
+fn encode_prev_task(task_id: usize, generation: usize) -> usize {
+    debug_assert!(task_id <= TASK_ID_MASK);
+    debug_assert_ne!(generation, 0);
+    (generation << MAX_TASKS.ilog2()) | task_id
+}
+
+#[inline]
+fn decode_prev_task(encoded: usize) -> Option<(usize, usize)> {
+    if encoded == 0 {
+        return None;
+    }
+
+    let task_id = encoded & TASK_ID_MASK;
+    let generation = encoded >> MAX_TASKS.ilog2();
+    if task_id == 0 || generation == 0 {
+        return None;
+    }
+
+    Some((task_id, generation))
+}
+
+#[inline]
 fn ready_queue(cpu_id: usize) -> &'static spin::Mutex<VecDeque<usize>> {
     assert_valid_cpu_id(cpu_id);
     &READY_QUEUES[cpu_id]
@@ -447,16 +523,6 @@ pub fn push_ready_task(cpu_id: usize, task_id: usize) {
     if !queue.contains(&task_id) {
         queue.push_back(task_id);
     }
-}
-
-fn ready_queue_contains(task_id: usize) -> bool {
-    let mut found = false;
-    for_each_online_cpu(|cpu_id| {
-        if !found && ready_queue(cpu_id).lock().contains(&task_id) {
-            found = true;
-        }
-    });
-    found
 }
 
 pub fn mark_blocked(task_id: usize) {
@@ -489,29 +555,45 @@ pub fn finalize_zombie(task_id: usize, parent_id: Option<usize>) {
 fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
     let _irq_guard = IrqGuard::new();
     let cpu_id = cpu.get_cpuid();
-    let old_current_task_id = current_task_id(cpu_id);
+    release_deferred_prev(cpu_id);
 
-    if let Some(current_id) = old_current_task_id {
-        if let Some(task) = TaskPool::get_task_mut(current_id) {
-            match task.state.load(Ordering::SeqCst) {
-                TaskState::Ready | TaskState::Running => {
-                    task.state.store(TaskState::Ready, Ordering::SeqCst);
+    let old_id = current_task_id(cpu_id);
+    let old_task = old_id.and_then(TaskPool::get_task);
+
+    let mut next_id: Option<usize> = None;
+    'outer: loop {
+        let candidate = { ready_queue(cpu_id).lock().pop_front() };
+        match candidate {
+            Some(task_id) => {
+                let Some(task) = TaskPool::get_task(task_id) else {
+                    continue;
+                };
+                if task.pinned_cpu.is_some_and(|p| p != cpu_id) {
+                    push_ready_task(task.pinned_cpu.unwrap(), task_id);
+                    continue;
                 }
-                TaskState::Zombie => finalize_zombie(current_id, task.get_parent_id()),
-                TaskState::Terminated | TaskState::Blocked(_) | TaskState::NotInitialized => {}
+                match task.state.load(Ordering::SeqCst) {
+                    TaskState::NotInitialized => {
+                        panic!("Task must be initialized before scheduling")
+                    }
+                    TaskState::Zombie => {
+                        finalize_zombie(task.get_id(), task.get_parent_id());
+                        continue;
+                    }
+                    TaskState::Terminated => continue,
+                    TaskState::Blocked(_) => continue,
+                    TaskState::Ready | TaskState::Running => {
+                        if task.running_cpu.load(Ordering::SeqCst) != NO_CPU {
+                            continue;
+                        }
+                        if try_claim_ready_task(task, cpu_id) {
+                            next_id = Some(task_id);
+                            break 'outer;
+                        }
+                        continue;
+                    }
+                }
             }
-        }
-    }
-
-    let old_current_runnable = old_current_task_id.is_some_and(|id| {
-        TaskPool::get_task(id).is_some_and(|t| t.state.load(Ordering::SeqCst) == TaskState::Ready)
-    });
-
-    loop {
-        let task_id = { ready_queue(cpu_id).lock().pop_front() };
-
-        let task_id = match task_id {
-            Some(id) => id,
             None => {
                 let mut stolen = None;
                 for_each_online_cpu(|remote_cpu| {
@@ -520,82 +602,78 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                     }
                     let mut remote_q = ready_queue(remote_cpu).lock();
                     if let Some(remote_id) = remote_q.pop_front() {
-                        if let Some(task) = TaskPool::get_task(remote_id) {
-                            if task.pinned_cpu.is_some() {
-                                remote_q.push_back(remote_id);
-                                return;
-                            }
-                        }
                         stolen = Some(remote_id);
                     }
                 });
                 match stolen {
-                    Some(id) => id,
-                    None => {
-                        if old_current_runnable {
-                            if let Some(current_id) = old_current_task_id {
-                                if let Some(task) = TaskPool::get_task_mut(current_id) {
-                                    task.state.store(TaskState::Ready, Ordering::SeqCst);
-                                    task.time_slice.store(
-                                        task.default_time_slice.load(Ordering::SeqCst),
-                                        Ordering::SeqCst,
-                                    );
-                                }
-                                set_current_task_id(cpu_id, Some(current_id));
-                                return (old_current_task_id, Some(current_id));
-                            }
-                        }
-                        let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
-                        if idle_id != 0 {
-                            if let Some(task) = TaskPool::get_task_mut(idle_id) {
-                                task.state.store(TaskState::Running, Ordering::SeqCst);
-                                task.time_slice.store(
-                                    task.default_time_slice.load(Ordering::SeqCst),
-                                    Ordering::SeqCst,
-                                );
-                            }
-                            set_current_task_id(cpu_id, Some(idle_id));
-                            return (old_current_task_id, Some(idle_id));
-                        }
-                        set_current_task_id(cpu_id, None);
-                        return (old_current_task_id, None);
+                    Some(id) => {
+                        push_ready_task(cpu_id, id);
+                        continue;
                     }
+                    None => break 'outer,
                 }
-            }
-        };
-
-        let Some(task) = TaskPool::get_task_mut(task_id) else {
-            continue;
-        };
-
-        match task.state.load(Ordering::SeqCst) {
-            TaskState::NotInitialized => panic!("Task must be initialized before scheduling"),
-            TaskState::Zombie => {
-                finalize_zombie(task.get_id(), task.get_parent_id());
-                continue;
-            }
-            TaskState::Terminated => {
-                let _ = get_task_pool().remove_task(task_id);
-                continue;
-            }
-            TaskState::Blocked(_) => continue,
-            TaskState::Ready | TaskState::Running => {
-                task.state.store(TaskState::Running, Ordering::SeqCst);
-                task.time_slice.store(
-                    task.default_time_slice.load(Ordering::SeqCst),
-                    Ordering::SeqCst,
-                );
-                let next_task_id = task.get_id();
-                if let Some(old_id) = old_current_task_id {
-                    if old_current_runnable && old_id != next_task_id {
-                        push_ready_task(cpu_id, old_id);
-                    }
-                }
-                set_current_task_id(cpu_id, Some(next_task_id));
-                return (old_current_task_id, Some(next_task_id));
             }
         }
     }
+
+    if next_id.is_none() {
+        if let (Some(oid), Some(ot)) = (old_id, old_task) {
+            if ot.running_cpu.load(Ordering::SeqCst) == cpu_id
+                && matches!(
+                    ot.state.load(Ordering::SeqCst),
+                    TaskState::Running | TaskState::Ready
+                )
+            {
+                ot.state.store(TaskState::Running, Ordering::SeqCst);
+                ot.time_slice.store(
+                    ot.default_time_slice.load(Ordering::SeqCst),
+                    Ordering::SeqCst,
+                );
+                set_current_task_id(cpu_id, Some(oid));
+                return (old_id, Some(oid));
+            }
+        }
+    }
+
+    if next_id.is_none() {
+        let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+        if idle_id != 0 {
+            if let Some(task) = TaskPool::get_task(idle_id) {
+                if try_claim_ready_task(task, cpu_id) {
+                    next_id = Some(idle_id);
+                }
+            }
+        }
+    }
+
+    let Some(next_id) = next_id else {
+        set_current_task_id(cpu_id, None);
+        return (old_id, None);
+    };
+
+    if let (Some(oid), Some(ot), Some(nid)) = (old_id, old_task, Some(next_id)) {
+        if oid != nid {
+            match ot.state.load(Ordering::SeqCst) {
+                TaskState::Running | TaskState::Ready => {
+                    let _ = ot.state.compare_exchange(
+                        TaskState::Running,
+                        TaskState::Ready,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    );
+                }
+                TaskState::Zombie => finalize_zombie(oid, ot.get_parent_id()),
+                TaskState::Terminated | TaskState::Blocked(_) | TaskState::NotInitialized => {}
+            }
+            if let Some(generation) = get_task_pool().task_generation(oid) {
+                SCHEDULE_PREV_TASK[cpu_id]
+                    .store(encode_prev_task(oid, generation), Ordering::SeqCst);
+            }
+        }
+    }
+
+    set_current_task_id(cpu_id, Some(next_id));
+    (old_id, Some(next_id))
 }
 
 pub fn add_task(task: Task, cpu_id: usize) -> usize {
@@ -614,7 +692,7 @@ pub fn sched_on_tick(cpu_id: usize, trapframe: &mut Trapframe) {
     let _tick = DEBUG_TICK.fetch_add(1, Ordering::Relaxed);
 
     if let Some(task_id) = current_task_id(cpu_id) {
-        if let Some(task) = TaskPool::get_task_mut(task_id) {
+        if let Some(task) = TaskPool::get_task(task_id) {
             let current_slice = task.time_slice.load(Ordering::SeqCst);
             if current_slice > 0 {
                 task.time_slice.store(current_slice - 1, Ordering::SeqCst);
@@ -637,28 +715,26 @@ pub fn schedule(trapframe: &mut Trapframe) {
     if let Some(next_task_id) = next_task_id {
         if current_task_id != Some(next_task_id) {
             if let Some(current_task_id) = current_task_id {
-                let current_task = get_task_by_id(current_task_id).unwrap();
-                current_task.last_cpu.store(cpu_id, Ordering::SeqCst);
-                current_task.vcpu.lock().store(trapframe);
-
-                #[cfg(all(feature = "hypervisor", target_arch = "riscv64"))]
-                {
-                    use crate::arch::hv::switch::{HypervisorSwitchData, VcpuSwitchData};
+                if let Some(current_task) = TaskPool::get_task(current_task_id) {
+                    current_task.last_cpu.store(cpu_id, Ordering::SeqCst);
+                    current_task.vcpu.lock().store(trapframe);
 
                     kernel_context_switch(cpu_id, current_task_id, next_task_id);
-                }
-                #[cfg(not(all(feature = "hypervisor", target_arch = "riscv64")))]
-                {
-                    kernel_context_switch(cpu_id, current_task_id, next_task_id);
-                }
 
-                let current_task = get_task_by_id(current_task_id).unwrap();
-                current_task.vcpu.lock().switch(trapframe);
-                set_next_mode(current_task.vcpu.lock().get_mode());
+                    current_task.vcpu.lock().switch(trapframe);
+                    set_next_mode(current_task.vcpu.lock().get_mode());
+                } else {
+                    set_current_task_id(cpu_id, None);
+                    if let Some(next_task) = TaskPool::get_task(next_task_id) {
+                        setup_task_execution(get_cpu(), next_task);
+                        arch_switch_to_user(next_task.get_trapframe());
+                    }
+                }
             } else {
-                let next_task = get_task_by_id(next_task_id).unwrap();
-                setup_task_execution(get_cpu(), next_task);
-                arch_switch_to_user(next_task.get_trapframe());
+                if let Some(next_task) = TaskPool::get_task(next_task_id) {
+                    setup_task_execution(get_cpu(), next_task);
+                    arch_switch_to_user(next_task.get_trapframe());
+                }
             }
         }
     }
@@ -709,17 +785,13 @@ pub fn current_task(cpu_id: usize) -> Option<&'static Task> {
     current_task_id(cpu_id).and_then(TaskPool::get_task)
 }
 
-pub fn current_task_mut(cpu_id: usize) -> Option<&'static mut Task> {
-    current_task_id(cpu_id).and_then(TaskPool::get_task_mut)
-}
-
 pub fn current_task_id(cpu_id: usize) -> Option<usize> {
     assert_valid_cpu_id(cpu_id);
     decode_task_id(CURRENT_TASK_IDS[cpu_id].load(Ordering::SeqCst))
 }
 
-pub fn get_task_by_id(task_id: usize) -> Option<&'static mut Task> {
-    TaskPool::get_task_mut(task_id)
+pub fn get_task_by_id(task_id: usize) -> Option<&'static Task> {
+    TaskPool::get_task(task_id)
 }
 
 pub fn wake_task(task_id: usize) -> bool {
@@ -731,7 +803,7 @@ pub fn wake_task(task_id: usize) -> bool {
             pinned
         } else {
             let last = task.last_cpu.load(Ordering::SeqCst);
-            if last > 0 && is_cpu_online(last) {
+            if is_cpu_online(last) {
                 last
             } else {
                 find_least_loaded_cpu()
@@ -743,21 +815,29 @@ pub fn wake_task(task_id: usize) -> bool {
 
 pub fn wake_task_on(task_id: usize, target_cpu: usize) -> bool {
     let _irq_guard = IrqGuard::new();
-    let Some(task) = TaskPool::get_task_mut(task_id) else {
+    let Some(task) = TaskPool::get_task(task_id) else {
         return false;
     };
 
-    if !matches!(task.state.load(Ordering::SeqCst), TaskState::Blocked(_)) {
-        return false;
+    let mut state = task.state.load(Ordering::SeqCst);
+    loop {
+        match state {
+            TaskState::Blocked(_) => {}
+            _ => return false,
+        }
+        match task.state.compare_exchange(
+            state,
+            TaskState::Ready,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => break,
+            Err(actual) => state = actual,
+        }
     }
 
-    task.state.store(TaskState::Running, Ordering::SeqCst);
-    core::sync::atomic::fence(Ordering::SeqCst);
     unmark_blocked(task_id);
-
-    if !ready_queue_contains(task_id) {
-        push_ready_task(target_cpu, task_id);
-    }
+    push_ready_task(target_cpu, task_id);
 
     if target_cpu != get_cpu().get_cpuid() {
         crate::arch::send_reschedule_ipi(target_cpu);
@@ -771,13 +851,10 @@ pub fn cleanup_zombie(task_id: usize) {
         let mut zombie_queue = ZOMBIE_QUEUE.lock();
         if let Some(pos) = zombie_queue.iter().position(|&id| id == task_id) {
             zombie_queue.remove(pos);
-            crate::println!("[Scheduler] Removed task {} from zombie_queue", task_id);
         }
     }
 
-    if let Some(_task) = get_task_pool().remove_task(task_id) {
-        crate::println!("[Scheduler] Cleaned up zombie task {}", task_id);
-    }
+    let _ = get_task_pool().remove_task(task_id);
 }
 
 pub fn remove_from_ready_queues(task_id: usize) {
@@ -787,10 +864,6 @@ pub fn remove_from_ready_queues(task_id: usize) {
         let mut queue = ready_queue(cpu_id).lock();
         while let Some(pos) = queue.iter().position(|&id| id == task_id) {
             queue.remove(pos);
-        }
-
-        if current_task_id(cpu_id) == Some(task_id) {
-            set_current_task_id(cpu_id, None);
         }
     });
 }
@@ -851,7 +924,7 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
         let mut to_ctx_ptr: *const crate::arch::context::KernelContext = core::ptr::null();
 
         {
-            if let Some(from_task) = TaskPool::get_task_mut(from_task_id) {
+            if let Some(from_task) = TaskPool::get_task(from_task_id) {
                 from_ctx_ptr = &mut *from_task.kernel_context.lock();
 
                 #[cfg(feature = "user-fpu")]
@@ -864,7 +937,7 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
                     &mut *from_task.vcpu.lock(),
                 );
             }
-            if let Some(to_task) = TaskPool::get_task_mut(to_task_id) {
+            if let Some(to_task) = TaskPool::get_task(to_task_id) {
                 to_ctx_ptr = &*to_task.kernel_context.lock();
             }
         }
@@ -892,7 +965,7 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
             let cpu = get_cpu();
             saved_arch_cpu_state.restore(cpu);
             set_trapvector(saved_trapvector);
-            if let Some(from_task) = TaskPool::get_task_mut(from_task_id) {
+            if let Some(from_task) = TaskPool::get_task(from_task_id) {
                 #[cfg(feature = "user-fpu")]
                 crate::arch::fpu::kernel_switch_in_user_fpu(&mut *from_task.vcpu.lock());
             }
@@ -901,7 +974,7 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
 }
 
 /// Setup task execution by configuring hardware and user context.
-pub fn setup_task_execution(cpu: &mut Arch, task: &mut Task) {
+pub fn setup_task_execution(cpu: &mut Arch, task: &Task) {
     let sp = if let Some((_slot, base)) = task.get_kernel_stack_window_base() {
         (base + crate::environment::PAGE_SIZE + crate::environment::TASK_KERNEL_STACK_SIZE) as u64
     } else {
@@ -910,12 +983,9 @@ pub fn setup_task_execution(cpu: &mut Arch, task: &mut Task) {
 
     cpu.set_kernel_stack(sp);
 
-    let task_ptr = task as *mut Task;
     let task_mode = task.vcpu.lock().get_mode();
-    unsafe {
-        let trapframe = (*task_ptr).get_trapframe();
-        (*task_ptr).vcpu.lock().switch(trapframe);
-    }
+    let trapframe = task.get_trapframe();
+    task.vcpu.lock().switch(trapframe);
 
     cpu.set_trap_handler(get_user_trap_handler());
     cpu.set_next_address_space(task.vm_manager.get_asid());
@@ -929,6 +999,8 @@ pub fn reset() {
     for cpu_id in 0..MAX_NUM_CPUS {
         ready_queue(cpu_id).lock().clear();
         set_current_task_id(cpu_id, None);
+        SCHEDULE_PREV_TASK[cpu_id].store(0, Ordering::SeqCst);
+        IDLE_TASK_IDS[cpu_id].store(0, Ordering::SeqCst);
     }
     ZOMBIE_QUEUE.lock().clear();
     BLOCKED_QUEUE.lock().clear();
@@ -937,7 +1009,7 @@ pub fn reset() {
 
 pub fn make_test_tasks() {
     println!("Making test tasks...");
-    let mut task0 = new_kernel_task("Task0".to_string(), 0, || {
+    let task0 = new_kernel_task("Task0".to_string(), 0, || {
         println!("Task0");
         let mut counter: usize = 0;
         loop {
@@ -959,7 +1031,7 @@ pub fn make_test_tasks() {
     task0.init();
     add_task(task0, 0);
 
-    let mut task1 = new_kernel_task("Task1".to_string(), 0, || {
+    let task1 = new_kernel_task("Task1".to_string(), 0, || {
         println!("Task1");
         let mut counter: usize = 0;
         loop {
@@ -978,7 +1050,7 @@ pub fn make_test_tasks() {
     task1.init();
     add_task(task1, 0);
 
-    let mut task2 = new_kernel_task("Task2".to_string(), 0, || {
+    let task2 = new_kernel_task("Task2".to_string(), 0, || {
         println!("Task2");
         /* Fizz Buzz */
         for i in 1..=1000000 {

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -504,8 +504,7 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
     }
 
     let old_current_runnable = old_current_task_id.is_some_and(|id| {
-        TaskPool::get_task(id)
-            .is_some_and(|t| t.state.load(Ordering::SeqCst) == TaskState::Ready)
+        TaskPool::get_task(id).is_some_and(|t| t.state.load(Ordering::SeqCst) == TaskState::Ready)
     });
 
     loop {

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -362,6 +362,11 @@ static READY_QUEUES: [spin::Mutex<VecDeque<usize>>; MAX_NUM_CPUS] =
 static ZOMBIE_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::new());
 static BLOCKED_QUEUE: spin::Mutex<VecDeque<usize>> = spin::Mutex::new(VecDeque::new());
 static DEBUG_TICK: AtomicU64 = AtomicU64::new(0);
+static NEXT_CPU: AtomicUsize = AtomicUsize::new(0);
+
+pub fn select_cpu() -> usize {
+    NEXT_CPU.fetch_add(1, Ordering::Relaxed) % MAX_NUM_CPUS
+}
 
 #[inline]
 fn assert_valid_cpu_id(cpu_id: usize) {
@@ -456,9 +461,29 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
     loop {
         let task_id = { ready_queue(cpu_id).lock().pop_front() };
 
-        let Some(task_id) = task_id else {
-            set_current_task_id(cpu_id, None);
-            return (old_current_task_id, None);
+        let task_id = match task_id {
+            Some(id) => id,
+            None => {
+                // Work stealing: try to take a task from another CPU's queue
+                let mut stolen = None;
+                for remote_cpu in 0..MAX_NUM_CPUS {
+                    if remote_cpu == cpu_id {
+                        continue;
+                    }
+                    let mut remote_q = ready_queue(remote_cpu).lock();
+                    if let Some(remote_id) = remote_q.pop_front() {
+                        stolen = Some(remote_id);
+                        break;
+                    }
+                }
+                match stolen {
+                    Some(id) => id,
+                    None => {
+                        set_current_task_id(cpu_id, None);
+                        return (old_current_task_id, None);
+                    }
+                }
+            }
         };
 
         let Some(task) = TaskPool::get_task_mut(task_id) else {

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -391,7 +391,7 @@ fn set_current_task_id(cpu_id: usize, task_id: Option<usize>) {
 }
 
 #[inline]
-fn push_ready_task(cpu_id: usize, task_id: usize) {
+pub fn push_ready_task(cpu_id: usize, task_id: usize) {
     let mut queue = ready_queue(cpu_id).lock();
     if !queue.contains(&task_id) {
         queue.push_back(task_id);

--- a/kernel/src/sync/cpu_local.rs
+++ b/kernel/src/sync/cpu_local.rs
@@ -1,0 +1,127 @@
+//! Per-CPU data abstraction for SMP support.
+//!
+//! `CpuLocal<T>` provides per-CPU copies of data, indexed by CPU ID.
+//! Each CPU accesses only its own slot, avoiding cross-CPU data races.
+//!
+//! # Safety Model
+//!
+//! - `get()` returns `&T` — safe, multiple readers allowed
+//! - `lock()` returns `CpuLocalGuard<'_, T>` holding `&mut T` + `IrqGuard`
+//!   - The `IrqGuard` proves interrupts are disabled, preventing re-entrant access
+//!   - Within the same task, calling `lock()` twice while the first guard lives
+//!     is technically possible but documented as forbidden (kernel code convention)
+//!
+//! # Architecture
+//!
+//! Data is stored as `[UnsafeCell<T>; MAX_NUM_CPUS]`, indexed by `get_cpu().get_cpuid()`.
+//! CPU ID comes from architecture-specific registers (sscratch on RISC-V, TPIDR_EL1 on AArch64).
+
+use crate::arch::get_cpu;
+use crate::environment::MAX_NUM_CPUS;
+use crate::sync::IrqGuard;
+use core::cell::UnsafeCell;
+
+/// Per-CPU data storage. Each CPU has its own copy of `T`.
+///
+/// # Thread Safety
+///
+/// `CpuLocal<T>` is `Sync` because:
+/// - Each CPU only accesses its own slot (by `get_cpuid()` index)
+/// - `lock()` requires `IrqGuard` which prevents re-entrant access on the same CPU
+/// - Cross-CPU access to the same slot is prevented by design
+pub struct CpuLocal<T> {
+    data: [UnsafeCell<T>; MAX_NUM_CPUS],
+}
+
+// SAFETY: Each CPU accesses only its own slot via get_cpuid().
+// The IrqGuard requirement on lock() prevents re-entrant same-CPU access.
+unsafe impl<T> Sync for CpuLocal<T> {}
+
+/// Guard providing exclusive `&mut` access to per-CPU data.
+///
+/// Holds an `IrqGuard` ensuring interrupts remain disabled for the
+/// duration of the exclusive access.
+pub struct CpuLocalGuard<'a, T> {
+    data: &'a mut T,
+    _irq_guard: IrqGuard,
+}
+
+impl<'a, T> core::ops::Deref for CpuLocalGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.data
+    }
+}
+
+impl<'a, T> core::ops::DerefMut for CpuLocalGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.data
+    }
+}
+
+impl<T> CpuLocal<T> {
+    /// Create a new `CpuLocal` with the given initial value for all CPUs.
+    ///
+    /// This requires `T: Copy` to initialize all CPU slots uniformly.
+    pub fn new(value: T) -> Self
+    where
+        T: Copy,
+    {
+        // Initialize array with copies of the value
+        let mut data: [UnsafeCell<T>; MAX_NUM_CPUS] = unsafe {
+            // SAFETY: We're creating an uninitialized array, but we immediately
+            // initialize every element in the loop below.
+            core::mem::MaybeUninit::uninit().assume_init()
+        };
+        for i in 0..MAX_NUM_CPUS {
+            data[i] = UnsafeCell::new(value);
+        }
+        Self { data }
+    }
+
+    /// Get a shared reference to the current CPU's data.
+    ///
+    /// This is safe because `&T` allows multiple readers.
+    /// The caller must ensure no `lock()` guard is currently held
+    /// for this CPU (otherwise it would be UB).
+    ///
+    /// In practice, this is safe because the kernel currently runs
+    /// without interrupts internally.
+    pub fn get(&self) -> &T {
+        let cpu_id = get_cpu().get_cpuid();
+        // SAFETY: cpu_id is valid (0..MAX_NUM_CPUS), and we return &T
+        // which is safe for shared reads. The caller must not hold a
+        // mutable guard for this CPU.
+        unsafe { &*self.data[cpu_id].get() }
+    }
+
+    /// Get exclusive access to the current CPU's data with interrupt guard.
+    ///
+    /// Returns a `CpuLocalGuard` that:
+    /// - Holds `&mut T` for the current CPU
+    /// - Holds `IrqGuard` proving interrupts are disabled
+    ///
+    /// # Safety Invariant
+    ///
+    /// The caller MUST NOT hold another `CpuLocalGuard` for the same `CpuLocal`
+    /// on the same CPU. Doing so would create two `&mut T` to the same data.
+    /// This is enforced by kernel code convention, not runtime checks.
+    pub fn lock(&self) -> CpuLocalGuard<'_, T> {
+        let cpu_id = get_cpu().get_cpuid();
+        // SAFETY: cpu_id is valid (0..MAX_NUM_CPUS).
+        // The IrqGuard ensures interrupts are disabled, preventing
+        // re-entrant access from interrupt handlers on this CPU.
+        // The caller is responsible for not calling lock() twice
+        // while a guard is held (kernel code convention).
+        let data = unsafe { &mut *self.data[cpu_id].get() };
+        CpuLocalGuard {
+            data,
+            _irq_guard: IrqGuard::new(),
+        }
+    }
+
+    /// Get the raw index for a CPU ID. Useful for debug/assertions.
+    pub fn cpu_count() -> usize {
+        MAX_NUM_CPUS
+    }
+}

--- a/kernel/src/sync/cpu_local.rs
+++ b/kernel/src/sync/cpu_local.rs
@@ -67,15 +67,7 @@ impl<T> CpuLocal<T> {
     where
         T: Copy,
     {
-        // Initialize array with copies of the value
-        let mut data: [UnsafeCell<T>; MAX_NUM_CPUS] = unsafe {
-            // SAFETY: We're creating an uninitialized array, but we immediately
-            // initialize every element in the loop below.
-            core::mem::MaybeUninit::uninit().assume_init()
-        };
-        for i in 0..MAX_NUM_CPUS {
-            data[i] = UnsafeCell::new(value);
-        }
+        let data = core::array::from_fn(|_| UnsafeCell::new(value));
         Self { data }
     }
 

--- a/kernel/src/sync/irq_guard.rs
+++ b/kernel/src/sync/irq_guard.rs
@@ -1,50 +1,19 @@
 //! Interrupt guard for SMP-safe per-CPU data access.
-//!
-//! `IrqGuard` serves as a proof that local interrupts are disabled.
-//! Currently a **stub** — the kernel does not handle interrupts internally yet,
-//! so this is a no-op. When interrupt support is added, this will actually
-//! disable/restore local interrupts using architecture-specific instructions.
-//!
-//! # Usage
-//!
-//! Wrap per-CPU data mutations in `IrqGuard` to ensure no interrupt
-//! (and thus no re-entrant schedule) can occur while the data is being modified:
-//!
-//! ```ignore
-//! let guard = IrqGuard::new();
-//! let local_data = cpu_local.lock(&guard);
-//! // ... mutate data ...
-//! // guard dropped here, interrupts would be restored
-//! ```
 
-/// A guard that represents a period where local interrupts are disabled.
-///
-/// Currently a no-op stub. When SMP interrupt support is implemented,
-/// `new()` will disable local interrupts and `drop()` will restore them.
-///
-/// This type is !Send — it must not be moved across CPUs.
 pub struct IrqGuard {
-    /// Whether interrupts were enabled before we disabled them.
-    /// Used to restore the previous state on drop.
-    _was_enabled: bool,
-    // Mark as !Send and !Sync
+    was_enabled: bool,
     _not_send: core::marker::PhantomData<*mut ()>,
 }
 
 impl IrqGuard {
-    /// Create a new IrqGuard, disabling local interrupts.
-    ///
-    /// # Safety (stub)
-    /// Currently a no-op. When implemented, this will:
-    /// - Read the current interrupt enable state
-    /// - Disable local interrupts
-    /// - Store the previous state for restoration on drop
     #[inline]
     pub fn new() -> Self {
-        // TODO: Actually disable interrupts when SMP is ready
-        // For now, this is a no-op stub
+        let was_enabled = crate::arch::interrupt::are_interrupts_enabled();
+        if was_enabled {
+            crate::arch::interrupt::disable_interrupts();
+        }
         Self {
-            _was_enabled: false,
+            was_enabled,
             _not_send: core::marker::PhantomData,
         }
     }
@@ -52,9 +21,8 @@ impl IrqGuard {
 
 impl Drop for IrqGuard {
     fn drop(&mut self) {
-        // TODO: Restore interrupt state when SMP is ready
-        // if self._was_enabled {
-        //     enable_local_irq();
-        // }
+        if self.was_enabled {
+            crate::arch::interrupt::enable_interrupts();
+        }
     }
 }

--- a/kernel/src/sync/irq_guard.rs
+++ b/kernel/src/sync/irq_guard.rs
@@ -1,0 +1,60 @@
+//! Interrupt guard for SMP-safe per-CPU data access.
+//!
+//! `IrqGuard` serves as a proof that local interrupts are disabled.
+//! Currently a **stub** — the kernel does not handle interrupts internally yet,
+//! so this is a no-op. When interrupt support is added, this will actually
+//! disable/restore local interrupts using architecture-specific instructions.
+//!
+//! # Usage
+//!
+//! Wrap per-CPU data mutations in `IrqGuard` to ensure no interrupt
+//! (and thus no re-entrant schedule) can occur while the data is being modified:
+//!
+//! ```ignore
+//! let guard = IrqGuard::new();
+//! let local_data = cpu_local.lock(&guard);
+//! // ... mutate data ...
+//! // guard dropped here, interrupts would be restored
+//! ```
+
+/// A guard that represents a period where local interrupts are disabled.
+///
+/// Currently a no-op stub. When SMP interrupt support is implemented,
+/// `new()` will disable local interrupts and `drop()` will restore them.
+///
+/// This type is !Send — it must not be moved across CPUs.
+pub struct IrqGuard {
+    /// Whether interrupts were enabled before we disabled them.
+    /// Used to restore the previous state on drop.
+    _was_enabled: bool,
+    // Mark as !Send and !Sync
+    _not_send: core::marker::PhantomData<*mut ()>,
+}
+
+impl IrqGuard {
+    /// Create a new IrqGuard, disabling local interrupts.
+    ///
+    /// # Safety (stub)
+    /// Currently a no-op. When implemented, this will:
+    /// - Read the current interrupt enable state
+    /// - Disable local interrupts
+    /// - Store the previous state for restoration on drop
+    #[inline]
+    pub fn new() -> Self {
+        // TODO: Actually disable interrupts when SMP is ready
+        // For now, this is a no-op stub
+        Self {
+            _was_enabled: false,
+            _not_send: core::marker::PhantomData,
+        }
+    }
+}
+
+impl Drop for IrqGuard {
+    fn drop(&mut self) {
+        // TODO: Restore interrupt state when SMP is ready
+        // if self._was_enabled {
+        //     enable_local_irq();
+        // }
+    }
+}

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -4,8 +4,12 @@
 //! External modules should use these re-exports instead of depending on `spin` directly,
 //! so that the kernel can control the underlying lock implementation.
 
+pub mod cpu_local;
+pub mod irq_guard;
 pub mod waker;
 
+pub use cpu_local::CpuLocal;
+pub use irq_guard::IrqGuard;
 pub use waker::Waker;
 
 pub use spin::{Mutex, MutexGuard, Once, RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/kernel/src/sync/waker.rs
+++ b/kernel/src/sync/waker.rs
@@ -7,10 +7,11 @@
 extern crate alloc;
 
 use crate::arch::Trapframe;
-use crate::sched::scheduler::{get_task_by_id, schedule, wake_task};
+use crate::sched::scheduler::{get_task_by_id, schedule, unmark_blocked, wake_task};
 use crate::task::{BlockedType, TaskState};
 use alloc::collections::VecDeque;
 use core::fmt;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::Mutex;
 
 /// A synchronization primitive that manages waiting and waking of tasks
@@ -38,6 +39,10 @@ pub struct Waker {
     block_type: BlockedType,
     /// Human-readable name for debugging purposes
     name: &'static str,
+    /// Pending wake count: incremented by wake_one()/wake_all() when the queue
+    /// is empty (i.e. the wake arrived before the waiter enqueued itself).
+    /// Consumed by wait() so the task does not sleep on an already-fired wake.
+    pending_wakes: AtomicUsize,
 }
 
 impl Waker {
@@ -61,6 +66,7 @@ impl Waker {
             wait_queue: Mutex::new(VecDeque::new()),
             block_type: BlockedType::Interruptible,
             name,
+            pending_wakes: AtomicUsize::new(0),
         }
     }
 
@@ -84,6 +90,7 @@ impl Waker {
             wait_queue: Mutex::new(VecDeque::new()),
             block_type: BlockedType::Uninterruptible,
             name,
+            pending_wakes: AtomicUsize::new(0),
         }
     }
 
@@ -113,9 +120,20 @@ impl Waker {
     /// 1. Set task state to Blocked BEFORE adding to queue
     /// 2. This ensures wake_task() can safely operate even if called immediately
     pub fn wait(&self, task_id: usize, trapframe: &mut Trapframe) {
-        // CRITICAL: Set task state to Blocked FIRST, before adding to queue
-        // This prevents race condition where wake_one() is called after queue.push_back()
-        // but before set_state(), which would leave the task in Running state but not in queue
+        // Consume a pending wake that arrived before we enqueued ourselves.
+        // This closes the lost-wake window on SMP: if wake_one()/wake_all()
+        // fired while the queue was empty (between the caller's condition check
+        // and this wait() call), we return immediately instead of sleeping.
+        if self
+            .pending_wakes
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                if n > 0 { Some(n - 1) } else { None }
+            })
+            .is_ok()
+        {
+            return;
+        }
+
         if let Some(task) = get_task_by_id(task_id) {
             task.set_state(TaskState::Blocked(self.block_type));
         } else {
@@ -124,20 +142,36 @@ impl Waker {
 
         crate::sched::scheduler::mark_blocked(task_id);
 
-        // Memory barrier to ensure state change is visible before queue operation
-        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
-
-        // Now add task to wait queue - at this point task is already Blocked
-        // Even if wake_one() is called immediately, wake_task() will work correctly
-        {
+        // Enqueue and re-check pending_wakes under the same lock acquisition.
+        // This closes the SMP lost-wake window: wake_one()/wake_all() that fires
+        // after the initial pending_wakes check but before queue insertion will
+        // increment pending_wakes on an empty queue.  Re-checking here catches
+        // that case so the waiter never sleeps on an already-fired wake.
+        let late_wake = {
             let mut queue = self.wait_queue.lock();
             queue.push_back(task_id);
+
+            self.pending_wakes
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                    if n > 0 { Some(n - 1) } else { None }
+                })
+                .is_ok()
+        };
+
+        if late_wake {
+            {
+                let mut queue = self.wait_queue.lock();
+                if let Some(pos) = queue.iter().position(|&id| id == task_id) {
+                    queue.remove(pos);
+                }
+            }
+            unmark_blocked(task_id);
+            if let Some(task) = get_task_by_id(task_id) {
+                task.set_state(TaskState::Running);
+            }
+            return;
         }
 
-        // Memory barrier to ensure queue addition is visible before yielding
-        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
-
-        // Yield CPU to scheduler - returns when woken
         schedule(trapframe);
     }
 
@@ -301,9 +335,9 @@ impl Waker {
         };
 
         if let Some(task_id) = task_id {
-            // Use the scheduler's wake_task method to move from blocked to ready queue
             wake_task(task_id)
         } else {
+            self.pending_wakes.fetch_add(1, Ordering::SeqCst);
             false
         }
     }
@@ -331,9 +365,13 @@ impl Waker {
             ids
         };
 
+        if task_ids.is_empty() {
+            self.pending_wakes.fetch_add(1, Ordering::SeqCst);
+            return 0;
+        }
+
         let mut woken_count = 0;
         for task_id in task_ids {
-            // Use the scheduler's wake_task method to move from blocked to ready queue
             if wake_task(task_id) {
                 woken_count += 1;
             }
@@ -479,6 +517,7 @@ impl fmt::Debug for Waker {
             .field("block_type", &self.block_type)
             .field("waiting_count", &waiting_tasks.len())
             .field("waiting_task_ids", &*waiting_tasks)
+            .field("pending_wakes", &self.pending_wakes.load(Ordering::Relaxed))
             .finish()
     }
 }

--- a/kernel/src/sync/waker.rs
+++ b/kernel/src/sync/waker.rs
@@ -122,6 +122,8 @@ impl Waker {
             panic!("[WAKER] Task ID {} not found in scheduler", task_id);
         }
 
+        crate::sched::scheduler::mark_blocked(task_id);
+
         // Memory barrier to ensure state change is visible before queue operation
         core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
 

--- a/kernel/src/sync/waker.rs
+++ b/kernel/src/sync/waker.rs
@@ -7,7 +7,7 @@
 extern crate alloc;
 
 use crate::arch::Trapframe;
-use crate::sched::scheduler::get_scheduler;
+use crate::sched::scheduler::{get_task_by_id, schedule, wake_task};
 use crate::task::{BlockedType, TaskState};
 use alloc::collections::VecDeque;
 use core::fmt;
@@ -116,7 +116,7 @@ impl Waker {
         // CRITICAL: Set task state to Blocked FIRST, before adding to queue
         // This prevents race condition where wake_one() is called after queue.push_back()
         // but before set_state(), which would leave the task in Running state but not in queue
-        if let Some(task) = get_scheduler().get_task_by_id(task_id) {
+        if let Some(task) = get_task_by_id(task_id) {
             task.set_state(TaskState::Blocked(self.block_type));
         } else {
             panic!("[WAKER] Task ID {} not found in scheduler", task_id);
@@ -136,7 +136,7 @@ impl Waker {
         core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
 
         // Yield CPU to scheduler - returns when woken
-        get_scheduler().schedule(trapframe);
+        schedule(trapframe);
     }
 
     /// Block the task until woken or the timeout elapses.
@@ -165,8 +165,7 @@ impl Waker {
             impl TimerHandler for TimeoutWake {
                 fn on_timer_expired(self: Arc<Self>, _context: usize) {
                     self.timed_out.store(true, Ordering::SeqCst);
-                    let scheduler = get_scheduler();
-                    let _ = scheduler.wake_task(self.task_id);
+                    let _ = wake_task(self.task_id);
                 }
             }
 
@@ -212,8 +211,7 @@ impl Waker {
         impl TimerHandler for MinTimeoutWake {
             fn on_timer_expired(self: Arc<Self>, _context: usize) {
                 self.fired.store(true, Ordering::SeqCst);
-                let scheduler = get_scheduler();
-                let _ = scheduler.wake_task(self.task_id);
+                let _ = wake_task(self.task_id);
             }
         }
 
@@ -302,7 +300,7 @@ impl Waker {
 
         if let Some(task_id) = task_id {
             // Use the scheduler's wake_task method to move from blocked to ready queue
-            get_scheduler().wake_task(task_id)
+            wake_task(task_id)
         } else {
             false
         }
@@ -334,7 +332,7 @@ impl Waker {
         let mut woken_count = 0;
         for task_id in task_ids {
             // Use the scheduler's wake_task method to move from blocked to ready queue
-            if get_scheduler().wake_task(task_id) {
+            if wake_task(task_id) {
                 woken_count += 1;
             }
         }

--- a/kernel/src/sync/waker.rs
+++ b/kernel/src/sync/waker.rs
@@ -335,7 +335,17 @@ impl Waker {
         };
 
         if let Some(task_id) = task_id {
-            wake_task(task_id)
+            let woke = wake_task(task_id);
+            if crate::sched::scheduler::DEBUG_SMP_TASK_FLOW {
+                crate::println!(
+                    "[SMPDBG waker-wake-one] waker={} cpu={} task={} woke={}",
+                    self.name,
+                    crate::arch::get_cpu().get_cpuid(),
+                    task_id,
+                    woke,
+                );
+            }
+            woke
         } else {
             self.pending_wakes.fetch_add(1, Ordering::SeqCst);
             false
@@ -372,8 +382,18 @@ impl Waker {
 
         let mut woken_count = 0;
         for task_id in task_ids {
-            if wake_task(task_id) {
+            let woke = wake_task(task_id);
+            if woke {
                 woken_count += 1;
+            }
+            if crate::sched::scheduler::DEBUG_SMP_TASK_FLOW {
+                crate::println!(
+                    "[SMPDBG waker-wake-all] waker={} cpu={} task={} woke={}",
+                    self.name,
+                    crate::arch::get_cpu().get_cpuid(),
+                    task_id,
+                    woke,
+                );
             }
         }
 

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -108,9 +108,9 @@ use crate::object::handle::syscall::{
 };
 use crate::task::syscall::{
     sys_brk, sys_clone, sys_create_namespace, sys_execve, sys_execve_abi, sys_exit, sys_exit_group,
-    sys_get_tls, sys_getchar, sys_getpid, sys_getppid, sys_putchar, sys_register_abi_zone,
-    sys_sbrk, sys_set_tid_address, sys_set_tls, sys_shutdown, sys_sleep, sys_unregister_abi_zone,
-    sys_waitpid, sys_yield,
+    sys_get_task_info_count, sys_get_task_info_list, sys_get_tls, sys_getchar, sys_getpid,
+    sys_getppid, sys_putchar, sys_register_abi_zone, sys_sbrk, sys_set_tid_address, sys_set_tls,
+    sys_shutdown, sys_sleep, sys_unregister_abi_zone, sys_waitpid, sys_yield,
 };
 
 #[macro_use]
@@ -184,6 +184,9 @@ syscall_table! {
     Yield = 21 => sys_yield,
 
     ExitGroup = 23 => sys_exit_group, // Exit all tasks in thread group
+    // Process information
+    GetTaskInfoCount = 24 => sys_get_task_info_count, // Number of tasks
+    GetTaskInfoList = 25 => sys_get_task_info_list,   // TaskInfo snapshots
     // TLS (Thread Local Storage) Management
     SetTls = 30 => sys_set_tls,
     GetTls = 31 => sys_get_tls,

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -437,6 +437,8 @@ pub struct Task {
     pub sleep_waker: Waker,
     /// Kernel stack window base (slot_index, base_vaddr)
     pub kernel_stack_window_base: Mutex<Option<(usize, usize)>>,
+    pub pinned_cpu: Option<usize>,
+    pub last_cpu: atomic::AtomicUsize,
 
     // === Already protected fields ===
     /// Task-local event queue with priority ordering
@@ -568,6 +570,8 @@ impl Task {
             handle_table: HandleTable::new(),
             sleep_waker: Waker::new_interruptible("task_sleep_waker"),
             kernel_stack_window_base: Mutex::new(None),
+            pinned_cpu: None,
+            last_cpu: atomic::AtomicUsize::new(0),
             // Already protected
             event_queue: Mutex::new(crate::ipc::event::TaskEventQueue::new()),
             events_enabled: Mutex::new(true),

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -33,9 +33,8 @@ use crate::{
     mem::page::ContiguousPages,
     object::handle::HandleTable,
     sched::scheduler::{
-        current_task, current_task_mut, finalize_zombie, get_all_task_ids, get_task_by_id,
-        remove_from_ready_queues, remove_task_from_queues, schedule, setup_task_execution,
-        unmark_blocked,
+        current_task, finalize_zombie, get_all_task_ids, get_task_by_id, remove_from_ready_queues,
+        schedule, setup_task_execution, unmark_blocked,
     },
     timer::{TimerHandler, add_timer, get_tick},
     vm::{
@@ -47,7 +46,7 @@ use crate::{
 };
 use alloc::collections::BTreeMap;
 use core::ops::Range;
-use core::sync::atomic::{AtomicI32, AtomicU8, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicI32, AtomicU8, AtomicU32, AtomicUsize, Ordering};
 use spin::Once;
 
 /// Global registry of task-specific wakers for waitpid
@@ -334,7 +333,7 @@ impl<T> TaskLocal<T> {
     #[inline]
     pub unsafe fn get(&self) -> &T {
         // SAFETY: Upheld by caller (single-hart-per-task invariant).
-        &*self.inner.get()
+        unsafe { &*self.inner.get() }
     }
 
     /// Get a mutable reference to the contained value.
@@ -347,7 +346,7 @@ impl<T> TaskLocal<T> {
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn get_mut(&self) -> &mut T {
         // SAFETY: Upheld by caller (single-hart-per-task invariant).
-        &mut *self.inner.get()
+        unsafe { &mut *self.inner.get() }
     }
 }
 
@@ -360,7 +359,7 @@ pub struct Task {
     namespace: RwLock<Arc<namespace::TaskNamespace>>,
     pub task_type: TaskType,
     pub entry: usize,
-    parent_id: Option<usize>,
+    parent_id: AtomicUsize,
     /// Thread Group ID (TGID) - identifies tasks in the same thread group
     thread_group_id: usize,
     /// Task Group ID - for job control and signal delivery (e.g., pipeline members)
@@ -439,6 +438,10 @@ pub struct Task {
     pub kernel_stack_window_base: Mutex<Option<(usize, usize)>>,
     pub pinned_cpu: Option<usize>,
     pub last_cpu: atomic::AtomicUsize,
+    /// CPU that currently "owns" this task (has saved its context or is
+    /// actively running it). `usize::MAX` means unowned / available.
+    /// Used as a CAS claim token to prevent double-scheduling on SMP.
+    pub running_cpu: atomic::AtomicUsize,
 
     // === Already protected fields ===
     /// Task-local event queue with priority ordering
@@ -535,7 +538,7 @@ impl Task {
             namespace: RwLock::new(ns),
             task_type,
             entry: 0,
-            parent_id: None,
+            parent_id: AtomicUsize::new(0),
             thread_group_id: 0,
             task_group_id: AtomicUsize::new(0),
             max_stack_size: DEAFAULT_MAX_TASK_STACK_SIZE,
@@ -572,6 +575,7 @@ impl Task {
             kernel_stack_window_base: Mutex::new(None),
             pinned_cpu: None,
             last_cpu: atomic::AtomicUsize::new(0),
+            running_cpu: atomic::AtomicUsize::new(usize::MAX),
             // Already protected
             event_queue: Mutex::new(crate::ipc::event::TaskEventQueue::new()),
             events_enabled: Mutex::new(true),
@@ -1080,15 +1084,18 @@ impl Task {
     /// # Returns
     /// The parent task ID, or None if there is no parent
     pub fn get_parent_id(&self) -> Option<usize> {
-        self.parent_id
+        match self.parent_id.load(Ordering::SeqCst) {
+            0 => None,
+            id => Some(id),
+        }
     }
 
     /// Set the parent task
     ///
     /// # Arguments
     /// * `parent_id` - The ID of the parent task
-    pub fn set_parent_id(&mut self, parent_id: usize) {
-        self.parent_id = Some(parent_id);
+    pub fn set_parent_id(&self, parent_id: usize) {
+        self.parent_id.store(parent_id, Ordering::SeqCst);
     }
 
     /// Add a child task
@@ -1492,10 +1499,8 @@ impl Task {
         if child.get_kernel_stack_window_base().is_none() {
             crate::vm::setup_trampoline_for_task_kstack_window(&mut child)?;
         }
-        // Set the state to Ready
-        child
-            .state
-            .store(self.state.load(Ordering::SeqCst), Ordering::SeqCst);
+        // Cloned task starts as Ready regardless of parent's current state
+        child.state.store(TaskState::Ready, Ordering::SeqCst);
 
         // NOTE: Parent-child relationship will be established AFTER add_task()
         // when the child has a valid ID. The caller is responsible for calling:
@@ -1531,7 +1536,7 @@ impl Task {
         // Use take/restore to avoid aliasing &mut self and &mut field
         self.with_default_abi_mut(|abi, task| abi.on_task_exit(task));
 
-        match self.parent_id {
+        match self.get_parent_id() {
             Some(parent_id) => {
                 if get_task_by_id(parent_id).is_none() {
                     // crate::println!("Task {}: Parent {} not found, terminating", self.id, parent_id);
@@ -1559,7 +1564,7 @@ impl Task {
             // (current task path goes through schedule() -> pick_next -> finalize_zombie)
             if matches!(self.state.load(Ordering::SeqCst), TaskState::Zombie) {
                 unmark_blocked(self.id);
-                finalize_zombie(self.id, self.parent_id);
+                finalize_zombie(self.id, self.get_parent_id());
             }
             return;
         }
@@ -2029,9 +2034,14 @@ pub fn set_current_task_cwd(path: String) -> bool {
 /// This function is called when a task is first scheduled.
 pub fn task_initial_kernel_entrypoint() -> ! {
     let cpu = get_cpu();
-    let current_task = current_task_mut(cpu.get_cpuid()).unwrap();
-    setup_task_execution(cpu, current_task);
-    arch_switch_to_user(current_task.get_trapframe());
+    if let Some(current_task) = current_task(cpu.get_cpuid()) {
+        setup_task_execution(cpu, current_task);
+        arch_switch_to_user(current_task.get_trapframe());
+    }
+
+    loop {
+        crate::arch::instruction::idle();
+    }
 }
 
 #[cfg(test)]
@@ -2040,7 +2050,7 @@ mod tests {
     use alloc::sync::Arc;
     use core::sync::atomic::Ordering;
 
-    use crate::sched::scheduler::{add_task, get_task_by_id, remove_task_from_queues, reset};
+    use crate::sched::scheduler::{add_task, get_task_by_id, reset};
     use crate::task::CloneFlags;
     use crate::vm::addr::{phys_to_virt, virt_to_phys};
 
@@ -2584,8 +2594,6 @@ mod tests {
         // Reset scheduler state before test
         reset();
 
-        use super::namespace;
-
         // Create task in root namespace
         let task = super::new_user_task("TestTask".to_string(), 0);
         assert_eq!(task.get_namespace().get_name(), "root");
@@ -2603,8 +2611,6 @@ mod tests {
     fn test_task_namespace_inheritance() {
         // Reset scheduler state before test
         reset();
-
-        use super::namespace;
 
         let mut parent = super::new_user_task("Parent".to_string(), 0);
         parent.init();
@@ -2712,9 +2718,6 @@ mod tests {
     fn test_all_abis_share_root_namespace_by_default() {
         // Reset scheduler state before test
         reset();
-
-        use super::namespace;
-        use alloc::vec::Vec;
 
         // Create tasks using default Task::new (which uses root namespace)
         let mut task1 = super::new_user_task("Task1".to_string(), 0);

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -2034,7 +2034,20 @@ pub fn set_current_task_cwd(path: String) -> bool {
 /// This function is called when a task is first scheduled.
 pub fn task_initial_kernel_entrypoint() -> ! {
     let cpu = get_cpu();
+    crate::sched::scheduler::complete_deferred_context_switch(cpu.get_cpuid());
     if let Some(current_task) = current_task(cpu.get_cpuid()) {
+        if current_task.task_type == TaskType::Kernel {
+            let entry = current_task.vcpu.lock().get_pc();
+            // SAFETY: `new_kernel_task` stores a valid `fn()` entry pointer in
+            // the kernel-mode VCPU PC before the task is made runnable.
+            let entry: fn() = unsafe { core::mem::transmute(entry as usize) };
+            entry();
+            current_task.exit(0);
+            loop {
+                crate::arch::instruction::idle();
+            }
+        }
+
         setup_task_execution(cpu, current_task);
         arch_switch_to_user(current_task.get_trapframe());
     }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -33,8 +33,9 @@ use crate::{
     mem::page::ContiguousPages,
     object::handle::HandleTable,
     sched::scheduler::{
-        current_task, current_task_mut, get_all_task_ids, get_task_by_id, schedule,
-        setup_task_execution,
+        current_task, current_task_mut, finalize_zombie, get_all_task_ids, get_task_by_id,
+        remove_from_ready_queues, remove_task_from_queues, schedule, setup_task_execution,
+        unmark_blocked,
     },
     timer::{TimerHandler, add_timer, get_tick},
     vm::{
@@ -1550,7 +1551,12 @@ impl Task {
         // Task cleanup completed - ABI module handles event cleanup
 
         if mytask().is_none() || mytask().unwrap().get_id() != self.id {
-            // Not the current task, nothing more to do
+            // Non-current task: finalize zombie state manually
+            // (current task path goes through schedule() -> pick_next -> finalize_zombie)
+            if matches!(self.state.load(Ordering::SeqCst), TaskState::Zombie) {
+                unmark_blocked(self.id);
+                finalize_zombie(self.id, self.parent_id);
+            }
             return;
         }
 
@@ -1606,6 +1612,8 @@ impl Task {
                         // Close handles to prevent resource leaks
                         (*task_ptr).handle_table.close_all();
                     }
+                    remove_from_ready_queues(task_id);
+                    unmark_blocked(task_id);
                 }
             }
         }
@@ -2028,7 +2036,7 @@ mod tests {
     use alloc::sync::Arc;
     use core::sync::atomic::Ordering;
 
-    use crate::sched::scheduler::{add_task, get_task_by_id, reset};
+    use crate::sched::scheduler::{add_task, get_task_by_id, remove_task_from_queues, reset};
     use crate::task::CloneFlags;
     use crate::vm::addr::{phys_to_virt, virt_to_phys};
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -32,7 +32,10 @@ use crate::{
     ipc::{EventContent, event::ProcessControlType},
     mem::page::ContiguousPages,
     object::handle::HandleTable,
-    sched::scheduler::{Scheduler, get_scheduler},
+    sched::scheduler::{
+        current_task, current_task_mut, get_all_task_ids, get_task_by_id, schedule,
+        setup_task_execution,
+    },
     timer::{TimerHandler, add_timer, get_tick},
     vm::{
         addr::{phys_to_virt, virt_to_phys},
@@ -1525,7 +1528,7 @@ impl Task {
 
         match self.parent_id {
             Some(parent_id) => {
-                if get_scheduler().get_task_by_id(parent_id).is_none() {
+                if get_task_by_id(parent_id).is_none() {
                     // crate::println!("Task {}: Parent {} not found, terminating", self.id, parent_id);
                     self.state.store(TaskState::Terminated, Ordering::SeqCst);
                     return;
@@ -1553,7 +1556,7 @@ impl Task {
 
         // The scheduler will handle saving the current task state internally
         if let Some(current_task) = mytask() {
-            get_scheduler().schedule(current_task.get_trapframe());
+            schedule(current_task.get_trapframe());
         }
     }
 
@@ -1574,8 +1577,7 @@ impl Task {
         let my_id = self.id;
 
         // Get all task IDs in the system
-        let scheduler = get_scheduler();
-        let all_task_ids = scheduler.get_all_task_ids();
+        let all_task_ids = get_all_task_ids();
 
         // Terminate all tasks with the same thread group ID (except self)
         for task_id in all_task_ids {
@@ -1583,7 +1585,7 @@ impl Task {
                 continue; // Skip self
             }
 
-            if let Some(task) = scheduler.get_task_by_id(task_id) {
+            if let Some(task) = get_task_by_id(task_id) {
                 if task.get_thread_group_id() == thread_group_id {
                     // Terminate this thread group member
                     crate::println!(
@@ -1625,7 +1627,7 @@ impl Task {
             return Err(WaitError::NoSuchChild("No such child task".to_string()));
         }
 
-        if let Some(child_task) = get_scheduler().get_task_by_id(child_id) {
+        if let Some(child_task) = get_task_by_id(child_id) {
             if child_task.get_state() == TaskState::Zombie {
                 let status = child_task.get_exit_status().unwrap_or(-1);
                 child_task.set_state(TaskState::Terminated);
@@ -1658,7 +1660,7 @@ impl Task {
 
         impl TimerHandler for SleepWakerHandler {
             fn on_timer_expired(self: Arc<Self>, _context: usize) {
-                if let Some(task) = get_scheduler().get_task_by_id(self.task_id) {
+                if let Some(task) = get_task_by_id(self.task_id) {
                     let handler: Arc<dyn TimerHandler> = self.clone();
                     task.remove_software_timer_handler(&handler);
                     // Memory barrier to ensure state change is visible
@@ -1985,7 +1987,7 @@ pub fn mytask() -> Option<&'static Task> {
     }
 
     let cpu = get_cpu();
-    get_scheduler().get_current_task(cpu.get_cpuid())
+    current_task(cpu.get_cpuid())
 }
 
 /// Set the current working directory for the current task via VfsManager
@@ -2015,12 +2017,8 @@ pub fn set_current_task_cwd(path: String) -> bool {
 /// This function is called when a task is first scheduled.
 pub fn task_initial_kernel_entrypoint() -> ! {
     let cpu = get_cpu();
-    let current_task = unsafe {
-        get_scheduler()
-            .get_current_task_mut(cpu.get_cpuid())
-            .unwrap()
-    };
-    Scheduler::setup_task_execution(cpu, current_task);
+    let current_task = current_task_mut(cpu.get_cpuid()).unwrap();
+    setup_task_execution(cpu, current_task);
     arch_switch_to_user(current_task.get_trapframe());
 }
 
@@ -2030,6 +2028,7 @@ mod tests {
     use alloc::sync::Arc;
     use core::sync::atomic::Ordering;
 
+    use crate::sched::scheduler::{add_task, get_task_by_id, reset};
     use crate::task::CloneFlags;
     use crate::vm::addr::{phys_to_virt, virt_to_phys};
 
@@ -2051,8 +2050,7 @@ mod tests {
     #[test_case]
     fn test_task_parent_child_relationship() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         let mut parent_task = super::new_user_task("ParentTask".to_string(), 0);
         parent_task.init();
@@ -2061,33 +2059,33 @@ mod tests {
         child_task.init();
 
         // Add tasks to scheduler to allocate IDs
-        let parent_id = scheduler.add_task(parent_task, 0);
-        let child_id = scheduler.add_task(child_task, 0);
+        let parent_id = add_task(parent_task, 0);
+        let child_id = add_task(child_task, 0);
 
         // Set parent-child relationship using allocated IDs
         // We need to do this sequentially due to borrow checker
         {
-            let child_task = scheduler.get_task_by_id(child_id).unwrap();
+            let child_task = get_task_by_id(child_id).unwrap();
             child_task.set_parent_id(parent_id);
         }
         {
-            let parent_task = scheduler.get_task_by_id(parent_id).unwrap();
+            let parent_task = get_task_by_id(parent_id).unwrap();
             parent_task.add_child(child_id);
         }
 
         // Verify parent-child relationship
         {
-            let child_task = scheduler.get_task_by_id(child_id).unwrap();
+            let child_task = get_task_by_id(child_id).unwrap();
             assert_eq!(child_task.get_parent_id(), Some(parent_id));
         }
         {
-            let parent_task = scheduler.get_task_by_id(parent_id).unwrap();
+            let parent_task = get_task_by_id(parent_id).unwrap();
             assert!(parent_task.get_children().contains(&child_id));
         }
 
         // Remove child and verify
         {
-            let parent_task = scheduler.get_task_by_id(parent_id).unwrap();
+            let parent_task = get_task_by_id(parent_id).unwrap();
             assert!(parent_task.remove_child(child_id));
             assert!(!parent_task.get_children().contains(&child_id));
         }
@@ -2112,8 +2110,7 @@ mod tests {
     #[test_case]
     fn test_clone_task_memory_copy() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         let mut parent_task = super::new_user_task("ParentTask".to_string(), 0);
         parent_task.init();
@@ -2168,53 +2165,52 @@ mod tests {
         let child_page_allocations_len = child_task.page_allocations.read().len();
 
         // Add both tasks to scheduler to establish parent-child relationship
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        let parent_id = scheduler.add_task(parent_task, 0);
-        let child_id = scheduler.add_task(child_task, 0);
+        let parent_id = add_task(parent_task, 0);
+        let child_id = add_task(child_task, 0);
 
         // Establish parent-child relationship
         {
-            let child = scheduler.get_task_by_id(child_id).unwrap();
+            let child = get_task_by_id(child_id).unwrap();
             child.set_parent_id(parent_id);
         }
         {
-            let parent = scheduler.get_task_by_id(parent_id).unwrap();
+            let parent = get_task_by_id(parent_id).unwrap();
             parent.add_child(child_id);
         }
 
         // Verify parent-child relationship was established (in separate scopes)
         {
-            let child = scheduler.get_task_by_id(child_id).unwrap();
+            let child = get_task_by_id(child_id).unwrap();
             assert_eq!(child.get_parent_id(), Some(parent_id));
         }
         {
-            let parent = scheduler.get_task_by_id(parent_id).unwrap();
+            let parent = get_task_by_id(parent_id).unwrap();
             assert!(parent.get_children().contains(&child_id));
         }
 
         // Get references for further verification (in separate scopes)
         let child_stack_size = {
-            let child = scheduler.get_task_by_id(child_id).unwrap();
+            let child = get_task_by_id(child_id).unwrap();
             child.stack_size.load(Ordering::SeqCst)
         };
         let child_data_size = {
-            let child = scheduler.get_task_by_id(child_id).unwrap();
+            let child = get_task_by_id(child_id).unwrap();
             child.data_size.load(Ordering::SeqCst)
         };
         let child_text_size = {
-            let child = scheduler.get_task_by_id(child_id).unwrap();
+            let child = get_task_by_id(child_id).unwrap();
             child.text_size.load(Ordering::SeqCst)
         };
         let parent_stack_size = {
-            let parent = scheduler.get_task_by_id(parent_id).unwrap();
+            let parent = get_task_by_id(parent_id).unwrap();
             parent.stack_size.load(Ordering::SeqCst)
         };
         let parent_data_size = {
-            let parent = scheduler.get_task_by_id(parent_id).unwrap();
+            let parent = get_task_by_id(parent_id).unwrap();
             parent.data_size.load(Ordering::SeqCst)
         };
         let parent_text_size = {
-            let parent = scheduler.get_task_by_id(parent_id).unwrap();
+            let parent = get_task_by_id(parent_id).unwrap();
             parent.text_size.load(Ordering::SeqCst)
         };
 
@@ -2226,7 +2222,7 @@ mod tests {
         // Find the corresponding memory map in child that matches our test allocation
         let child_mmap = {
             let mut found = None;
-            let child = scheduler.get_task_by_id(child_id).unwrap();
+            let child = get_task_by_id(child_id).unwrap();
             child.vm_manager.with_memmaps(|mm| {
                 for m in mm.values() {
                     if m.vmarea.start == vaddr
@@ -2299,8 +2295,7 @@ mod tests {
     #[test_case]
     fn test_clone_task_stack_copy() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         let mut parent_task = super::new_user_task("ParentWithStack".to_string(), 0);
         parent_task.init();
@@ -2415,8 +2410,7 @@ mod tests {
     #[test_case]
     fn test_clone_task_shared_memory() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         use crate::environment::PAGE_SIZE;
         use crate::mem::page::allocate_raw_pages;
@@ -2532,8 +2526,7 @@ mod tests {
     #[test_case]
     fn test_clone_task_with_clone_vm_shares_address_space() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         use crate::environment::PAGE_SIZE;
 
@@ -2577,8 +2570,7 @@ mod tests {
     #[test_case]
     fn test_task_namespace_creation() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         use super::namespace;
 
@@ -2588,21 +2580,17 @@ mod tests {
         assert!(task.get_namespace().is_root());
 
         // Add task to scheduler to allocate namespace ID
-        let task_id = scheduler.add_task(task, 0);
+        let task_id = add_task(task, 0);
 
         // Verify namespace-local ID was allocated
-        let ns_id = scheduler
-            .get_task_by_id(task_id)
-            .unwrap()
-            .get_namespace_id();
+        let ns_id = get_task_by_id(task_id).unwrap().get_namespace_id();
         assert!(ns_id >= 1); // Should start from 1
     }
 
     #[test_case]
     fn test_task_namespace_inheritance() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         use super::namespace;
 
@@ -2619,27 +2607,19 @@ mod tests {
         );
 
         // Add both to scheduler to allocate namespace IDs
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        let parent_id = scheduler.add_task(parent, 0);
-        let child_id = scheduler.add_task(child, 0);
+        let parent_id = add_task(parent, 0);
+        let child_id = add_task(child, 0);
 
         // But should have different namespace-local IDs
-        let parent_ns_id = scheduler
-            .get_task_by_id(parent_id)
-            .unwrap()
-            .get_namespace_id();
-        let child_ns_id = scheduler
-            .get_task_by_id(child_id)
-            .unwrap()
-            .get_namespace_id();
+        let parent_ns_id = get_task_by_id(parent_id).unwrap().get_namespace_id();
+        let child_ns_id = get_task_by_id(child_id).unwrap().get_namespace_id();
         assert_ne!(parent_ns_id, child_ns_id);
     }
 
     #[test_case]
     fn test_task_namespace_id_allocation() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         use super::namespace;
 
@@ -2675,15 +2655,14 @@ mod tests {
         task3.init();
 
         // Add tasks to scheduler to allocate IDs
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        let id1 = scheduler.add_task(task1, 0);
-        let id2 = scheduler.add_task(task2, 0);
-        let id3 = scheduler.add_task(task3, 0);
+        let id1 = add_task(task1, 0);
+        let id2 = add_task(task2, 0);
+        let id3 = add_task(task3, 0);
 
         // All should have sequential namespace-local IDs
-        let ns_id1 = scheduler.get_task_by_id(id1).unwrap().get_namespace_id();
-        let ns_id2 = scheduler.get_task_by_id(id2).unwrap().get_namespace_id();
-        let ns_id3 = scheduler.get_task_by_id(id3).unwrap().get_namespace_id();
+        let ns_id1 = get_task_by_id(id1).unwrap().get_namespace_id();
+        let ns_id2 = get_task_by_id(id2).unwrap().get_namespace_id();
+        let ns_id3 = get_task_by_id(id3).unwrap().get_namespace_id();
         assert_eq!(ns_id1, 1);
         assert_eq!(ns_id2, 2);
         assert_eq!(ns_id3, 3);
@@ -2720,8 +2699,7 @@ mod tests {
     #[test_case]
     fn test_all_abis_share_root_namespace_by_default() {
         // Reset scheduler state before test
-        let scheduler = crate::sched::scheduler::get_scheduler();
-        scheduler.reset();
+        reset();
 
         use super::namespace;
         use alloc::vec::Vec;
@@ -2737,9 +2715,9 @@ mod tests {
         task3.init();
 
         // Add tasks to scheduler to allocate namespace IDs
-        let id1 = scheduler.add_task(task1, 0);
-        let id2 = scheduler.add_task(task2, 0);
-        let id3 = scheduler.add_task(task3, 0);
+        let id1 = add_task(task1, 0);
+        let id2 = add_task(task2, 0);
+        let id3 = add_task(task3, 0);
 
         // Verify all tasks have valid IDs after being added to scheduler
         assert_ne!(id1, 0, "Task ID should be non-zero after add_task");
@@ -2747,13 +2725,13 @@ mod tests {
         assert_ne!(id3, 0, "Task ID should be non-zero after add_task");
 
         // Get namespace IDs to verify (in separate scopes to avoid borrow issues)
-        let ns_id1 = scheduler.get_task_by_id(id1).unwrap().get_namespace_id();
+        let ns_id1 = get_task_by_id(id1).unwrap().get_namespace_id();
         assert_ne!(ns_id1, 0, "Namespace ID should be non-zero after add_task");
 
-        let ns_id2 = scheduler.get_task_by_id(id2).unwrap().get_namespace_id();
+        let ns_id2 = get_task_by_id(id2).unwrap().get_namespace_id();
         assert_ne!(ns_id2, 0, "Namespace ID should be non-zero after add_task");
 
-        let ns_id3 = scheduler.get_task_by_id(id3).unwrap().get_namespace_id();
+        let ns_id3 = get_task_by_id(id3).unwrap().get_namespace_id();
         assert_ne!(ns_id3, 0, "Namespace ID should be non-zero after add_task");
 
         // Verify namespace IDs are unique
@@ -2762,34 +2740,22 @@ mod tests {
 
         // Verify all tasks are in root namespace (in separate scopes)
         {
-            let task1 = scheduler.get_task_by_id(id1).unwrap();
+            let task1 = get_task_by_id(id1).unwrap();
             assert_eq!(task1.get_namespace().get_name(), "root");
         }
         {
-            let task2 = scheduler.get_task_by_id(id2).unwrap();
+            let task2 = get_task_by_id(id2).unwrap();
             assert_eq!(task2.get_namespace().get_name(), "root");
         }
         {
-            let task3 = scheduler.get_task_by_id(id3).unwrap();
+            let task3 = get_task_by_id(id3).unwrap();
             assert_eq!(task3.get_namespace().get_name(), "root");
         }
 
         // Verify all tasks share the same namespace instance
-        let ns1_id = scheduler
-            .get_task_by_id(id1)
-            .unwrap()
-            .get_namespace()
-            .get_id();
-        let ns2_id = scheduler
-            .get_task_by_id(id2)
-            .unwrap()
-            .get_namespace()
-            .get_id();
-        let ns3_id = scheduler
-            .get_task_by_id(id3)
-            .unwrap()
-            .get_namespace()
-            .get_id();
+        let ns1_id = get_task_by_id(id1).unwrap().get_namespace().get_id();
+        let ns2_id = get_task_by_id(id2).unwrap().get_namespace().get_id();
+        let ns3_id = get_task_by_id(id3).unwrap().get_namespace().get_id();
         assert_eq!(ns1_id, ns2_id, "All tasks should share root namespace");
         assert_eq!(ns2_id, ns3_id, "All tasks should share root namespace");
     }

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -15,6 +15,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{cell::UnsafeCell, sync::atomic};
+use spin::mutex::SpinMutex;
 use spin::{Mutex, RwLock};
 
 use crate::abi::{AbiModule, scarlet::ScarletAbi};
@@ -48,6 +49,51 @@ use alloc::collections::BTreeMap;
 use core::ops::Range;
 use core::sync::atomic::{AtomicI32, AtomicU8, AtomicU32, AtomicUsize, Ordering};
 use spin::Once;
+
+/// Lock type used for the architecture kernel context.
+///
+/// The scheduler needs a stable raw pointer to this context while performing
+/// low-level context switches. `SpinMutex` exposes `as_mut_ptr()` for that
+/// scheduler-only path, while normal setup code still uses `lock()`.
+pub type KernelContextMutex = SpinMutex<KernelContext>;
+
+/// Snapshot of task state exposed to user space via the `GetTaskInfo` syscall.
+///
+/// This is a fixed-size, `#[repr(C)]` structure so that the kernel and user
+/// library can agree on the layout without sharing a header.
+///
+/// Future fields can be appended without breaking backward compatibility
+/// (user space simply reads fewer bytes on older kernels).
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct TaskInfo {
+    /// Namespace-local PID visible to user space.
+    pub pid: usize,
+    /// Namespace-local parent PID (0 if none).
+    pub ppid: usize,
+    /// Task state as a discriminant (see `TaskState::to_u8`):
+    ///   0 = NotInitialized, 1 = Ready, 2 = Running,
+    ///   3 = Blocked(Interruptible), 4 = Blocked(Uninterruptible),
+    ///   5 = Zombie, 6 = Terminated.
+    pub state: u8,
+    /// Task type: 0 = Kernel, 1 = User.
+    pub task_type: u8,
+    /// CPU the task last ran on (MAX_CPU = no CPU).
+    pub cpu_id: u8,
+    /// Reserved for future use.
+    pub _reserved: u8,
+    /// Exit status (meaningful only when `state == Zombie`).
+    pub exit_status: i32,
+    /// Thread-group ID (process ID for multi-threaded tasks).
+    pub tgid: usize,
+    /// Null-terminated task name (truncated to fit).
+    pub name: [u8; 64],
+}
+
+impl TaskInfo {
+    /// Maximum task name length (excluding null terminator).
+    pub const NAME_CAP: usize = 63;
+}
 
 /// Global registry of task-specific wakers for waitpid
 static WAITPID_WAKERS: Once<Mutex<BTreeMap<usize, Waker>>> = Once::new();
@@ -423,7 +469,7 @@ pub struct Task {
     /// VCPU state for context switching
     pub vcpu: Mutex<Vcpu>,
     /// Kernel context for context switching
-    pub kernel_context: Mutex<KernelContext>,
+    pub kernel_context: KernelContextMutex,
     /// Virtual memory manager (already thread-safe internally)
     pub vm_manager: VirtualMemoryManager,
     /// Default ABI module (task-local: only accessed by the executing hart)
@@ -566,7 +612,7 @@ impl Task {
                 TaskType::Kernel => crate::arch::Mode::Kernel,
                 TaskType::User => crate::arch::Mode::User,
             })),
-            kernel_context: Mutex::new(KernelContext::new()),
+            kernel_context: KernelContextMutex::new(KernelContext::new()),
             vm_manager: VirtualMemoryManager::new(),
             default_abi: TaskLocal::new(Some(Box::new(ScarletAbi::default()))),
             abi_zones: TaskLocal::new(BTreeMap::new()),
@@ -2036,11 +2082,34 @@ pub fn task_initial_kernel_entrypoint() -> ! {
     let cpu = get_cpu();
     crate::sched::scheduler::complete_deferred_context_switch(cpu.get_cpuid());
     if let Some(current_task) = current_task(cpu.get_cpuid()) {
+        if crate::sched::scheduler::DEBUG_SMP_TASK_FLOW {
+            let vcpu = current_task.vcpu.lock();
+            crate::println!(
+                "[SMPDBG task-entry] cpu={} task={} name={} type={:?} state={:?} running_cpu={} last_cpu={} pc={:#x} mode={:?}",
+                cpu.get_cpuid(),
+                current_task.get_id(),
+                current_task.name.read().as_str(),
+                current_task.task_type,
+                current_task.state.load(Ordering::SeqCst),
+                current_task.running_cpu.load(Ordering::SeqCst),
+                current_task.last_cpu.load(Ordering::SeqCst),
+                vcpu.get_pc(),
+                vcpu.get_mode(),
+            );
+        }
         if current_task.task_type == TaskType::Kernel {
             let entry = current_task.vcpu.lock().get_pc();
             // SAFETY: `new_kernel_task` stores a valid `fn()` entry pointer in
             // the kernel-mode VCPU PC before the task is made runnable.
             let entry: fn() = unsafe { core::mem::transmute(entry as usize) };
+            if crate::sched::scheduler::DEBUG_SMP_TASK_FLOW {
+                crate::println!(
+                    "[SMPDBG task-entry-kernel-jump] cpu={} task={} entry={:#x}",
+                    cpu.get_cpuid(),
+                    current_task.get_id(),
+                    entry as usize,
+                );
+            }
             entry();
             current_task.exit(0);
             loop {
@@ -2048,6 +2117,14 @@ pub fn task_initial_kernel_entrypoint() -> ! {
             }
         }
 
+        if crate::sched::scheduler::DEBUG_SMP_TASK_FLOW {
+            crate::println!(
+                "[SMPDBG task-entry-user-jump] cpu={} task={} name={}",
+                cpu.get_cpuid(),
+                current_task.get_id(),
+                current_task.name.read().as_str(),
+            );
+        }
         setup_task_execution(cpu, current_task);
         arch_switch_to_user(current_task.get_trapframe());
     }

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -24,8 +24,11 @@ use crate::library::std::string::{
     parse_c_string_from_userspace, parse_string_array_from_userspace,
 };
 
-use crate::arch::{Trapframe, get_cpu};
-use crate::sched::scheduler::{add_task, get_task_by_id, remove_task_from_queues, schedule};
+use crate::arch::Trapframe;
+use crate::sched::scheduler::{
+    enqueue_task, get_all_task_ids, get_task_by_id, register_task, remove_task_from_queues,
+    schedule,
+};
 use crate::task::{
     CloneFlags, CloneFlagsDef, WaitError, get_parent_waitpid_waker, get_waitpid_waker,
 };
@@ -157,9 +160,11 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
                 child_task.vcpu.lock().set_tls_pointer(tls_ptr);
             }
 
-            // Add child to scheduler and get the allocated ID
-            let cpu_id = get_cpu().get_cpuid();
-            let child_id = add_task(child_task, cpu_id);
+            // Register the child first, finish parent/child metadata, then enqueue it.
+            // On SMP, enqueueing before the metadata is complete lets a remote CPU
+            // start the child immediately from the reschedule IPI.
+            let cpu_id = crate::sched::scheduler::select_cpu();
+            let child_id = register_task(child_task);
             // crate::println!("[CLONE] Child task {} added to scheduler", child_id);
 
             // Establish parent-child relationship now that both have valid IDs
@@ -174,6 +179,8 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
             let child_ns_pid = get_task_by_id(child_id)
                 .map(|t| t.get_namespace_id())
                 .unwrap_or(0);
+
+            enqueue_task(child_id, cpu_id);
 
             /* Return the child task PID (namespace-local) to the parent task */
             child_ns_pid
@@ -911,4 +918,105 @@ pub fn sys_shutdown(trapframe: &mut Trapframe) -> usize {
     // This line should never be reached if shutdown succeeds
     crate::println!("[SHUTDOWN] ERROR: Shutdown did not complete!");
     usize::MAX
+}
+
+/// Return the number of tasks currently visible to the caller.
+///
+/// # Arguments
+/// None.
+///
+/// # Returns
+/// The number of tasks in the system.
+pub fn sys_get_task_info_count(trapframe: &mut Trapframe) -> usize {
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+    get_all_task_ids().len()
+}
+
+/// Populate a user-supplied buffer with [`TaskInfo`] snapshots.
+///
+/// # Arguments
+/// * `trapframe.get_arg(0)` — pointer to a user buffer of `TaskInfo` slots.
+/// * `trapframe.get_arg(1)` — capacity of the buffer (number of slots).
+///
+/// # Returns
+/// The number of `TaskInfo` entries actually written.  If the buffer is
+/// smaller than the total number of tasks, only the first `capacity` entries
+/// are written and the return value equals `capacity`.  The caller can
+/// compare against `GetTaskInfoCount` to detect truncation.
+pub fn sys_get_task_info_list(trapframe: &mut Trapframe) -> usize {
+    use crate::library::std::usercopy::copy_to_user;
+    use crate::task::TaskInfo;
+    use core::sync::atomic::Ordering;
+
+    let task = mytask().unwrap();
+    trapframe.increment_pc_next(task);
+
+    let buf_ptr = trapframe.get_arg(0);
+    let capacity = trapframe.get_arg(1);
+    let caller_namespace = task.get_namespace();
+
+    let ids = get_all_task_ids();
+    let count = core::cmp::min(capacity, ids.len());
+
+    for (i, task_id) in ids.iter().take(count).enumerate() {
+        let Some(target) = get_task_by_id(*task_id) else {
+            continue;
+        };
+
+        // Resolve namespace-local PID/PPID.
+        let pid = caller_namespace.resolve_local_id(*task_id).unwrap_or(0);
+        let ppid = match target.get_parent_id() {
+            Some(parent_global) => caller_namespace
+                .resolve_local_id(parent_global)
+                .unwrap_or(0),
+            None => 0,
+        };
+
+        let state_u8 = target.state.load(Ordering::SeqCst).to_u8();
+        let task_type_u8 = match target.task_type {
+            super::TaskType::Kernel => 0,
+            super::TaskType::User => 1,
+        };
+        let cpu_id = target.last_cpu.load(Ordering::SeqCst) as u8; // saturates on MAX
+
+        let exit_status = target.exit_status.load(Ordering::SeqCst);
+
+        let tgid = caller_namespace
+            .resolve_local_id(target.get_thread_group_id())
+            .unwrap_or(0);
+
+        let mut name = [0u8; 64];
+        {
+            let task_name = target.name.read();
+            let bytes = task_name.as_bytes();
+            let len = core::cmp::min(bytes.len(), TaskInfo::NAME_CAP);
+            name[..len].copy_from_slice(&bytes[..len]);
+            // name[len] is already 0
+        }
+
+        let info = TaskInfo {
+            pid,
+            ppid,
+            state: state_u8,
+            task_type: task_type_u8,
+            cpu_id,
+            _reserved: 0,
+            exit_status,
+            tgid,
+            name,
+        };
+
+        let info_bytes = unsafe {
+            core::slice::from_raw_parts(
+                &info as *const TaskInfo as *const u8,
+                core::mem::size_of::<TaskInfo>(),
+            )
+        };
+        let dest = buf_ptr + i * core::mem::size_of::<TaskInfo>();
+        // Best-effort: skip on copy error.
+        let _ = copy_to_user(task, dest, info_bytes);
+    }
+
+    count
 }

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -25,7 +25,7 @@ use crate::library::std::string::{
 };
 
 use crate::arch::{Trapframe, get_cpu};
-use crate::sched::scheduler::get_scheduler;
+use crate::sched::scheduler::{add_task, get_task_by_id, remove_task_from_queues, schedule};
 use crate::task::{
     CloneFlags, CloneFlagsDef, WaitError, get_parent_waitpid_waker, get_waitpid_waker,
 };
@@ -141,7 +141,6 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
                 child_task.vcpu.lock().iregs.set_arg(0, child_arg);
             }
 
-            let scheduler = get_scheduler();
             let cpu_id = get_cpu().get_cpuid();
             let parent_id = parent_task.get_id();
 
@@ -160,20 +159,19 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
             }
 
             // Add child to scheduler and get the allocated ID
-            let child_id = scheduler.add_task(child_task, cpu_id);
+            let child_id = add_task(child_task, cpu_id);
             // crate::println!("[CLONE] Child task {} added to scheduler", child_id);
 
             // Establish parent-child relationship now that both have valid IDs
-            if let Some(child) = scheduler.get_task_by_id(child_id) {
+            if let Some(child) = get_task_by_id(child_id) {
                 child.set_parent_id(parent_id);
             }
-            if let Some(parent) = scheduler.get_task_by_id(parent_id) {
+            if let Some(parent) = get_task_by_id(parent_id) {
                 parent.add_child(child_id);
             }
 
             // Get the child's namespace-local PID (after add_task has set the IDs)
-            let child_ns_pid = scheduler
-                .get_task_by_id(child_id)
+            let child_ns_pid = get_task_by_id(child_id)
                 .map(|t| t.get_namespace_id())
                 .unwrap_or(0);
 
@@ -572,7 +570,7 @@ pub fn sys_yield(trapframe: &mut Trapframe) -> usize {
     trapframe.increment_pc_next(task);
 
     // Yield CPU to scheduler - returns when this task is scheduled again
-    get_scheduler().schedule(trapframe);
+    schedule(trapframe);
 
     0
 }
@@ -810,7 +808,6 @@ pub fn sys_create_namespace(trapframe: &mut Trapframe) -> usize {
 /// Returns error code on failure
 pub fn sys_shutdown(trapframe: &mut Trapframe) -> usize {
     use crate::arch::shutdown;
-    use crate::sched::scheduler::get_scheduler;
     use crate::task::TaskState;
 
     let task = mytask().unwrap();
@@ -845,7 +842,6 @@ pub fn sys_shutdown(trapframe: &mut Trapframe) -> usize {
     // We iterate through all possible task IDs and terminate those that are running
     crate::println!("[SHUTDOWN] Step 1: Terminating all tasks...");
 
-    let scheduler = get_scheduler();
     let current_task_id = task.get_id();
 
     crate::println!("[SHUTDOWN] Dropping all tasks...");
@@ -853,7 +849,7 @@ pub fn sys_shutdown(trapframe: &mut Trapframe) -> usize {
         if task_id == current_task_id {
             continue;
         }
-        scheduler.remove_task_from_queues(task_id);
+        remove_task_from_queues(task_id);
         if let Some(task) = crate::sched::scheduler::get_task_pool().remove_task(task_id) {
             drop(task);
         }

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -121,7 +121,7 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
 
     /* Clone the task */
     match parent_task.clone_task(clone_flags) {
-        Ok(mut child_task) => {
+        Ok(child_task) => {
             // crate::println!("[CLONE] Successfully created child task {}, state: {:?}, PC: 0x{:x}",
             //     child_id, child_task.get_state(), child_task.vcpu.get_pc());
             child_task.vcpu.lock().iregs.set_return_value(0); /* Set the return value to 0 in the child task */
@@ -141,7 +141,6 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
                 child_task.vcpu.lock().iregs.set_arg(0, child_arg);
             }
 
-            let cpu_id = get_cpu().get_cpuid();
             let parent_id = parent_task.get_id();
 
             // Handle SetTls flag: set TLS pointer and tp register
@@ -159,6 +158,7 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
             }
 
             // Add child to scheduler and get the allocated ID
+            let cpu_id = get_cpu().get_cpuid();
             let child_id = add_task(child_task, cpu_id);
             // crate::println!("[CLONE] Child task {} added to scheduler", child_id);
 
@@ -806,9 +806,9 @@ pub fn sys_create_namespace(trapframe: &mut Trapframe) -> usize {
 /// # Returns
 /// This function does not return on success (system shuts down)
 /// Returns error code on failure
+#[allow(unreachable_code)]
 pub fn sys_shutdown(trapframe: &mut Trapframe) -> usize {
     use crate::arch::shutdown;
-    use crate::task::TaskState;
 
     let task = mytask().unwrap();
     trapframe.increment_pc_next(task);

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -3,16 +3,17 @@
 //! This module provides time-related functionality for the kernel,
 //! including current time access for filesystem operations.
 
-use crate::timer::get_kernel_timer;
+use crate::timer::get_time_us;
 
 /// Get the current time in microseconds
 ///
 /// This function returns the current system time in microseconds since boot.
 /// For filesystem operations, this provides a monotonic timestamp.
 pub fn current_time() -> u64 {
-    // For now, use CPU 0's timer. In a multi-core system, this might need
-    // to be more sophisticated to get a consistent global timestamp.
-    get_kernel_timer().get_time_us(0)
+    // Use the current CPU's architected timer. The boot CPU is not guaranteed
+    // to be CPU 0, and the supported SMP platforms expose synchronized
+    // per-CPU timer counters.
+    get_time_us()
 }
 
 /// Get the current time in milliseconds

--- a/kernel/src/timer.rs
+++ b/kernel/src/timer.rs
@@ -7,7 +7,7 @@
 use crate::arch::Trapframe;
 use crate::arch::timer::ArchTimer;
 use crate::environment::MAX_NUM_CPUS;
-use crate::sched::scheduler::get_scheduler;
+use crate::sched::scheduler::sched_on_tick;
 use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicU64, Ordering};
 extern crate alloc;
@@ -90,9 +90,8 @@ pub fn tick(trapframe: &mut Trapframe) {
     let now = TICK_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
     check_software_timers(now);
     // Call scheduler tick handler to manage time slices
-    let scheduler = get_scheduler();
     // crate::println!("[timer] Tick: {}, CPU: {}", now, cpu_id);
-    scheduler.on_tick(cpu_id, trapframe);
+    sched_on_tick(cpu_id, trapframe);
 }
 
 /// Get the current tick count (monotonic, since boot)

--- a/kernel/src/timer.rs
+++ b/kernel/src/timer.rs
@@ -81,16 +81,38 @@ impl KernelTimer {
 // Global tick counter (monotonic, incremented by timer interrupt)
 static TICK_COUNT: AtomicU64 = AtomicU64::new(0);
 
-/// Increment the global tick counter. Call this from the timer interrupt handler.
+/// The CPU ID designated as the global timekeeper.
+/// Only this CPU advances TICK_COUNT and fires software timers.
+/// Initialized to u64::MAX (unset); call set_global_timekeeper() during boot.
+static GLOBAL_TIMEKEEPER_CPU: AtomicU64 = AtomicU64::new(u64::MAX);
+
+/// Designate a CPU as the global timekeeper.
+/// Must be called once during boot (from start_kernel) before any timer interrupts fire.
+pub fn set_global_timekeeper(cpu_id: usize) {
+    GLOBAL_TIMEKEEPER_CPU.store(cpu_id as u64, Ordering::Relaxed);
+}
+
+/// Timer interrupt handler. Called on every CPU local timer interrupt.
+///
+/// - Re-arms the per-CPU local timer (all CPUs).
+/// - Advances the global TICK_COUNT and fires software timers only on the
+///   designated global timekeeper CPU, so global time advances exactly once
+///   per quantum system-wide regardless of how many CPUs are running.
+/// - Always calls sched_on_tick() for per-CPU scheduler accounting.
 pub fn tick(trapframe: &mut Trapframe) {
     let cpu_id = crate::arch::get_cpu().get_cpuid();
     let timer = get_kernel_timer();
     timer.set_interval_us(cpu_id, TICK_INTERVAL_US);
     timer.start(cpu_id);
-    let now = TICK_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
-    check_software_timers(now);
-    // Call scheduler tick handler to manage time slices
-    // crate::println!("[timer] Tick: {}, CPU: {}", now, cpu_id);
+
+    // Only the designated global timekeeper advances global time and fires
+    // software timers. All other CPUs skip this block entirely.
+    if cpu_id as u64 == GLOBAL_TIMEKEEPER_CPU.load(Ordering::Relaxed) {
+        let now = TICK_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+        check_software_timers(now);
+    }
+
+    // Per-CPU scheduler accounting runs on every CPU regardless.
     sched_on_tick(cpu_id, trapframe);
 }
 

--- a/kernel/src/timer.rs
+++ b/kernel/src/timer.rs
@@ -100,6 +100,17 @@ pub fn set_global_timekeeper(cpu_id: usize) {
 ///   per quantum system-wide regardless of how many CPUs are running.
 /// - Always calls sched_on_tick() for per-CPU scheduler accounting.
 pub fn tick(trapframe: &mut Trapframe) {
+    tick_with_scheduler(trapframe, true);
+}
+
+/// Timer interrupt handler with optional scheduler accounting.
+///
+/// Kernel-mode traps on a non-idle user task must not preempt via the normal
+/// user-task scheduler path: the trapframe describes an in-kernel continuation,
+/// not the task's user context.  Such paths still need timer re-arming and
+/// global timer processing, but scheduler accounting is deferred until the task
+/// returns to user mode or blocks explicitly.
+pub fn tick_with_scheduler(trapframe: &mut Trapframe, run_scheduler: bool) {
     let cpu_id = crate::arch::get_cpu().get_cpuid();
     let timer = get_kernel_timer();
     timer.set_interval_us(cpu_id, TICK_INTERVAL_US);
@@ -112,8 +123,10 @@ pub fn tick(trapframe: &mut Trapframe) {
         check_software_timers(now);
     }
 
-    // Per-CPU scheduler accounting runs on every CPU regardless.
-    sched_on_tick(cpu_id, trapframe);
+    if run_scheduler {
+        // Per-CPU scheduler accounting runs on every CPU when preemption is safe.
+        sched_on_tick(cpu_id, trapframe);
+    }
 }
 
 /// Get the current tick count (monotonic, since boot)

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -229,6 +229,7 @@ pub fn kernel_vm_init(
     #[cfg(any(debug_assertions, test))]
     early_println!("[vm] kernel_vm_init: switch (ttbr0/arch-dependent)...");
     root_page_table.switch(manager.get_asid());
+    crate::arch::vm::save_kernel_page_table();
 
     // Initialize the ioremap subsystem now that the kernel VM manager and heap
     // are ready.  Device drivers call ioremap() to map their MMIO regions

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -37,7 +37,7 @@ use crate::environment::{
     KERNEL_HEAP_SIZE, KERNEL_KSTACK_REGION_END, KERNEL_KSTACK_REGION_START,
     KERNEL_KSTACK_SLOT_SIZE, KERNEL_KSTACK_SLOTS, TASK_KERNEL_STACK_SIZE,
 };
-use crate::sched::scheduler::get_scheduler;
+use crate::sched::scheduler::current_task;
 use crate::task::Task;
 use core::sync::atomic::Ordering;
 use spin::{Mutex, Once};
@@ -623,9 +623,7 @@ pub fn switch_to_kernel_vm() {
 
 pub fn switch_to_user_vm(cpu: &mut Arch) {
     let cpu_id = cpu.get_cpuid();
-    let task = get_scheduler()
-        .get_current_task(cpu_id)
-        .expect("No current task found");
+    let task = current_task(cpu_id).expect("No current task found");
     let manager = &task.vm_manager;
     let root_page_table = manager
         .get_root_page_table()

--- a/user/bin/.cargo/config.toml
+++ b/user/bin/.cargo/config.toml
@@ -1,5 +1,5 @@
 [profile.dev]
-opt-level = 0
+opt-level = 3
 
 [build]
 target = "../targets/riscv64gc-unknown-scarlet-elf.json"

--- a/user/bin/Cargo.toml
+++ b/user/bin/Cargo.toml
@@ -182,6 +182,14 @@ path = "src/lsm_unload.rs"
 name = "lsm_list"
 path = "src/lsm_list.rs"
 
+[[bin]]
+name = "ps"
+path = "src/ps.rs"
+
+[[bin]]
+name = "top"
+path = "src/top.rs"
+
 [dependencies]
 scarlet_std = { path = "../lib/std", features = ["alloc_debug"] }
 scpm = { path = "../lib/scpm" }

--- a/user/bin/src/ps.rs
+++ b/user/bin/src/ps.rs
@@ -1,0 +1,114 @@
+//! `ps` — report a snapshot of current tasks.
+//!
+//! Usage: `ps`  or  `ps -l` (long format)
+
+#![no_std]
+#![no_main]
+
+extern crate scarlet_std as std;
+
+use crate::std::string::ToString;
+use std::task::{self, TaskState};
+use std::{format, println};
+
+#[unsafe(no_mangle)]
+fn main() -> i32 {
+    let args: std::vec::Vec<std::string::String> = std::env::args().collect();
+    let long = args.iter().any(|a| a == "-l" || a == "--long");
+
+    let tasks = task::info();
+
+    if tasks.is_empty() {
+        println!("No tasks found.");
+        return 0;
+    }
+
+    if long {
+        // Long format: PID PPID TGID TYPE STATE CPU NAME EXIT
+        let mut max_pid = 3;
+        let mut max_ppid = 4;
+        let mut max_tgid = 4;
+        let mut max_name = 4;
+
+        for t in &tasks {
+            max_pid = max_pid.max(format!("{}", t.pid()).len());
+            max_ppid = max_ppid.max(format!("{}", t.ppid()).len());
+            max_tgid = max_tgid.max(format!("{}", t.tgid()).len());
+            max_name = max_name.max(t.name().len());
+        }
+
+        println!(
+            "{:>w_pid$} {:>w_ppid$} {:>w_tgid$} {:<4} {:<7} {:<3} {:<w_name$} {}",
+            "PID",
+            "PPID",
+            "TGID",
+            "TYPE",
+            "STATE",
+            "CPU",
+            "NAME",
+            "EXIT",
+            w_pid = max_pid,
+            w_ppid = max_ppid,
+            w_tgid = max_tgid,
+            w_name = max_name,
+        );
+
+        for t in &tasks {
+            let exit_str = if t.state() == TaskState::Zombie {
+                format!("{}", t.exit_status())
+            } else {
+                "-".to_string()
+            };
+            println!(
+                "{:>w_pid$} {:>w_ppid$} {:>w_tgid$} {:<4} {:<7} {:<3} {:<w_name$} {}",
+                t.pid(),
+                t.ppid(),
+                t.tgid(),
+                t.task_type(),
+                t.state(),
+                t.cpu(),
+                t.name(),
+                exit_str,
+                w_pid = max_pid,
+                w_ppid = max_ppid,
+                w_tgid = max_tgid,
+                w_name = max_name,
+            );
+        }
+    } else {
+        // Default format: PID TYPE STATE CPU NAME
+        let mut max_pid = 3;
+        let mut max_name = 4;
+
+        for t in &tasks {
+            max_pid = max_pid.max(format!("{}", t.pid()).len());
+            max_name = max_name.max(t.name().len());
+        }
+
+        println!(
+            "{:>w_pid$} {:<4} {:<7} {:<3} {:<w_name$}",
+            "PID",
+            "TYPE",
+            "STATE",
+            "CPU",
+            "NAME",
+            w_pid = max_pid,
+            w_name = max_name,
+        );
+
+        for t in &tasks {
+            println!(
+                "{:>w_pid$} {:<4} {:<7} {:<3} {:<w_name$}",
+                t.pid(),
+                t.task_type(),
+                t.state(),
+                t.cpu(),
+                t.name(),
+                w_pid = max_pid,
+                w_name = max_name,
+            );
+        }
+    }
+
+    0
+}

--- a/user/bin/src/ps.rs
+++ b/user/bin/src/ps.rs
@@ -1,56 +1,165 @@
 //! `ps` — report a snapshot of current tasks.
 //!
-//! Usage: `ps`  or  `ps -l` (long format)
+//! Usage:
+//!   `ps`           — default format (PID, STAT, CPU, COMMAND)
+//!   `ps -e`        — same as default (all processes)
+//!   `ps -l` / `ps --long`  — long format (PID, PPID, TGID, STAT, CPU, COMMAND, EXIT)
+//!   `ps -T`        — show threads (TGID column added)
+//!
+//! Sort options:
+//!   `ps -p`                        — sort by PID (default)
+//!   `ps --sort pid`                — sort by PID ascending
+//!   `ps --sort -pid`               — sort by PID descending
+//!   `ps --sort cpu`                — sort by CPU id
+//!   `ps --sort name`               — sort by command name
+//!   `ps --sort state`              — sort by state
+//!   `ps --sort type`               — sort by task type
 
 #![no_std]
 #![no_main]
 
 extern crate scarlet_std as std;
 
-use crate::std::string::ToString;
-use std::task::{self, TaskState};
+use std::string::ToString;
+use std::task::{self, TaskState, TaskType};
 use std::{format, println};
+
+/// How to sort the output.
+#[derive(Clone, Copy)]
+enum SortKey {
+    Pid,
+    Cpu,
+    Name,
+    State,
+    Type,
+}
+
+fn parse_sort_key(s: &str) -> SortKey {
+    match s {
+        "pid" => SortKey::Pid,
+        "cpu" => SortKey::Cpu,
+        "name" => SortKey::Name,
+        "state" => SortKey::State,
+        "type" => SortKey::Type,
+        _ => SortKey::Pid,
+    }
+}
+
+/// Short STAT representation (default format).
+fn format_stat(state: TaskState) -> &'static str {
+    match state {
+        TaskState::Running => "R",
+        TaskState::Ready => "R<",
+        TaskState::BlockedInterruptible => "S",
+        TaskState::BlockedUninterruptible => "D",
+        TaskState::Zombie => "Z",
+        TaskState::Terminated => "T",
+        TaskState::NotInitialized => "?",
+    }
+}
+
+/// Long STAT representation (includes kernel/user suffix like Linux).
+fn format_stat_long(state: TaskState, task_type: TaskType) -> std::string::String {
+    let base = match state {
+        TaskState::Running => "R",
+        TaskState::Ready => "R",
+        TaskState::BlockedInterruptible => "S",
+        TaskState::BlockedUninterruptible => "D",
+        TaskState::Zombie => "Z",
+        TaskState::Terminated => "T",
+        TaskState::NotInitialized => "?",
+    };
+    let suffix = match task_type {
+        TaskType::Kernel => "k",
+        TaskType::User => "",
+    };
+    let mut s = std::string::String::new();
+    s.push_str(base);
+    s.push_str(suffix);
+    s
+}
+
+/// Apply sorting to the task list.
+fn apply_sort(tasks: &mut [std::task::TaskInfo], key: SortKey, ascending: bool) {
+    let dir = |ord: core::cmp::Ordering| {
+        if ascending { ord } else { ord.reverse() }
+    };
+    tasks.sort_by(|a, b| {
+        let primary = match key {
+            SortKey::Pid => a.pid().cmp(&b.pid()),
+            SortKey::Cpu => a.cpu().cmp(&b.cpu()),
+            SortKey::Name => a.name().cmp(b.name()),
+            SortKey::State => format!("{}", a.state()).cmp(&format!("{}", b.state())),
+            SortKey::Type => format!("{}", a.task_type()).cmp(&format!("{}", b.task_type())),
+        };
+        dir(primary).then_with(|| a.pid().cmp(&b.pid()))
+    });
+}
 
 #[unsafe(no_mangle)]
 fn main() -> i32 {
     let args: std::vec::Vec<std::string::String> = std::env::args().collect();
-    let long = args.iter().any(|a| a == "-l" || a == "--long");
 
-    let tasks = task::info();
+    let long = args.iter().any(|a| a == "-l" || a == "--long");
+    let show_threads = args.iter().any(|a| a == "-T" || a == "--threads");
+
+    // Parse sort key
+    let mut sort_key = SortKey::Pid;
+    let mut sort_ascending = true;
+    for (i, a) in args.iter().enumerate() {
+        if a == "-p" {
+            sort_key = SortKey::Pid;
+        } else if a == "--sort" {
+            if let Some(key_str) = args.get(i + 1) {
+                if key_str.starts_with('-') {
+                    sort_ascending = false;
+                    sort_key = parse_sort_key(&key_str[1..]);
+                } else {
+                    sort_key = parse_sort_key(key_str);
+                }
+            }
+        }
+    }
+
+    let mut tasks = task::info();
 
     if tasks.is_empty() {
         println!("No tasks found.");
         return 0;
     }
 
+    apply_sort(&mut tasks, sort_key, sort_ascending);
+
     if long {
-        // Long format: PID PPID TGID TYPE STATE CPU NAME EXIT
+        // ── Long format: PID PPID TGID STAT CPU COMMAND EXIT ──
         let mut max_pid = 3;
         let mut max_ppid = 4;
         let mut max_tgid = 4;
-        let mut max_name = 4;
+        let mut max_cmd = 7;
+        let mut max_cpu = 4; // "CPU" header
 
         for t in &tasks {
             max_pid = max_pid.max(format!("{}", t.pid()).len());
             max_ppid = max_ppid.max(format!("{}", t.ppid()).len());
             max_tgid = max_tgid.max(format!("{}", t.tgid()).len());
-            max_name = max_name.max(t.name().len());
+            max_cmd = max_cmd.max(t.name().len());
+            max_cpu = max_cpu.max(format!("CPU{}", t.cpu()).len());
         }
 
         println!(
-            "{:>w_pid$} {:>w_ppid$} {:>w_tgid$} {:<4} {:<7} {:<3} {:<w_name$} {}",
+            "{:>w_pid$} {:>w_ppid$} {:>w_tgid$} {:<5} {:<w_cpu$} {:<w_cmd$} {}",
             "PID",
             "PPID",
             "TGID",
-            "TYPE",
-            "STATE",
+            "STAT",
             "CPU",
-            "NAME",
+            "COMMAND",
             "EXIT",
             w_pid = max_pid,
             w_ppid = max_ppid,
             w_tgid = max_tgid,
-            w_name = max_name,
+            w_cpu = max_cpu,
+            w_cmd = max_cmd,
         );
 
         for t in &tasks {
@@ -59,53 +168,99 @@ fn main() -> i32 {
             } else {
                 "-".to_string()
             };
+            let stat = format_stat_long(t.state(), t.task_type());
             println!(
-                "{:>w_pid$} {:>w_ppid$} {:>w_tgid$} {:<4} {:<7} {:<3} {:<w_name$} {}",
+                "{:>w_pid$} {:>w_ppid$} {:>w_tgid$} {:<5} {:<w_cpu$} {:<w_cmd$} {}",
                 t.pid(),
                 t.ppid(),
                 t.tgid(),
-                t.task_type(),
-                t.state(),
-                t.cpu(),
+                stat,
+                format!("CPU{}", t.cpu()),
                 t.name(),
                 exit_str,
                 w_pid = max_pid,
                 w_ppid = max_ppid,
                 w_tgid = max_tgid,
-                w_name = max_name,
+                w_cpu = max_cpu,
+                w_cmd = max_cmd,
             );
         }
-    } else {
-        // Default format: PID TYPE STATE CPU NAME
+    } else if show_threads {
+        // ── Thread format: PID TGID STAT CPU COMMAND ──
         let mut max_pid = 3;
-        let mut max_name = 4;
+        let mut max_tgid = 4;
+        let mut max_cmd = 7;
+        let mut max_cpu = 4;
 
         for t in &tasks {
             max_pid = max_pid.max(format!("{}", t.pid()).len());
-            max_name = max_name.max(t.name().len());
+            max_tgid = max_tgid.max(format!("{}", t.tgid()).len());
+            max_cmd = max_cmd.max(t.name().len());
+            max_cpu = max_cpu.max(format!("CPU{}", t.cpu()).len());
         }
 
         println!(
-            "{:>w_pid$} {:<4} {:<7} {:<3} {:<w_name$}",
+            "{:>w_pid$} {:>w_tgid$} {:<5} {:<w_cpu$} {:<w_cmd$}",
             "PID",
-            "TYPE",
-            "STATE",
+            "TGID",
+            "STAT",
             "CPU",
-            "NAME",
+            "COMMAND",
             w_pid = max_pid,
-            w_name = max_name,
+            w_tgid = max_tgid,
+            w_cpu = max_cpu,
+            w_cmd = max_cmd,
         );
 
         for t in &tasks {
+            let stat = format_stat(t.state());
             println!(
-                "{:>w_pid$} {:<4} {:<7} {:<3} {:<w_name$}",
+                "{:>w_pid$} {:>w_tgid$} {:<5} {:<w_cpu$} {:<w_cmd$}",
                 t.pid(),
-                t.task_type(),
-                t.state(),
-                t.cpu(),
+                t.tgid(),
+                stat,
+                format!("CPU{}", t.cpu()),
                 t.name(),
                 w_pid = max_pid,
-                w_name = max_name,
+                w_tgid = max_tgid,
+                w_cpu = max_cpu,
+                w_cmd = max_cmd,
+            );
+        }
+    } else {
+        // ── Default format: PID STAT CPU COMMAND ──
+        let mut max_pid = 3;
+        let mut max_cmd = 7;
+        let mut max_cpu = 4;
+
+        for t in &tasks {
+            max_pid = max_pid.max(format!("{}", t.pid()).len());
+            max_cmd = max_cmd.max(t.name().len());
+            max_cpu = max_cpu.max(format!("CPU{}", t.cpu()).len());
+        }
+
+        println!(
+            "{:>w_pid$} {:<5} {:<w_cpu$} {:<w_cmd$}",
+            "PID",
+            "STAT",
+            "CPU",
+            "COMMAND",
+            w_pid = max_pid,
+            w_cpu = max_cpu,
+            w_cmd = max_cmd,
+        );
+
+        for t in &tasks {
+            let stat = format_stat(t.state());
+            println!(
+                "{:>w_pid$} {:<5} {:<w_cpu$} {:<w_cmd$}",
+                t.pid(),
+                stat,
+                format!("CPU{}", t.cpu()),
+                t.name(),
+                w_pid = max_pid,
+                w_cpu = max_cpu,
+                w_cmd = max_cmd,
             );
         }
     }

--- a/user/bin/src/stemd/main.rs
+++ b/user/bin/src/stemd/main.rs
@@ -12,7 +12,7 @@
 
 extern crate scarlet_std as std;
 
-use core::{hint::spin_loop, sync::atomic::fence};
+use core::sync::atomic::fence;
 use sbus_client as sbus;
 use std::{
     format,
@@ -1562,15 +1562,6 @@ tty = "/dev/tty0"
             }
         }
     }
-
-    // Start idle thread early so sbusd can run
-    println!("stemd: Starting idle thread");
-    let _idle = thread::spawn(|| {
-        loop {
-            scarlet_std::thread::yield_now();
-            spin_loop();
-        }
-    });
 
     // Phase 2: Register with sbus (now that sbusd should be running)
     println!("stemd: Registering with sbus...");

--- a/user/bin/src/stemd/main.rs
+++ b/user/bin/src/stemd/main.rs
@@ -94,9 +94,20 @@ struct RunningApp {
     exec_path: String,
 }
 
+/// Running service tracking
+#[derive(Debug, Clone)]
+struct RunningService {
+    name: String,
+    pid: i32,
+    exec_path: String,
+}
+
 // Global tracking for running applications
 // Thread-safe using Mutex (static, not mutable)
 static RUNNING_APPS: Mutex<Vec<RunningApp>> = Mutex::new(Vec::new());
+
+// Global tracking for running services
+static RUNNING_SERVICES: Mutex<Vec<RunningService>> = Mutex::new(Vec::new());
 
 // Global sbus connection for receiving method calls
 // Wrapped in Option to handle initialization
@@ -281,6 +292,23 @@ fn remove_running_app_by_pid(pid: i32) -> bool {
 fn find_running_app(app_id: &str) -> Option<RunningApp> {
     let apps = RUNNING_APPS.lock();
     apps.iter().find(|app| app.app_id == app_id).cloned()
+}
+
+fn add_running_service(name: String, pid: i32, exec_path: String) {
+    let mut services = RUNNING_SERVICES.lock();
+    services.push(RunningService {
+        name,
+        pid,
+        exec_path,
+    });
+}
+
+fn remove_running_service_by_pid(pid: i32) -> Option<RunningService> {
+    let mut services = RUNNING_SERVICES.lock();
+    services
+        .iter()
+        .position(|service| service.pid == pid)
+        .map(|pos| services.remove(pos))
 }
 
 /// Focus a window by app_id
@@ -686,6 +714,11 @@ fn launch_service(service: &Service) -> Result<i32, &'static str> {
         }
         pid => {
             // println!("stemd: Service {} started with PID: {}", service.name, pid);
+            add_running_service(service.name.clone(), pid, service.exec.clone());
+            println!(
+                "stemd: Service '{}' launched with PID={} exec={}",
+                service.name, pid, service.exec
+            );
             Ok(pid)
         }
     }
@@ -1681,6 +1714,17 @@ tty = "/dev/tty0"
         if pid < 0 {
             continue;
         }
-        println!("stemd: Reaped child PID={} status={}", pid, status);
+        if let Some(service) = remove_running_service_by_pid(pid) {
+            println!(
+                "stemd: Reaped service PID={} status={} name={} exec={}",
+                pid, status, service.name, service.exec_path
+            );
+            continue;
+        }
+        if remove_running_app_by_pid(pid) {
+            println!("stemd: Reaped app PID={} status={}", pid, status);
+            continue;
+        }
+        println!("stemd: Reaped unknown child PID={} status={}", pid, status);
     }
 }

--- a/user/bin/src/top.rs
+++ b/user/bin/src/top.rs
@@ -1,0 +1,102 @@
+//! `top` — display dynamic real-time view of running tasks.
+//!
+//! In the current Scarlet terminal, escape sequences for screen clearing
+//! are not available, so this shows a single snapshot (like a one-shot `top -b -n 1`).
+//!
+//! Usage: `top`
+
+#![no_std]
+#![no_main]
+
+extern crate scarlet_std as std;
+
+use crate::std::string::ToString;
+use std::task::{self, TaskType};
+use std::{format, println};
+
+#[unsafe(no_mangle)]
+fn main() -> i32 {
+    let tasks = task::info();
+
+    if tasks.is_empty() {
+        println!("No tasks found.");
+        return 0;
+    }
+
+    let total = tasks.len();
+    let running = tasks
+        .iter()
+        .filter(|t| t.state() == std::task::TaskState::Running)
+        .count();
+    let sleeping = tasks
+        .iter()
+        .filter(|t| t.state() == std::task::TaskState::BlockedInterruptible)
+        .count();
+    let zombies = tasks
+        .iter()
+        .filter(|t| t.state() == std::task::TaskState::Zombie)
+        .count();
+    let user_tasks = tasks
+        .iter()
+        .filter(|t| t.task_type() == TaskType::User)
+        .count();
+    let kernel_tasks = tasks
+        .iter()
+        .filter(|t| t.task_type() == TaskType::Kernel)
+        .count();
+
+    // Summary
+    println!(
+        "Tasks: {} total, {} running, {} sleeping, {} zombie",
+        total, running, sleeping, zombies
+    );
+    println!("       {} user, {} kernel", user_tasks, kernel_tasks);
+    println!();
+
+    // Column layout — sorted by PID
+    let mut sorted = tasks;
+    sorted.sort_by_key(|t| t.pid());
+
+    let mut max_pid = 3;
+    let mut max_name = 4;
+
+    for t in &sorted {
+        max_pid = max_pid.max(format!("{}", t.pid()).len());
+        max_name = max_name.max(t.name().len());
+    }
+
+    println!(
+        "{:>w_pid$} {:<4} {:<8} {:<3} {:>5} {:<w_name$} {}",
+        "PID",
+        "TYPE",
+        "STATE",
+        "CPU",
+        "TGID",
+        "COMMAND",
+        "EXIT",
+        w_pid = max_pid,
+        w_name = max_name,
+    );
+
+    for t in &sorted {
+        let exit_str = if t.state() == std::task::TaskState::Zombie {
+            format!("{}", t.exit_status())
+        } else {
+            "  -".to_string()
+        };
+        println!(
+            "{:>w_pid$} {:<4} {:<8} {:<3} {:>5} {:<w_name$} {}",
+            t.pid(),
+            t.task_type(),
+            t.state(),
+            t.cpu(),
+            t.tgid(),
+            t.name(),
+            exit_str,
+            w_pid = max_pid,
+            w_name = max_name,
+        );
+    }
+
+    0
+}

--- a/user/bin/src/top.rs
+++ b/user/bin/src/top.rs
@@ -1,21 +1,101 @@
 //! `top` — display dynamic real-time view of running tasks.
 //!
 //! In the current Scarlet terminal, escape sequences for screen clearing
-//! are not available, so this shows a single snapshot (like a one-shot `top -b -n 1`).
+//! are not available, so this shows a single snapshot (like `top -b -n 1`).
 //!
-//! Usage: `top`
+//! Usage:
+//!   `top`                            — sorted by CPU core (default)
+//!   `top -p` / `top --sort pid`      — sort by PID
+//!   `top -n` / `top --sort name`     — sort by command name
+//!   `top -c` / `top --sort cpu`      — sort by CPU id
+//!   `top -s` / `top --sort state`    — sort by state
+//!   `top -m` / `top --sort mem`      — sort by PID descending (no mem info yet)
+//!
+//! Column descriptions (Linux-esque):
+//!   PID     — Process/Task ID
+//!   USER    — K (kernel) / U (user)
+//!   PR      — Priority placeholder (always '-')
+//!   STAT    — Task state (R/S/D/Z/T)
+//!   CPU     — CPU core the task is on
+//!   TIME+   — Placeholder (not tracked yet)
+//!   COMMAND — Task name / binary path
 
 #![no_std]
 #![no_main]
 
 extern crate scarlet_std as std;
 
-use crate::std::string::ToString;
-use std::task::{self, TaskType};
+use std::string::ToString;
+use std::task::{self, TaskState, TaskType};
 use std::{format, println};
+
+#[derive(Clone, Copy)]
+enum SortKey {
+    Pid,
+    Cpu,
+    Name,
+    State,
+    Type,
+}
+
+fn parse_sort_key(s: &str) -> SortKey {
+    match s {
+        "pid" => SortKey::Pid,
+        "cpu" | "c" => SortKey::Cpu,
+        "name" | "n" => SortKey::Name,
+        "state" | "s" => SortKey::State,
+        "type" => SortKey::Type,
+        _ => SortKey::Cpu,
+    }
+}
+
+fn format_stat(state: TaskState) -> &'static str {
+    match state {
+        TaskState::Running => "R",
+        TaskState::Ready => "R<",
+        TaskState::BlockedInterruptible => "S",
+        TaskState::BlockedUninterruptible => "D",
+        TaskState::Zombie => "Z",
+        TaskState::Terminated => "T",
+        TaskState::NotInitialized => "?",
+    }
+}
+
+fn apply_sort(tasks: &mut [std::task::TaskInfo], key: SortKey) {
+    tasks.sort_by(|a, b| {
+        let primary = match key {
+            SortKey::Pid => a.pid().cmp(&b.pid()),
+            SortKey::Cpu => a.cpu().cmp(&b.cpu()),
+            SortKey::Name => a.name().cmp(b.name()),
+            SortKey::State => format!("{}", a.state()).cmp(&format!("{}", b.state())),
+            SortKey::Type => format!("{}", a.task_type()).cmp(&format!("{}", b.task_type())),
+        };
+        primary.then_with(|| a.pid().cmp(&b.pid()))
+    });
+}
 
 #[unsafe(no_mangle)]
 fn main() -> i32 {
+    let args: std::vec::Vec<std::string::String> = std::env::args().collect();
+
+    // Parse sort key — default: CPU
+    let mut sort_key = SortKey::Cpu;
+    for (i, a) in args.iter().enumerate() {
+        match a.as_str() {
+            "-p" => sort_key = SortKey::Pid,
+            "-n" => sort_key = SortKey::Name,
+            "-c" => sort_key = SortKey::Cpu,
+            "-s" => sort_key = SortKey::State,
+            "-m" => sort_key = SortKey::Pid, // placeholder
+            "--sort" => {
+                if let Some(v) = args.get(i + 1) {
+                    sort_key = parse_sort_key(v);
+                }
+            }
+            _ => {}
+        }
+    }
+
     let tasks = task::info();
 
     if tasks.is_empty() {
@@ -26,15 +106,19 @@ fn main() -> i32 {
     let total = tasks.len();
     let running = tasks
         .iter()
-        .filter(|t| t.state() == std::task::TaskState::Running)
+        .filter(|t| t.state() == TaskState::Running)
         .count();
     let sleeping = tasks
         .iter()
-        .filter(|t| t.state() == std::task::TaskState::BlockedInterruptible)
+        .filter(|t| t.state() == TaskState::BlockedInterruptible)
+        .count();
+    let stopped = tasks
+        .iter()
+        .filter(|t| t.state() == TaskState::Terminated)
         .count();
     let zombies = tasks
         .iter()
-        .filter(|t| t.state() == std::task::TaskState::Zombie)
+        .filter(|t| t.state() == TaskState::Zombie)
         .count();
     let user_tasks = tasks
         .iter()
@@ -45,56 +129,68 @@ fn main() -> i32 {
         .filter(|t| t.task_type() == TaskType::Kernel)
         .count();
 
-    // Summary
+    // ── Summary header (Linux top style) ──
     println!(
-        "Tasks: {} total, {} running, {} sleeping, {} zombie",
-        total, running, sleeping, zombies
+        "Tasks: {:>3} total, {:>3} running, {:>3} sleeping, {:>3} stopped, {:>3} zombie",
+        total, running, sleeping, stopped, zombies
     );
-    println!("       {} user, {} kernel", user_tasks, kernel_tasks);
+    println!("       {:>3} user,  {:>3} kernel", user_tasks, kernel_tasks);
     println!();
 
-    // Column layout — sorted by PID
+    // ── Column layout ──
     let mut sorted = tasks;
-    sorted.sort_by_key(|t| t.pid());
+    apply_sort(&mut sorted, sort_key);
 
     let mut max_pid = 3;
-    let mut max_name = 4;
+    let mut max_cmd = 7;
+    let mut max_cpu = 4;
 
     for t in &sorted {
         max_pid = max_pid.max(format!("{}", t.pid()).len());
-        max_name = max_name.max(t.name().len());
+        max_cmd = max_cmd.max(t.name().len());
+        max_cpu = max_cpu.max(format!("CPU{}", t.cpu()).len());
     }
 
     println!(
-        "{:>w_pid$} {:<4} {:<8} {:<3} {:>5} {:<w_name$} {}",
+        "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:<5} {:<w_cmd$} {}",
         "PID",
-        "TYPE",
-        "STATE",
+        "USER",
+        "PR",
+        "STAT",
         "CPU",
-        "TGID",
+        "TIME+",
         "COMMAND",
-        "EXIT",
+        "TGID",
         w_pid = max_pid,
-        w_name = max_name,
+        w_cpu = max_cpu,
+        w_cmd = max_cmd,
     );
 
     for t in &sorted {
-        let exit_str = if t.state() == std::task::TaskState::Zombie {
+        let user = match t.task_type() {
+            TaskType::Kernel => "K",
+            TaskType::User => "U",
+        };
+        let stat = format_stat(t.state());
+        let exit_str = if t.state() == TaskState::Zombie {
             format!("{}", t.exit_status())
         } else {
             "  -".to_string()
         };
+
         println!(
-            "{:>w_pid$} {:<4} {:<8} {:<3} {:>5} {:<w_name$} {}",
+            "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:<5} {:<w_cmd$} {}",
             t.pid(),
-            t.task_type(),
-            t.state(),
-            t.cpu(),
-            t.tgid(),
+            user,
+            "-", // PR placeholder
+            stat,
+            format!("CPU{}", t.cpu()),
+            exit_str, // TIME+ placeholder — reuse for TGID when zombie
             t.name(),
-            exit_str,
+            t.tgid(),
             w_pid = max_pid,
-            w_name = max_name,
+            w_cpu = max_cpu,
+            w_cmd = max_cmd,
         );
     }
 

--- a/user/lib/std/src/syscall.rs
+++ b/user/lib/std/src/syscall.rs
@@ -23,6 +23,10 @@ pub enum Syscall {
 
     ExitGroup = 23, // Exit all tasks in thread group
 
+    // Process information
+    GetTaskInfoCount = 24, // Number of tasks
+    GetTaskInfoList = 25,  // TaskInfo snapshots
+
     // TLS (Thread Local Storage) Management
     SetTls = 30,
     GetTls = 31,

--- a/user/lib/std/src/task.rs
+++ b/user/lib/std/src/task.rs
@@ -1,4 +1,5 @@
 use crate::boxed::Box;
+use crate::string::ToString;
 use crate::syscall::{Syscall, syscall0, syscall1, syscall2, syscall3, syscall4, syscall5};
 use crate::vec::Vec;
 
@@ -637,4 +638,232 @@ pub enum ShutdownType {
 pub fn shutdown(shutdown_type: ShutdownType) -> ! {
     syscall1(Syscall::Shutdown, shutdown_type as usize);
     unreachable!("shutdown syscall should not return");
+}
+
+// ---------------------------------------------------------------------------
+// Task information (for ps / top)
+// ---------------------------------------------------------------------------
+
+/// Task state, mirroring the kernel `TaskState` discriminant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TaskState {
+    NotInitialized = 0,
+    Ready = 1,
+    Running = 2,
+    BlockedInterruptible = 3,
+    BlockedUninterruptible = 4,
+    Zombie = 5,
+    Terminated = 6,
+}
+
+impl TaskState {
+    /// Parse from the raw kernel discriminant.
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::NotInitialized),
+            1 => Some(Self::Ready),
+            2 => Some(Self::Running),
+            3 => Some(Self::BlockedInterruptible),
+            4 => Some(Self::BlockedUninterruptible),
+            5 => Some(Self::Zombie),
+            6 => Some(Self::Terminated),
+            _ => None,
+        }
+    }
+
+    /// Short human-readable label (fits in fixed-width columns).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::NotInitialized => "NotInit",
+            Self::Ready => "Ready",
+            Self::Running => "Running",
+            Self::BlockedInterruptible => "Sleep",
+            Self::BlockedUninterruptible => "DiskSlp",
+            Self::Zombie => "Zombie",
+            Self::Terminated => "Term",
+        }
+    }
+}
+
+impl core::fmt::Display for TaskState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Whether a task runs in kernel or user mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TaskType {
+    Kernel = 0,
+    User = 1,
+}
+
+impl TaskType {
+    fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::Kernel),
+            1 => Some(Self::User),
+            _ => None,
+        }
+    }
+
+    /// Short label for display.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Kernel => "K",
+            Self::User => "U",
+        }
+    }
+}
+
+impl core::fmt::Display for TaskType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Snapshot of a single task's metadata.
+///
+/// This is the user-space mirror of `kernel::task::TaskInfo`.
+/// Obtained via [`task::info()`] or the lower-level [`task::info_raw()`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::task;
+///
+/// for t in task::info() {
+///     println!("{} {} {} CPU{}", t.pid(), t.name(), t.state(), t.cpu());
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct TaskInfo {
+    pid: usize,
+    ppid: usize,
+    state: TaskState,
+    task_type: TaskType,
+    cpu: u8,
+    exit_status: i32,
+    tgid: usize,
+    name: crate::string::String,
+}
+
+impl TaskInfo {
+    /// Process ID (namespace-local).
+    pub fn pid(&self) -> usize {
+        self.pid
+    }
+    /// Parent PID (0 if none).
+    pub fn ppid(&self) -> usize {
+        self.ppid
+    }
+    /// Current task state.
+    pub fn state(&self) -> TaskState {
+        self.state
+    }
+    /// Whether this is a kernel or user task.
+    pub fn task_type(&self) -> TaskType {
+        self.task_type
+    }
+    /// CPU the task last ran on.
+    pub fn cpu(&self) -> u8 {
+        self.cpu
+    }
+    /// Exit status (meaningful only when `state == Zombie`).
+    pub fn exit_status(&self) -> i32 {
+        self.exit_status
+    }
+    /// Thread-group ID (PID for multi-threaded tasks).
+    pub fn tgid(&self) -> usize {
+        self.tgid
+    }
+    /// Task name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Raw C-layout struct for the syscall boundary
+// ---------------------------------------------------------------------------
+
+/// Opaque raw layout shared with the kernel (`#[repr(C)]`).
+///
+/// Users should prefer [`TaskInfo`] obtained through [`info()`].
+/// This type is public only for advanced use-cases that need zero-copy.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct RawTaskInfo {
+    pub pid: usize,
+    pub ppid: usize,
+    pub state: u8,
+    pub task_type: u8,
+    pub cpu_id: u8,
+    pub _reserved: u8,
+    pub exit_status: i32,
+    pub tgid: usize,
+    pub name: [u8; 64],
+}
+
+impl RawTaskInfo {
+    fn decode(&self) -> TaskInfo {
+        let end = self
+            .name
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(self.name.len());
+        let name = core::str::from_utf8(&self.name[..end])
+            .unwrap_or("<invalid>")
+            .to_string();
+        TaskInfo {
+            pid: self.pid,
+            ppid: self.ppid,
+            state: TaskState::from_u8(self.state).unwrap_or(TaskState::NotInitialized),
+            task_type: TaskType::from_u8(self.task_type).unwrap_or(TaskType::Kernel),
+            cpu: self.cpu_id,
+            exit_status: self.exit_status,
+            tgid: self.tgid,
+            name,
+        }
+    }
+}
+
+/// Collect a snapshot of all task metadata.
+///
+/// This is the primary high-level API — analogous to reading `/proc`
+/// on a Unix system.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::task;
+///
+/// for t in task::info() {
+///     println!("{:>4} {:>4} {:>8} {} CPU{}", t.pid(), t.ppid(), t.state(), t.name(), t.cpu());
+/// }
+/// ```
+pub fn info() -> crate::vec::Vec<TaskInfo> {
+    let raw = info_raw();
+    raw.iter().map(|r| r.decode()).collect()
+}
+
+/// Collect raw task info snapshots (zero-allocation decode deferred).
+///
+/// Prefer [`info()`] for ergonomics. Use this when you need maximum
+/// performance or want to decode only a subset.
+pub fn info_raw() -> crate::vec::Vec<RawTaskInfo> {
+    let total = syscall0(Syscall::GetTaskInfoCount);
+    let mut buf = crate::vec![RawTaskInfo {
+        pid: 0, ppid: 0, state: 0, task_type: 0, cpu_id: 0,
+        _reserved: 0, exit_status: 0, tgid: 0, name: [0; 64],
+    }; total];
+    let n = syscall2(
+        Syscall::GetTaskInfoList,
+        buf.as_mut_ptr() as usize,
+        buf.len(),
+    );
+    buf.truncate(n);
+    buf
 }


### PR DESCRIPTION
This pull request makes significant improvements to architecture code separation, simplifies interrupt management in device drivers, and refactors kernel scheduling and task management APIs for clarity and maintainability. It also updates documentation to reflect new architectural requirements and adjusts QEMU scripts to better utilize available CPU cores.

**Architecture and Documentation Updates:**

* Enforces strict separation of architecture-specific code by requiring all `#[cfg(target_arch)]` logic to reside in `kernel/src/arch/{riscv64,aarch64}/`, with a unified public API exposed via `crate::arch::*`. Both architectures must implement the same API, even if some functions are no-ops. Documentation in `AGENTS.md` updated accordingly.

**Kernel Scheduling and Task Management Refactor:**

* Refactors kernel scheduler APIs:
  - Replaces `get_scheduler().schedule(trapframe)` with a direct `schedule(trapframe)` call in Linux syscalls and process management code.
  - Replaces `get_scheduler().get_task_by_id` with `get_task_by_id` and introduces explicit task registration and queueing (`register_task`, `enqueue_task`, etc.) in `sys_clone` and related logic.
  - Ensures correct marking and unmarking of blocked tasks, and proper manipulation of ready queues during signal handling. [[1]](diffhunk://#diff-5f23e773175792feec01de2723672fba09a814d048ef561a40ce1c74b7ad782cL84-R84) [[2]](diffhunk://#diff-5f23e773175792feec01de2723672fba09a814d048ef561a40ce1c74b7ad782cR110-R121) [[3]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L11-R11) [[4]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L938-R938) [[5]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L1042-R1042) [[6]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L1168-R1168) [[7]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L1253-R1253) [[8]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L1391-R1391) [[9]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L2784-R2784) [[10]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L2875-R2875) [[11]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL3-R4) [[12]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL81-R90) [[13]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL563-R563) [[14]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL576-R587) [[15]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL606-R606) [[16]](diffhunk://#diff-74fcaf4192ae87d7847cab15e2393859d93a13dc7bdbe83fb03f479aa1b51e24L11-R11) [[17]](diffhunk://#diff-74fcaf4192ae87d7847cab15e2393859d93a13dc7bdbe83fb03f479aa1b51e24L1168-R1168) [[18]](diffhunk://#diff-a37667a54bf6d122af0920f2c87bdb462d406c9e6a227742339a2390afea142bL938-R938)

**Interrupt Management Simplification in Drivers:**

* Removes the use of `InterruptManager::with_manager` in device drivers, replacing it with direct calls to `scarlet::interrupt` functions for registering and enabling interrupts. This streamlines the interrupt registration process and reduces indirection. [[1]](diffhunk://#diff-bde771c0f9821a0b75e8a760627dd94b9275bdc0603da839174b014c3a816345L20-R20) [[2]](diffhunk://#diff-bde771c0f9821a0b75e8a760627dd94b9275bdc0603da839174b014c3a816345L231-R234) [[3]](diffhunk://#diff-014966b7b0b6c344f55fef2f5f1b5556185fdb9232c77722131f3c25e58a32d9L17-R17) [[4]](diffhunk://#diff-014966b7b0b6c344f55fef2f5f1b5556185fdb9232c77722131f3c25e58a32d9L556-R558) [[5]](diffhunk://#diff-acfe90dcf1143f38dd5e5db001570b68ad6ed8d8e31476ed9ab45651faea60f8L24-R24) [[6]](diffhunk://#diff-acfe90dcf1143f38dd5e5db001570b68ad6ed8d8e31476ed9ab45651faea60f8L119-R119) [[7]](diffhunk://#diff-acfe90dcf1143f38dd5e5db001570b68ad6ed8d8e31476ed9ab45651faea60f8L373-R375)

**QEMU Script Improvements:**

* Updates QEMU run scripts to increase the number of virtual CPUs: `-smp 4` for AArch64 and `-smp 16` for RISC-V, improving multicore testing and development. [[1]](diffhunk://#diff-4f260356ff626aa4d07e357a8399f4d0c6a8325a0d94c14b8d6a1358aa0630a1R164) [[2]](diffhunk://#diff-e253756ce7105aab11dc2207e2b09a962a70b33de25a4223475b554232098f43R130)

**Miscellaneous:**

* Minor bug fixes and cleanups in task cloning and process exit handling for correctness and clarity. [[1]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL563-R563) [[2]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL576-R587) [[3]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL606-R606)

Let me know if you want a deeper dive into any of these areas!This pull request focuses on improving code organization, consistency, and maintainability across the kernel and drivers. The most significant changes are the refactoring of interrupt management APIs, scheduler API usage, and enforcing a clearer separation of architecture-specific code. Additionally, QEMU run scripts are updated for multi-core support.

**Interrupt Management API Refactor:**

* Refactored all drivers (`apple-pinctrl`, `apple-aic`, `s5l-uart`) to use the new `scarlet::interrupt::*` free functions (e.g., `register_interrupt_device`, `enable_external_interrupt`) instead of the `InterruptManager` trait/object pattern. This simplifies interrupt registration and handling throughout the codebase. [[1]](diffhunk://#diff-bde771c0f9821a0b75e8a760627dd94b9275bdc0603da839174b014c3a816345L20-R20) [[2]](diffhunk://#diff-bde771c0f9821a0b75e8a760627dd94b9275bdc0603da839174b014c3a816345L231-R234) [[3]](diffhunk://#diff-014966b7b0b6c344f55fef2f5f1b5556185fdb9232c77722131f3c25e58a32d9L17-R17) [[4]](diffhunk://#diff-014966b7b0b6c344f55fef2f5f1b5556185fdb9232c77722131f3c25e58a32d9L556-R558) [[5]](diffhunk://#diff-acfe90dcf1143f38dd5e5db001570b68ad6ed8d8e31476ed9ab45651faea60f8L24-R24) [[6]](diffhunk://#diff-acfe90dcf1143f38dd5e5db001570b68ad6ed8d8e31476ed9ab45651faea60f8L119-R119) [[7]](diffhunk://#diff-acfe90dcf1143f38dd5e5db001570b68ad6ed8d8e31476ed9ab45651faea60f8L373-R375)

**Scheduler API Refactor:**

* Replaced direct usage of `get_scheduler()` and its methods with new free functions (`schedule`, `add_task`, `get_task_by_id`, `wake_task`, etc.) in the scheduler module across all Linux ABI syscall implementations and related logic. This leads to a more functional and less stateful interface for scheduling and task management. [[1]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L11-R11) [[2]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L938-R938) [[3]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L1042-R1042) [[4]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L1168-R1168) [[5]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L1253-R1253) [[6]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L1391-R1391) [[7]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L2784-R2784) [[8]](diffhunk://#diff-3cbeefe4ed1f6317f67e3ef2e388a5606ecd8bd0aca5bb9c4e43e03623f1dcd3L2875-R2875) [[9]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL4-R4) [[10]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL81-R90) [[11]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL576-R586) [[12]](diffhunk://#diff-1fd1ff187e407d4f7f159a82c4eae48a8ba5daa840bb6079680668b37a41a5cdL606-R605) [[13]](diffhunk://#diff-74fcaf4192ae87d7847cab15e2393859d93a13dc7bdbe83fb03f479aa1b51e24L11-R11) [[14]](diffhunk://#diff-74fcaf4192ae87d7847cab15e2393859d93a13dc7bdbe83fb03f479aa1b51e24L1168-R1168) [[15]](diffhunk://#diff-a7438e7c64f4d709964ade1dff33891bd62fcd740a9cbfef16480d6705a1c8a6L13-R13) [[16]](diffhunk://#diff-a7438e7c64f4d709964ade1dff33891bd62fcd740a9cbfef16480d6705a1c8a6L213-R213) [[17]](diffhunk://#diff-a37667a54bf6d122af0920f2c87bdb462d406c9e6a227742339a2390afea142bL938-R938) [[18]](diffhunk://#diff-a37667a54bf6d122af0920f2c87bdb462d406c9e6a227742339a2390afea142bL1042-R1042) [[19]](diffhunk://#diff-a37667a54bf6d122af0920f2c87bdb462d406c9e6a227742339a2390afea142bL1168-R1168)

**Architecture-Specific Code Organization:**

* Updated documentation to enforce that architecture-specific logic must reside in `kernel/src/arch/{riscv64,aarch64}/` and not in common code, and that both architectures must expose a unified public API via `crate::arch::*`. This ensures a clean separation and easier cross-arch maintenance.

**Task State and Signal Handling Improvements:**

* Enhanced task state transitions in signal handling by explicitly marking tasks as blocked/unblocked and managing their presence in ready queues, improving correctness and clarity of task scheduling. [[1]](diffhunk://#diff-5f23e773175792feec01de2723672fba09a814d048ef561a40ce1c74b7ad782cL84-R84) [[2]](diffhunk://#diff-5f23e773175792feec01de2723672fba09a814d048ef561a40ce1c74b7ad782cR110-R121)

**QEMU Run Script Updates:**

* Added `-smp 2` to both AArch64 and RISC-V QEMU run scripts, enabling multi-core emulation for better testing and development. [[1]](diffhunk://#diff-4f260356ff626aa4d07e357a8399f4d0c6a8325a0d94c14b8d6a1358aa0630a1R164) [[2]](diffhunk://#diff-e253756ce7105aab11dc2207e2b09a962a70b33de25a4223475b554232098f43R130)