### PR TITLE
feat: enhance AArch64 EFI firmware handling in run scripts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -207,8 +207,15 @@
             # EFI firmware paths (consumed by run/test scripts via env vars)
             SCARLET_EFI_CODE_RV64 = "${ovmf-riscv64-pflash}/FV/RISCV_VIRT_CODE.fd";
             SCARLET_EFI_VARS_RV64 = "${ovmf-riscv64-pflash}/FV/RISCV_VIRT_VARS.fd";
-            SCARLET_EFI_CODE_ARM64 = "${ovmf-aarch64-pflash}/FV/QEMU_EFI.fd";
-            SCARLET_EFI_VARS_ARM64 = "${ovmf-aarch64-pflash}/FV/QEMU_VARS.fd";
+
+            # AArch64 needs two firmware tracks today:
+            # - HVF + GICv3 works with QEMU's bundled ArmVirt firmware.
+            # - TCG + EL2/VHE currently needs the self-built edk2-stable202502
+            #   firmware until the Limine/EDK2 handoff issue is resolved.
+            SCARLET_EFI_CODE_ARM64_HVF = "${pkgs.qemu}/share/qemu/edk2-aarch64-code.fd";
+            SCARLET_EFI_VARS_ARM64_HVF = "${pkgs.qemu}/share/qemu/edk2-arm-vars.fd";
+            SCARLET_EFI_CODE_ARM64_EL2 = "${ovmf-aarch64-pflash}/FV/QEMU_EFI.fd";
+            SCARLET_EFI_VARS_ARM64_EL2 = "${ovmf-aarch64-pflash}/FV/QEMU_VARS.fd";
 
             CARGO_NET_GIT_FETCH_WITH_CLI = "true";
 

--- a/flake.nix
+++ b/flake.nix
@@ -216,6 +216,8 @@
             SCARLET_EFI_VARS_ARM64_HVF = "${pkgs.qemu}/share/qemu/edk2-arm-vars.fd";
             SCARLET_EFI_CODE_ARM64_EL2 = "${ovmf-aarch64-pflash}/FV/QEMU_EFI.fd";
             SCARLET_EFI_VARS_ARM64_EL2 = "${ovmf-aarch64-pflash}/FV/QEMU_VARS.fd";
+            SCARLET_EFI_CODE_ARM64 = "${ovmf-aarch64-pflash}/FV/QEMU_EFI.fd";
+            SCARLET_EFI_VARS_ARM64 = "${ovmf-aarch64-pflash}/FV/QEMU_VARS.fd";
 
             CARGO_NET_GIT_FETCH_WITH_CLI = "true";
 

--- a/kernel/tools/test_aarch64.sh
+++ b/kernel/tools/test_aarch64.sh
@@ -83,7 +83,11 @@ if [ ! -f "$BOOT_IMAGE" ]; then
 fi
 
 find_efi_code() {
-    # Environment variable takes priority (for Nix devShell etc.)
+    if [ -n "${SCARLET_EFI_CODE_ARM64_EL2:-}" ] && [ -f "${SCARLET_EFI_CODE_ARM64_EL2}" ]; then
+        printf '%s\n' "${SCARLET_EFI_CODE_ARM64_EL2}"
+        return 0
+    fi
+    # Legacy environment variable takes priority for older devShells.
     if [ -n "${SCARLET_EFI_CODE_ARM64:-}" ] && [ -f "${SCARLET_EFI_CODE_ARM64}" ]; then
         printf '%s\n' "${SCARLET_EFI_CODE_ARM64}"
         return 0
@@ -102,7 +106,11 @@ find_efi_code() {
 }
 
 find_efi_vars_template() {
-    # Environment variable takes priority (for Nix devShell etc.)
+    if [ -n "${SCARLET_EFI_VARS_ARM64_EL2:-}" ] && [ -f "${SCARLET_EFI_VARS_ARM64_EL2}" ]; then
+        printf '%s\n' "${SCARLET_EFI_VARS_ARM64_EL2}"
+        return 0
+    fi
+    # Legacy environment variable takes priority for older devShells.
     if [ -n "${SCARLET_EFI_VARS_ARM64:-}" ] && [ -f "${SCARLET_EFI_VARS_ARM64}" ]; then
         printf '%s\n' "${SCARLET_EFI_VARS_ARM64}"
         return 0
@@ -120,6 +128,15 @@ find_efi_vars_template() {
     return 1
 }
 
+ensure_efi_vars_writable() {
+    local vars_file="$1"
+
+    if ! chmod u+w "$vars_file" 2>/dev/null || [ ! -w "$vars_file" ]; then
+        echo "Error: AArch64 EFI vars runtime file is not writable: $vars_file"
+        exit 1
+    fi
+}
+
 EFI_CODE="$(find_efi_code || true)"
 EFI_VARS_TEMPLATE="$(find_efi_vars_template || true)"
 EFI_VARS_RUNTIME="$(mktemp "$PROJECT_ROOT/mkfs/dist/AAVMF_VARS.run.XXXXXX.fd")"
@@ -135,6 +152,7 @@ if [ -z "$EFI_VARS_TEMPLATE" ]; then
 fi
 
 cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
+ensure_efi_vars_writable "$EFI_VARS_RUNTIME"
 trap 'rm -f "$EFI_VARS_RUNTIME" "$TEMP_OUTPUT"' EXIT
 
 qemu-system-aarch64 \

--- a/projects/aarch64-limine-full/tools/run_aarch64.sh
+++ b/projects/aarch64-limine-full/tools/run_aarch64.sh
@@ -125,7 +125,14 @@ fi
 TEMP_OUTPUT=$(mktemp)
 
 find_efi_code() {
-    # Environment variable takes priority (for Nix devShell etc.)
+    if [ "$QEMU_ACCEL" = "hvf" ] && [ -n "${SCARLET_EFI_CODE_ARM64_HVF:-}" ] && [ -f "${SCARLET_EFI_CODE_ARM64_HVF}" ]; then
+        printf '%s\n' "${SCARLET_EFI_CODE_ARM64_HVF}"
+        return 0
+    fi
+    if [ -n "${SCARLET_EFI_CODE_ARM64_EL2:-}" ] && [ -f "${SCARLET_EFI_CODE_ARM64_EL2}" ]; then
+        printf '%s\n' "${SCARLET_EFI_CODE_ARM64_EL2}"
+        return 0
+    fi
     if [ -n "${SCARLET_EFI_CODE_ARM64:-}" ] && [ -f "${SCARLET_EFI_CODE_ARM64}" ]; then
         printf '%s\n' "${SCARLET_EFI_CODE_ARM64}"
         return 0
@@ -144,7 +151,14 @@ find_efi_code() {
 }
 
 find_efi_vars_template() {
-    # Environment variable takes priority (for Nix devShell etc.)
+    if [ "$QEMU_ACCEL" = "hvf" ] && [ -n "${SCARLET_EFI_VARS_ARM64_HVF:-}" ] && [ -f "${SCARLET_EFI_VARS_ARM64_HVF}" ]; then
+        printf '%s\n' "${SCARLET_EFI_VARS_ARM64_HVF}"
+        return 0
+    fi
+    if [ -n "${SCARLET_EFI_VARS_ARM64_EL2:-}" ] && [ -f "${SCARLET_EFI_VARS_ARM64_EL2}" ]; then
+        printf '%s\n' "${SCARLET_EFI_VARS_ARM64_EL2}"
+        return 0
+    fi
     if [ -n "${SCARLET_EFI_VARS_ARM64:-}" ] && [ -f "${SCARLET_EFI_VARS_ARM64}" ]; then
         printf '%s\n' "${SCARLET_EFI_VARS_ARM64}"
         return 0
@@ -176,16 +190,23 @@ if [ -z "$EFI_VARS_TEMPLATE" ] && [ -z "${SCARLET_EFI_VARS_RUNTIME_ARM64:-}" ]; 
     exit 1
 fi
 
+echo "Using AArch64 EFI code: $EFI_CODE"
+if [ -n "$EFI_VARS_TEMPLATE" ]; then
+    echo "Using AArch64 EFI vars template: $EFI_VARS_TEMPLATE"
+fi
+
 if [ -n "${SCARLET_EFI_VARS_RUNTIME_ARM64:-}" ]; then
     EFI_VARS_RUNTIME="$SCARLET_EFI_VARS_RUNTIME_ARM64"
 elif [ "${SCARLET_EFI_VARS_PERSIST:-0}" = "1" ] || [ "${SCARLET_EFI_VARS_PERSIST:-}" = "true" ]; then
     EFI_VARS_RUNTIME="$EFI_VARS_PERSISTENT"
     if [ ! -f "$EFI_VARS_RUNTIME" ]; then
         cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
+        chmod u+w "$EFI_VARS_RUNTIME"
     fi
 else
     EFI_VARS_RUNTIME="$(mktemp "$PROJECT_ROOT/mkfs/dist/AAVMF_VARS.run.XXXXXX.fd")"
     cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
+    chmod u+w "$EFI_VARS_RUNTIME"
     trap 'rm -f "$EFI_VARS_RUNTIME"' EXIT
 fi
 

--- a/projects/aarch64-limine-full/tools/run_aarch64.sh
+++ b/projects/aarch64-limine-full/tools/run_aarch64.sh
@@ -176,6 +176,15 @@ find_efi_vars_template() {
     return 1
 }
 
+ensure_efi_vars_writable() {
+    local vars_file="$1"
+
+    if ! chmod u+w "$vars_file" 2>/dev/null || [ ! -w "$vars_file" ]; then
+        echo "Error: AArch64 EFI vars runtime file is not writable: $vars_file"
+        exit 1
+    fi
+}
+
 EFI_CODE="$(find_efi_code || true)"
 EFI_VARS_TEMPLATE="$(find_efi_vars_template || true)"
 EFI_VARS_PERSISTENT="${SCARLET_EFI_VARS_RUNTIME_ARM64:-$PROJECT_ROOT/mkfs/dist/AAVMF_VARS.fd}"
@@ -201,14 +210,14 @@ elif [ "${SCARLET_EFI_VARS_PERSIST:-0}" = "1" ] || [ "${SCARLET_EFI_VARS_PERSIST
     EFI_VARS_RUNTIME="$EFI_VARS_PERSISTENT"
     if [ ! -f "$EFI_VARS_RUNTIME" ]; then
         cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
-        chmod u+w "$EFI_VARS_RUNTIME"
     fi
 else
     EFI_VARS_RUNTIME="$(mktemp "$PROJECT_ROOT/mkfs/dist/AAVMF_VARS.run.XXXXXX.fd")"
     cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
-    chmod u+w "$EFI_VARS_RUNTIME"
     trap 'rm -f "$EFI_VARS_RUNTIME"' EXIT
 fi
+
+ensure_efi_vars_writable "$EFI_VARS_RUNTIME"
 
 QEMU_FRAMEBUFFER_ARGS=()
 case "$QEMU_FRAMEBUFFER" in

--- a/projects/aarch64-limine-microvm/tools/run_aarch64.sh
+++ b/projects/aarch64-limine-microvm/tools/run_aarch64.sh
@@ -179,6 +179,15 @@ find_efi_vars_template() {
     return 1
 }
 
+ensure_efi_vars_writable() {
+    local vars_file="$1"
+
+    if ! chmod u+w "$vars_file" 2>/dev/null || [ ! -w "$vars_file" ]; then
+        echo "Error: AArch64 EFI vars runtime file is not writable: $vars_file"
+        exit 1
+    fi
+}
+
 EFI_CODE="$(find_efi_code || true)"
 EFI_VARS_TEMPLATE="$(find_efi_vars_template || true)"
 EFI_VARS_PERSISTENT="$PROJECT_DIR/.scarlet/images/AAVMF_VARS.fd"
@@ -227,13 +236,13 @@ if [ "${SCARLET_EFI_VARS_PERSIST:-0}" = "1" ] || [ "${SCARLET_EFI_VARS_PERSIST:-
     EFI_VARS_RUNTIME="$EFI_VARS_PERSISTENT"
     if [ ! -f "$EFI_VARS_RUNTIME" ]; then
         cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
-        chmod u+w "$EFI_VARS_RUNTIME"
     fi
+    ensure_efi_vars_writable "$EFI_VARS_RUNTIME"
     set_efi_timeout_zero "$EFI_VARS_RUNTIME"
 else
     EFI_VARS_RUNTIME="$(mktemp "$PROJECT_DIR/.scarlet/images/AAVMF_VARS.run.XXXXXX.fd")"
     cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
-    chmod u+w "$EFI_VARS_RUNTIME"
+    ensure_efi_vars_writable "$EFI_VARS_RUNTIME"
     set_efi_timeout_zero "$EFI_VARS_RUNTIME"
     trap 'rm -f "$EFI_VARS_RUNTIME"' EXIT
 fi

--- a/projects/aarch64-limine-microvm/tools/run_aarch64.sh
+++ b/projects/aarch64-limine-microvm/tools/run_aarch64.sh
@@ -128,6 +128,14 @@ fi
 TEMP_OUTPUT=$(mktemp)
 
 find_efi_code() {
+    if [ "$QEMU_ACCEL" = "hvf" ] && [ -n "${SCARLET_EFI_CODE_ARM64_HVF:-}" ] && [ -f "${SCARLET_EFI_CODE_ARM64_HVF}" ]; then
+        printf '%s\n' "${SCARLET_EFI_CODE_ARM64_HVF}"
+        return 0
+    fi
+    if [ -n "${SCARLET_EFI_CODE_ARM64_EL2:-}" ] && [ -f "${SCARLET_EFI_CODE_ARM64_EL2}" ]; then
+        printf '%s\n' "${SCARLET_EFI_CODE_ARM64_EL2}"
+        return 0
+    fi
     if [ -n "${SCARLET_EFI_CODE_ARM64:-}" ] && [ -f "${SCARLET_EFI_CODE_ARM64}" ]; then
         printf '%s\n' "${SCARLET_EFI_CODE_ARM64}"
         return 0
@@ -146,6 +154,14 @@ find_efi_code() {
 }
 
 find_efi_vars_template() {
+    if [ "$QEMU_ACCEL" = "hvf" ] && [ -n "${SCARLET_EFI_VARS_ARM64_HVF:-}" ] && [ -f "${SCARLET_EFI_VARS_ARM64_HVF}" ]; then
+        printf '%s\n' "${SCARLET_EFI_VARS_ARM64_HVF}"
+        return 0
+    fi
+    if [ -n "${SCARLET_EFI_VARS_ARM64_EL2:-}" ] && [ -f "${SCARLET_EFI_VARS_ARM64_EL2}" ]; then
+        printf '%s\n' "${SCARLET_EFI_VARS_ARM64_EL2}"
+        return 0
+    fi
     if [ -n "${SCARLET_EFI_VARS_ARM64:-}" ] && [ -f "${SCARLET_EFI_VARS_ARM64}" ]; then
         printf '%s\n' "${SCARLET_EFI_VARS_ARM64}"
         return 0
@@ -204,15 +220,20 @@ if [ -z "$EFI_VARS_TEMPLATE" ]; then
     exit 1
 fi
 
+echo "Using AArch64 EFI code: $EFI_CODE"
+echo "Using AArch64 EFI vars template: $EFI_VARS_TEMPLATE"
+
 if [ "${SCARLET_EFI_VARS_PERSIST:-0}" = "1" ] || [ "${SCARLET_EFI_VARS_PERSIST:-}" = "true" ]; then
     EFI_VARS_RUNTIME="$EFI_VARS_PERSISTENT"
     if [ ! -f "$EFI_VARS_RUNTIME" ]; then
         cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
+        chmod u+w "$EFI_VARS_RUNTIME"
     fi
     set_efi_timeout_zero "$EFI_VARS_RUNTIME"
 else
     EFI_VARS_RUNTIME="$(mktemp "$PROJECT_DIR/.scarlet/images/AAVMF_VARS.run.XXXXXX.fd")"
     cp "$EFI_VARS_TEMPLATE" "$EFI_VARS_RUNTIME"
+    chmod u+w "$EFI_VARS_RUNTIME"
     set_efi_timeout_zero "$EFI_VARS_RUNTIME"
     trap 'rm -f "$EFI_VARS_RUNTIME"' EXIT
 fi


### PR DESCRIPTION
This pull request updates the way AArch64 EFI firmware is selected and handled for QEMU-based development and testing. It introduces support for selecting different firmware images depending on the QEMU accelerator (HVF or TCG/EL2), and ensures correct permissions and improved logging for firmware variable files. The changes are mainly focused on improving compatibility and developer experience when running AArch64 virtual machines.

**AArch64 EFI firmware selection improvements:**

* In `flake.nix`, the single `SCARLET_EFI_CODE_ARM64` and `SCARLET_EFI_VARS_ARM64` variables are replaced with separate variables for HVF (`SCARLET_EFI_CODE_ARM64_HVF`, `SCARLET_EFI_VARS_ARM64_HVF`) and EL2 (`SCARLET_EFI_CODE_ARM64_EL2`, `SCARLET_EFI_VARS_ARM64_EL2`) firmware tracks, allowing the scripts to pick the correct firmware based on the QEMU accelerator.

* Both `projects/aarch64-limine-full/tools/run_aarch64.sh` and `projects/aarch64-limine-microvm/tools/run_aarch64.sh` are updated so their `find_efi_code` and `find_efi_vars_template` functions prioritize the new HVF and EL2-specific environment variables, falling back to the legacy variable if needed. [[1]](diffhunk://#diff-babc9a2d40127e9923a39a5c0bf89acfebb25e78e95104561ff15020e622e4d0L128-R135) [[2]](diffhunk://#diff-babc9a2d40127e9923a39a5c0bf89acfebb25e78e95104561ff15020e622e4d0L147-R161) [[3]](diffhunk://#diff-06af9cbb0fe15724c4333adbdbe86d2c424648f66d998e733eddf06092491899R131-R138) [[4]](diffhunk://#diff-06af9cbb0fe15724c4333adbdbe86d2c424648f66d998e733eddf06092491899R157-R164)

**Developer experience and reliability improvements:**

* The scripts now print which AArch64 EFI code and vars template files are being used, making it easier to debug firmware selection issues. [[1]](diffhunk://#diff-babc9a2d40127e9923a39a5c0bf89acfebb25e78e95104561ff15020e622e4d0R193-R209) [[2]](diffhunk://#diff-06af9cbb0fe15724c4333adbdbe86d2c424648f66d998e733eddf06092491899R223-R236)

* When copying the EFI vars template to create a runtime file, the scripts explicitly set the file to be user-writable, preventing potential permission errors during emulation. [[1]](diffhunk://#diff-babc9a2d40127e9923a39a5c0bf89acfebb25e78e95104561ff15020e622e4d0R193-R209) [[2]](diffhunk://#diff-06af9cbb0fe15724c4333adbdbe86d2c424648f66d998e733eddf06092491899R223-R236)