### PR TITLE
Refactor handle duplication and enhance task management

### DIFF
--- a/kernel/src/abi/linux/device/kvm/aarch64.rs
+++ b/kernel/src/abi/linux/device/kvm/aarch64.rs
@@ -1,12 +1,11 @@
 //! AArch64 KVM register conversion and arch-specific hooks
 
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU64, Ordering};
 use spin::{Once, RwLock};
 
 use crate::arch::hv::reg_index::reg;
-use crate::hypervisor::VcpuRef;
+use crate::hypervisor::VcpuObject;
 use crate::hypervisor::types::VmExit;
 
 use super::{KVM_EXIT_SHUTDOWN, KVM_EXIT_SYSTEM_EVENT, KvmRun};
@@ -105,7 +104,7 @@ pub enum FirmwareCallResult {
     ForwardToUserspace,
 }
 
-fn finish_smccc_function_call(vcpu: &VcpuRef) {
+fn finish_smccc_function_call(vcpu: &dyn VcpuObject) {
     let pc = vcpu.get_reg(reg::PC).unwrap_or(0);
     let helper_pc = SMCCC_HELPER_RETURN_PC.load(Ordering::Acquire);
     let x8 = vcpu.get_reg(reg::X8).unwrap_or(0);
@@ -215,7 +214,7 @@ impl Default for KvmArmVcpuSysregState {
 }
 
 struct KvmArmVcpuSysregEntry {
-    vcpu: VcpuRef,
+    vcpu_key: usize,
     state: KvmArmVcpuSysregState,
 }
 
@@ -225,14 +224,18 @@ fn get_sysreg_states() -> &'static RwLock<Vec<KvmArmVcpuSysregEntry>> {
     KVM_ARM_SYSREG_STATES.call_once(|| RwLock::new(Vec::new()))
 }
 
-fn with_sysreg_state<R>(vcpu: &VcpuRef, f: impl FnOnce(&mut KvmArmVcpuSysregState) -> R) -> R {
+fn with_sysreg_state<R>(
+    vcpu: &dyn VcpuObject,
+    f: impl FnOnce(&mut KvmArmVcpuSysregState) -> R,
+) -> R {
+    let key = super::vcpu_key(vcpu);
     let mut states = get_sysreg_states().write();
-    if let Some(entry) = states.iter_mut().find(|e| Arc::ptr_eq(&e.vcpu, vcpu)) {
+    if let Some(entry) = states.iter_mut().find(|e| e.vcpu_key == key) {
         return f(&mut entry.state);
     }
 
     states.push(KvmArmVcpuSysregEntry {
-        vcpu: Arc::clone(vcpu),
+        vcpu_key: key,
         state: KvmArmVcpuSysregState::default(),
     });
 
@@ -247,7 +250,7 @@ fn with_sysreg_state<R>(vcpu: &VcpuRef, f: impl FnOnce(&mut KvmArmVcpuSysregStat
 // Public register API (used by shared KVM ioctl dispatch)
 // ---------------------------------------------------------------------------
 
-pub fn read_regs_to_kvm(vcpu: &VcpuRef) -> KvmRegs {
+pub fn read_regs_to_kvm(vcpu: &dyn VcpuObject) -> KvmRegs {
     let mut regs = [0u64; 31];
     for (i, slot) in regs.iter_mut().enumerate() {
         *slot = vcpu.get_reg(i as u32).unwrap_or(0);
@@ -265,7 +268,7 @@ pub fn read_regs_to_kvm(vcpu: &VcpuRef) -> KvmRegs {
     }
 }
 
-pub fn write_kvm_to_regs(vcpu: &VcpuRef, kvm_regs: &KvmRegs) {
+pub fn write_kvm_to_regs(vcpu: &dyn VcpuObject, kvm_regs: &KvmRegs) {
     for (i, value) in kvm_regs.regs.iter().enumerate() {
         let _ = vcpu.set_reg(i as u32, *value);
     }
@@ -274,7 +277,7 @@ pub fn write_kvm_to_regs(vcpu: &VcpuRef, kvm_regs: &KvmRegs) {
     let _ = vcpu.set_reg(reg::PSTATE, kvm_regs.pstate);
 }
 
-pub fn complete_mmio_read(vcpu: &VcpuRef, target_reg: u8, size: u8, value: u64) {
+pub fn complete_mmio_read(vcpu: &dyn VcpuObject, target_reg: u8, size: u8, value: u64) {
     if target_reg >= 31 {
         return;
     }
@@ -288,7 +291,7 @@ pub fn complete_mmio_read(vcpu: &VcpuRef, target_reg: u8, size: u8, value: u64) 
     let _ = vcpu.set_reg(target_reg as u32, value & mask);
 }
 
-pub fn get_one_reg(vcpu: &VcpuRef, id: u64) -> Result<u64, ()> {
+pub fn get_one_reg(vcpu: &dyn VcpuObject, id: u64) -> Result<u64, ()> {
     validate_one_reg_id(id)?;
 
     match kvm_reg_type(id) {
@@ -299,7 +302,7 @@ pub fn get_one_reg(vcpu: &VcpuRef, id: u64) -> Result<u64, ()> {
     }
 }
 
-pub fn set_one_reg(vcpu: &VcpuRef, id: u64, value: u64) -> Result<(), ()> {
+pub fn set_one_reg(vcpu: &dyn VcpuObject, id: u64, value: u64) -> Result<(), ()> {
     validate_one_reg_id(id)?;
 
     match kvm_reg_type(id) {
@@ -329,7 +332,7 @@ fn set_one_fw_reg(id: u64, value: u64) -> Result<(), ()> {
     }
 }
 
-fn get_one_core_reg(vcpu: &VcpuRef, index: u64) -> Result<u64, ()> {
+fn get_one_core_reg(vcpu: &dyn VcpuObject, index: u64) -> Result<u64, ()> {
     match index {
         idx if idx <= 60 && idx % 2 == 0 => vcpu.get_reg((idx / 2) as u32).map_err(|_| ()),
         KVM_CORE_REGS_SP => Ok(with_sysreg_state(vcpu, |s| s.sp_el0)),
@@ -352,7 +355,7 @@ fn get_one_core_reg(vcpu: &VcpuRef, index: u64) -> Result<u64, ()> {
     }
 }
 
-fn set_one_core_reg(vcpu: &VcpuRef, index: u64, value: u64) -> Result<(), ()> {
+fn set_one_core_reg(vcpu: &dyn VcpuObject, index: u64, value: u64) -> Result<(), ()> {
     match index {
         idx if idx <= 60 && idx % 2 == 0 => vcpu.set_reg((idx / 2) as u32, value).map_err(|_| ()),
         KVM_CORE_REGS_SP => {
@@ -380,7 +383,7 @@ fn set_one_core_reg(vcpu: &VcpuRef, index: u64, value: u64) -> Result<(), ()> {
 }
 
 /// Map a decoded sysreg ID to a readable value. Returns Err for unknown regs.
-fn get_one_sysreg(vcpu: &VcpuRef, id: u64) -> Result<u64, ()> {
+fn get_one_sysreg(vcpu: &dyn VcpuObject, id: u64) -> Result<u64, ()> {
     match id {
         SYSREG_CNTV_CTL_EL0 => vcpu.get_reg(reg::CNTV_CTL_EL0).map_err(|_| ()),
         SYSREG_CNTV_CVAL_EL0 => vcpu.get_reg(reg::CNTV_CVAL_EL0).map_err(|_| ()),
@@ -419,7 +422,7 @@ fn get_one_sysreg(vcpu: &VcpuRef, id: u64) -> Result<u64, ()> {
 }
 
 /// Map a decoded sysreg ID to a writable target. Returns Err for unknown/read-only regs.
-fn set_one_sysreg(vcpu: &VcpuRef, id: u64, value: u64) -> Result<(), ()> {
+fn set_one_sysreg(vcpu: &dyn VcpuObject, id: u64, value: u64) -> Result<(), ()> {
     match id {
         // Timer registers
         SYSREG_CNTV_CTL_EL0 => vcpu.set_reg(reg::CNTV_CTL_EL0, value).map_err(|_| ()),
@@ -464,7 +467,7 @@ fn set_one_sysreg(vcpu: &VcpuRef, id: u64, value: u64) -> Result<(), ()> {
 /// Returns `Handled` if the call was processed and guest registers updated,
 /// `SystemOff` / `SystemReset` for PSCI shutdown (caller should exit to userspace),
 /// or `ForwardToUserspace` if the call should be forwarded.
-pub fn handle_firmware_call_in_kernel(vcpu: &VcpuRef) -> FirmwareCallResult {
+pub fn handle_firmware_call_in_kernel(vcpu: &dyn VcpuObject) -> FirmwareCallResult {
     let function_id = vcpu.get_reg(reg::X0).unwrap_or(0);
 
     match function_id {
@@ -502,7 +505,7 @@ pub fn handle_firmware_call_in_kernel(vcpu: &VcpuRef) -> FirmwareCallResult {
 
 /// Write architecture-specific exit data for firmware calls.
 /// On AArch64, PSCI SYSTEM_OFF/RESET maps to KVM_EXIT_SYSTEM_EVENT.
-pub fn write_firmware_exit(kvm_run: &mut KvmRun, exit: &VmExit, vcpu: &VcpuRef) {
+pub fn write_firmware_exit(kvm_run: &mut KvmRun, exit: &VmExit, vcpu: &dyn VcpuObject) {
     if let VmExit::FirmwareCall { epc: _ } = exit {
         let function_id = vcpu.get_reg(reg::X0).unwrap_or(0);
         match function_id {
@@ -744,7 +747,7 @@ pub struct KvmArmDeviceAddr {
 // ---------------------------------------------------------------------------
 
 struct KvmArmVcpuInitEntry {
-    vcpu: VcpuRef,
+    vcpu_key: usize,
     powered_off: bool,
 }
 
@@ -754,16 +757,27 @@ fn get_vcpu_init_states() -> &'static RwLock<Vec<KvmArmVcpuInitEntry>> {
     KVM_ARM_VCPU_INIT_STATES.call_once(|| RwLock::new(Vec::new()))
 }
 
-fn set_vcpu_powered_off(vcpu: &VcpuRef, powered_off: bool) {
+fn set_vcpu_powered_off(vcpu: &dyn VcpuObject, powered_off: bool) {
+    let key = super::vcpu_key(vcpu);
     let mut states = get_vcpu_init_states().write();
-    if let Some(entry) = states.iter_mut().find(|e| Arc::ptr_eq(&e.vcpu, vcpu)) {
+    if let Some(entry) = states.iter_mut().find(|e| e.vcpu_key == key) {
         entry.powered_off = powered_off;
     } else {
         states.push(KvmArmVcpuInitEntry {
-            vcpu: Arc::clone(vcpu),
+            vcpu_key: key,
             powered_off,
         });
     }
+}
+
+pub fn free_vcpu_state(vcpu: &dyn VcpuObject) {
+    let key = super::vcpu_key(vcpu);
+    get_sysreg_states()
+        .write()
+        .retain(|entry| entry.vcpu_key != key);
+    get_vcpu_init_states()
+        .write()
+        .retain(|entry| entry.vcpu_key != key);
 }
 
 // ---------------------------------------------------------------------------
@@ -810,7 +824,11 @@ pub fn handle_vm_ioctl(
 // Arch hook: ARM-specific vCPU-level ioctl dispatch
 // ---------------------------------------------------------------------------
 
-pub fn handle_vcpu_ioctl(request: u32, arg: usize, vcpu: &VcpuRef) -> Result<Option<usize>, ()> {
+pub fn handle_vcpu_ioctl(
+    request: u32,
+    arg: usize,
+    vcpu: &dyn VcpuObject,
+) -> Result<Option<usize>, ()> {
     match request {
         KVM_ARM_VCPU_INIT => {
             if arg == 0 {

--- a/kernel/src/abi/linux/device/kvm/mod.rs
+++ b/kernel/src/abi/linux/device/kvm/mod.rs
@@ -20,7 +20,7 @@ use crate::fs::{FileMetadata, FilePermission, FileType};
 use crate::hypervisor::memory::MemorySlotFlags;
 use crate::hypervisor::types::InterruptType;
 use crate::hypervisor::vm::VmObject;
-use crate::hypervisor::{VcpuRef, VmRef};
+use crate::hypervisor::{VcpuObject, VmRef};
 use crate::ipc::counter::{CounterObject, CounterWriteListener};
 use crate::object::KernelObject;
 use crate::object::capability::file::{FileObject, SeekFrom};
@@ -186,7 +186,7 @@ struct KvmIoEventFd {
 }
 
 struct KvmIoEvent {
-    vm: VmRef,
+    vm_key: usize,
     addr: u64,
     len: u32,
     datamatch: u64,
@@ -386,13 +386,21 @@ struct KvmRunPage {
 }
 
 struct KvmRunPageEntry {
-    vcpu: VcpuRef,
-    vm: VmRef,
+    vcpu_key: usize,
+    vm_key: usize,
     page: KvmRunPage,
 }
 
 static KVM_RUN_PAGES: Once<RwLock<Vec<KvmRunPageEntry>>> = Once::new();
 static KVM_IOEVENTS: Once<RwLock<Vec<KvmIoEvent>>> = Once::new();
+
+pub(super) fn vcpu_key(vcpu: &dyn VcpuObject) -> usize {
+    vcpu as *const dyn VcpuObject as *const () as usize
+}
+
+fn vm_key(vm: &VmRef) -> usize {
+    Arc::as_ptr(vm) as *const () as usize
+}
 
 fn get_run_pages() -> &'static RwLock<Vec<KvmRunPageEntry>> {
     KVM_RUN_PAGES.call_once(|| RwLock::new(Vec::new()))
@@ -403,7 +411,7 @@ fn get_ioevents() -> &'static RwLock<Vec<KvmIoEvent>> {
 }
 
 /// Allocate a shared kvm_run page for the given vCPU and register it.
-pub fn register_vcpu_run_page(vcpu: &VcpuRef, vm: &VmRef) -> Result<(), ()> {
+pub fn register_vcpu_run_page(vcpu: &dyn VcpuObject, vm: &VmRef) -> Result<(), ()> {
     use crate::mem::page::allocate_raw_pages;
     use crate::vm::addr::virt_to_phys;
 
@@ -415,18 +423,19 @@ pub fn register_vcpu_run_page(vcpu: &VcpuRef, vm: &VmRef) -> Result<(), ()> {
     let paddr = virt_to_phys(vaddr);
 
     get_run_pages().write().push(KvmRunPageEntry {
-        vcpu: Arc::clone(vcpu),
-        vm: Arc::clone(vm),
+        vcpu_key: vcpu_key(vcpu),
+        vm_key: vm_key(vm),
         page: KvmRunPage { vaddr, paddr },
     });
     Ok(())
 }
 
-fn get_vcpu_vm(vcpu: &VcpuRef) -> Option<VmRef> {
+fn get_vcpu_vm_key(vcpu: &dyn VcpuObject) -> Option<usize> {
+    let key = vcpu_key(vcpu);
     let pages = get_run_pages().read();
     for entry in pages.iter() {
-        if Arc::ptr_eq(&entry.vcpu, vcpu) {
-            return Some(Arc::clone(&entry.vm));
+        if entry.vcpu_key == key {
+            return Some(entry.vm_key);
         }
     }
     None
@@ -435,10 +444,11 @@ fn get_vcpu_vm(vcpu: &VcpuRef) -> Option<VmRef> {
 /// Look up the physical address of a vCPU's shared kvm_run page.
 /// Returns `None` if the vCPU was not created through the KVM compat layer
 /// (e.g., U-SHV vcpus created via sys_shv_vcpu_create).
-pub fn get_vcpu_run_paddr(vcpu: &VcpuRef) -> Option<usize> {
+pub fn get_vcpu_run_paddr(vcpu: &dyn VcpuObject) -> Option<usize> {
+    let key = vcpu_key(vcpu);
     let pages = get_run_pages().read();
     for entry in pages.iter() {
-        if Arc::ptr_eq(&entry.vcpu, vcpu) {
+        if entry.vcpu_key == key {
             return Some(entry.page.paddr);
         }
     }
@@ -470,10 +480,11 @@ fn decode_mmio_read_data(mmio: &KvmRunMmio) -> Option<(u8, u64)> {
     Some((len as u8, value))
 }
 
-fn read_vcpu_run_mmio_data(vcpu: &VcpuRef) -> Option<(u8, u64)> {
+fn read_vcpu_run_mmio_data(vcpu: &dyn VcpuObject) -> Option<(u8, u64)> {
+    let key = vcpu_key(vcpu);
     let pages = get_run_pages().read();
     for entry in pages.iter() {
-        if Arc::ptr_eq(&entry.vcpu, vcpu) {
+        if entry.vcpu_key == key {
             refresh_run_page_from_poc(entry.page.vaddr);
             let kvm_run = unsafe { &*(entry.page.vaddr as *const KvmRun) };
             if kvm_run.exit_reason == KVM_EXIT_MMIO {
@@ -500,16 +511,21 @@ fn signal_counter(counter: &dyn CounterObject) -> Result<(), ()> {
     counter.write(&value).map(|_| ()).map_err(|_| ())
 }
 
-fn handle_ioeventfd_mmio(vcpu: &VcpuRef, addr: u64, size: u8, data: u64) -> Result<bool, ()> {
+fn handle_ioeventfd_mmio(
+    vcpu: &dyn VcpuObject,
+    addr: u64,
+    size: u8,
+    data: u64,
+) -> Result<bool, ()> {
     const KVM_IOEVENTFD_FLAG_DATAMATCH: u32 = 1 << 1;
 
-    let Some(vm) = get_vcpu_vm(vcpu) else {
+    let Some(vm_key) = get_vcpu_vm_key(vcpu) else {
         return Ok(false);
     };
 
     let events = get_ioevents().read();
     for event in events.iter() {
-        if !Arc::ptr_eq(&event.vm, &vm) || event.addr != addr {
+        if event.vm_key != vm_key || event.addr != addr {
             continue;
         }
         if event.len != 0 && event.len != size as u32 {
@@ -532,10 +548,11 @@ fn handle_ioeventfd_mmio(vcpu: &VcpuRef, addr: u64, size: u8, data: u64) -> Resu
 /// Write VmExit information into a vCPU's shared kvm_run page.
 /// Does nothing if the vCPU has no registered run page (backward compat
 /// with the old pointer-based KVM_RUN path).
-pub fn write_vcpu_run_exit(vcpu: &VcpuRef, exit: &crate::hypervisor::VmExit) -> bool {
+pub fn write_vcpu_run_exit(vcpu: &dyn VcpuObject, exit: &crate::hypervisor::VmExit) -> bool {
+    let key = vcpu_key(vcpu);
     let pages = get_run_pages().read();
     for entry in pages.iter() {
-        if Arc::ptr_eq(&entry.vcpu, vcpu) {
+        if entry.vcpu_key == key {
             // SAFETY: vaddr points to a page-aligned, zero-initialized allocation
             // that is exclusively owned by this kvm_run page management code.
             let kvm_run = unsafe { &mut *(entry.page.vaddr as *mut KvmRun) };
@@ -552,9 +569,11 @@ pub fn write_vcpu_run_exit(vcpu: &VcpuRef, exit: &crate::hypervisor::VmExit) -> 
 
 /// Free a vCPU's shared kvm_run page. Called when the vCPU kernel object
 /// is dropped.
-pub fn free_vcpu_run_page(vcpu: &VcpuRef) {
+pub fn free_vcpu_run_page(vcpu: &dyn VcpuObject) {
+    arch::free_vcpu_state(vcpu);
+    let key = vcpu_key(vcpu);
     let mut pages = get_run_pages().write();
-    let idx = pages.iter().position(|e| Arc::ptr_eq(&e.vcpu, vcpu));
+    let idx = pages.iter().position(|e| e.vcpu_key == key);
     if let Some(i) = idx {
         use crate::mem::page::free_raw_pages;
         let entry = pages.remove(i);
@@ -639,7 +658,7 @@ pub fn handle_vm_ioctl(
             // crate::println!("[KVM] CREATE_VCPU(id={})", vcpu_id);
             let task = mytask().ok_or(())?;
             let vcpu = vm.create_vcpu(vcpu_id).map_err(|_| ())?;
-            register_vcpu_run_page(&vcpu, vm).map_err(|_| ())?;
+            register_vcpu_run_page(vcpu.as_ref(), vm).map_err(|_| ())?;
             let kernel_obj = KernelObject::HypervisorVcpu(vcpu);
             let handle = task.handle_table.insert(kernel_obj).map_err(|_| ())?;
             let fd = abi.allocate_fd(handle).map_err(|_| ())?;
@@ -783,8 +802,9 @@ pub fn handle_vm_ioctl(
             }
             if event.flags & KVM_IOEVENTFD_FLAG_DEASSIGN != 0 {
                 let mut events = get_ioevents().write();
+                let key = vm_key(vm);
                 events.retain(|registered| {
-                    !(Arc::ptr_eq(&registered.vm, vm)
+                    !(registered.vm_key == key
                         && registered.addr == event.addr
                         && registered.len == event.len
                         && registered.datamatch == event.datamatch
@@ -795,13 +815,13 @@ pub fn handle_vm_ioctl(
             }
 
             let handle = abi.get_handle(event.fd as usize).ok_or(())?;
-            let object = task.handle_table.get(handle).ok_or(())?;
+            let object = task.handle_table.get_arc_clone(handle).ok_or(())?;
             let counter = match object {
                 KernelObject::Counter(counter) => counter,
                 _ => return Err(()),
             };
             get_ioevents().write().push(KvmIoEvent {
-                vm: Arc::clone(vm),
+                vm_key: vm_key(vm),
                 addr: event.addr,
                 len: event.len,
                 datamatch: event.datamatch,
@@ -1043,7 +1063,7 @@ fn log_vm_exit(exit: &crate::hypervisor::VmExit) {
 pub fn handle_vcpu_ioctl(
     request: u32,
     arg: usize,
-    vcpu: &VcpuRef,
+    vcpu: &dyn VcpuObject,
     trapframe: &mut crate::arch::Trapframe,
 ) -> Result<Option<usize>, ()> {
     match request {
@@ -1259,7 +1279,7 @@ pub fn handle_vcpu_ioctl(
 // VmExit → kvm_run conversion
 // ---------------------------------------------------------------------------
 
-fn write_vm_exit(kvm_run: &mut KvmRun, exit: &crate::hypervisor::VmExit, vcpu: &VcpuRef) {
+fn write_vm_exit(kvm_run: &mut KvmRun, exit: &crate::hypervisor::VmExit, vcpu: &dyn VcpuObject) {
     use crate::hypervisor::VmExit;
 
     kvm_run.exit_data = KvmRunExitData {

--- a/kernel/src/abi/linux/device/kvm/riscv64.rs
+++ b/kernel/src/abi/linux/device/kvm/riscv64.rs
@@ -2,13 +2,12 @@
 
 extern crate alloc;
 
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use spin::{Once, RwLock};
 
 use crate::abi::linux::generic::LinuxAbi;
 use crate::arch::hv::reg_index::reg;
-use crate::hypervisor::{VcpuRef, VmRef};
+use crate::hypervisor::{VcpuObject, VmRef};
 
 pub fn irqfd_route_to_vcpu_irq(route: u32) -> u32 {
     route
@@ -165,7 +164,7 @@ struct KvmRiscvVcpuState {
 }
 
 struct KvmRiscvVcpuStateEntry {
-    vcpu: VcpuRef,
+    vcpu_key: usize,
     state: KvmRiscvVcpuState,
 }
 
@@ -251,17 +250,15 @@ fn default_vcpu_state() -> KvmRiscvVcpuState {
     }
 }
 
-fn with_vcpu_state<R>(vcpu: &VcpuRef, f: impl FnOnce(&mut KvmRiscvVcpuState) -> R) -> R {
+fn with_vcpu_state<R>(vcpu: &dyn VcpuObject, f: impl FnOnce(&mut KvmRiscvVcpuState) -> R) -> R {
     let mut states = get_vcpu_states().write();
-    if let Some(entry) = states
-        .iter_mut()
-        .find(|entry| Arc::ptr_eq(&entry.vcpu, vcpu))
-    {
+    let key = super::vcpu_key(vcpu);
+    if let Some(entry) = states.iter_mut().find(|entry| entry.vcpu_key == key) {
         return f(&mut entry.state);
     }
 
     states.push(KvmRiscvVcpuStateEntry {
-        vcpu: Arc::clone(vcpu),
+        vcpu_key: key,
         state: default_vcpu_state(),
     });
 
@@ -354,7 +351,7 @@ fn validate_one_reg_id(id: u64) -> Result<(), ()> {
     Ok(())
 }
 
-pub fn get_one_reg(vcpu: &VcpuRef, id: u64) -> Result<u64, ()> {
+pub fn get_one_reg(vcpu: &dyn VcpuObject, id: u64) -> Result<u64, ()> {
     validate_one_reg_id(id)?;
 
     match kvm_reg_type(id) {
@@ -429,7 +426,7 @@ pub fn get_one_reg(vcpu: &VcpuRef, id: u64) -> Result<u64, ()> {
     }
 }
 
-pub fn set_one_reg(vcpu: &VcpuRef, id: u64, value: u64) -> Result<(), ()> {
+pub fn set_one_reg(vcpu: &dyn VcpuObject, id: u64, value: u64) -> Result<(), ()> {
     validate_one_reg_id(id)?;
 
     match kvm_reg_type(id) {
@@ -563,7 +560,7 @@ pub fn set_one_reg(vcpu: &VcpuRef, id: u64, value: u64) -> Result<(), ()> {
     }
 }
 
-pub fn read_regs_to_kvm(vcpu: &VcpuRef) -> KvmRegs {
+pub fn read_regs_to_kvm(vcpu: &dyn VcpuObject) -> KvmRegs {
     let mut buf = [0u64; 32];
     for (slot, &idx) in PTRACE_REG_INDEX.iter().enumerate() {
         buf[slot] = vcpu.get_reg(idx).unwrap_or(0);
@@ -571,14 +568,14 @@ pub fn read_regs_to_kvm(vcpu: &VcpuRef) -> KvmRegs {
     unsafe { core::mem::transmute(buf) }
 }
 
-pub fn write_kvm_to_regs(vcpu: &VcpuRef, kvm_regs: &KvmRegs) {
+pub fn write_kvm_to_regs(vcpu: &dyn VcpuObject, kvm_regs: &KvmRegs) {
     let buf: &[u64; 32] = unsafe { core::mem::transmute(kvm_regs) };
     for (&idx, &val) in PTRACE_REG_INDEX.iter().zip(buf.iter()) {
         let _ = vcpu.set_reg(idx, val);
     }
 }
 
-pub fn complete_mmio_read(vcpu: &VcpuRef, target_reg: u8, size: u8, value: u64) {
+pub fn complete_mmio_read(vcpu: &dyn VcpuObject, target_reg: u8, size: u8, value: u64) {
     if target_reg == 0 {
         return;
     }
@@ -603,12 +600,12 @@ pub enum FirmwareCallResult {
     ForwardToUserspace,
 }
 
-pub fn handle_firmware_call_in_kernel(vcpu: &VcpuRef) -> FirmwareCallResult {
+pub fn handle_firmware_call_in_kernel(vcpu: &dyn VcpuObject) -> FirmwareCallResult {
     use crate::arch::hv::reg_index::reg;
     handle_sbi_in_kernel_impl(vcpu)
 }
 
-fn handle_sbi_in_kernel_impl(vcpu: &VcpuRef) -> FirmwareCallResult {
+fn handle_sbi_in_kernel_impl(vcpu: &dyn VcpuObject) -> FirmwareCallResult {
     use crate::arch::hv::reg_index::reg;
 
     let extension_id = vcpu.get_reg(reg::A7).unwrap_or(0);
@@ -721,7 +718,7 @@ fn handle_sbi_in_kernel_impl(vcpu: &VcpuRef) -> FirmwareCallResult {
 pub fn write_firmware_exit(
     kvm_run: &mut super::KvmRun,
     _exit: &crate::hypervisor::types::VmExit,
-    vcpu: &VcpuRef,
+    vcpu: &dyn VcpuObject,
 ) {
     use super::{KVM_EXIT_RISCV_SBI, KVM_EXIT_SHUTDOWN};
     use crate::arch::hv::reg_index::reg;
@@ -744,6 +741,13 @@ pub fn write_firmware_exit(
         sbi.extension_id = extension_id;
         sbi.function_id = vcpu.get_reg(reg::A6).unwrap_or(0);
     }
+}
+
+pub fn free_vcpu_state(vcpu: &dyn VcpuObject) {
+    let key = super::vcpu_key(vcpu);
+    get_vcpu_states()
+        .write()
+        .retain(|entry| entry.vcpu_key != key);
 }
 
 pub fn check_extension(_cap: usize) -> Option<usize> {
@@ -829,6 +833,10 @@ pub fn handle_vm_ioctl(
 // Arch hook: vCPU-level ioctl dispatch (RISC-V stub)
 // ---------------------------------------------------------------------------
 
-pub fn handle_vcpu_ioctl(_request: u32, _arg: usize, _vcpu: &VcpuRef) -> Result<Option<usize>, ()> {
+pub fn handle_vcpu_ioctl(
+    _request: u32,
+    _arg: usize,
+    _vcpu: &dyn VcpuObject,
+) -> Result<Option<usize>, ()> {
     Ok(None)
 }

--- a/kernel/src/abi/linux/generic/fs.rs
+++ b/kernel/src/abi/linux/generic/fs.rs
@@ -2336,8 +2336,8 @@ pub fn sys_ioctl(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
 
     // Dispatch hypervisor (KVM) ioctls before capability-based routing
     #[cfg(feature = "hypervisor")]
-    match &kernel_object {
-        crate::object::KernelObject::HypervisorVm(vm) => {
+    {
+        if let Some(vm) = kernel_object.as_hypervisor_vm_arc() {
             let result = crate::abi::linux::device::kvm::handle_vm_ioctl(request, arg, vm, abi);
             return match result {
                 Ok(Some(ret)) => ret,
@@ -2345,7 +2345,7 @@ pub fn sys_ioctl(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                 Err(_) => errno::to_result(errno::EINVAL),
             };
         }
-        crate::object::KernelObject::HypervisorVcpu(vcpu) => {
+        if let Some(vcpu) = kernel_object.as_hypervisor_vcpu() {
             let result =
                 crate::abi::linux::device::kvm::handle_vcpu_ioctl(request, arg, vcpu, trapframe);
             return match result {
@@ -2354,11 +2354,10 @@ pub fn sys_ioctl(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                 Err(_) => errno::to_result(errno::EINVAL),
             };
         }
-        _ => {}
     }
 
     if request == FIONBIO {
-        if let crate::object::KernelObject::Socket(socket) = &kernel_object {
+        if let Some(socket) = kernel_object.as_socket() {
             let arg_paddr = match task.vm_manager.translate_to_kva(arg) {
                 Some(addr) => addr,
                 None => return errno::to_result(errno::EFAULT),
@@ -2397,9 +2396,17 @@ pub fn sys_ioctl(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     let device_is_tty = caps
         .map(|caps| caps.iter().any(|c| *c == DeviceCapability::Tty))
         .unwrap_or(false);
-    if device_is_tty || crate::abi::linux::device::tty::is_tty_ioctl_target(request, &kernel_object)
+    if device_is_tty
+        || crate::abi::linux::device::tty::is_tty_ioctl_target(
+            request,
+            kernel_object.as_kernel_object(),
+        )
     {
-        match crate::abi::linux::device::tty::handle_ioctl(request, arg, &kernel_object) {
+        match crate::abi::linux::device::tty::handle_ioctl(
+            request,
+            arg,
+            kernel_object.as_kernel_object(),
+        ) {
             Ok(Some(ret)) => return ret,
             Ok(None) => {
                 // Do NOT pass through unknown TTY ioctls to device-specific control.
@@ -3200,21 +3207,7 @@ pub fn sys_ftruncate(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     let file_obj = match kernel_obj.as_file() {
         Some(f) => f,
         None => {
-            let kind = match kernel_obj {
-                crate::object::KernelObject::File(_) => "File",
-                crate::object::KernelObject::Pipe(_) => "Pipe",
-                crate::object::KernelObject::Counter(_) => "Counter",
-                crate::object::KernelObject::Timer(_) => "Timer",
-                crate::object::KernelObject::EventChannel(_) => "EventChannel",
-                crate::object::KernelObject::EventSubscription(_) => "EventSubscription",
-                crate::object::KernelObject::SharedMemory(_) => "SharedMemory",
-                #[cfg(feature = "network")]
-                crate::object::KernelObject::Socket(_) => "Socket",
-                #[cfg(feature = "hypervisor")]
-                crate::object::KernelObject::HypervisorVm(_) => "HypervisorVm",
-                #[cfg(feature = "hypervisor")]
-                crate::object::KernelObject::HypervisorVcpu(_) => "HypervisorVcpu",
-            };
+            let kind = kernel_obj.type_name();
             crate::println!(
                 "sys_ftruncate: fd={} kind={} is not truncatable len={}",
                 fd,
@@ -3229,21 +3222,7 @@ pub fn sys_ftruncate(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
         Ok(()) => 0,
         Err(err) => {
             if length > 0 {
-                let kind = match kernel_obj {
-                    crate::object::KernelObject::File(_) => "File",
-                    crate::object::KernelObject::Pipe(_) => "Pipe",
-                    crate::object::KernelObject::Counter(_) => "Counter",
-                    crate::object::KernelObject::Timer(_) => "Timer",
-                    crate::object::KernelObject::EventChannel(_) => "EventChannel",
-                    crate::object::KernelObject::EventSubscription(_) => "EventSubscription",
-                    crate::object::KernelObject::SharedMemory(_) => "SharedMemory",
-                    #[cfg(feature = "network")]
-                    crate::object::KernelObject::Socket(_) => "Socket",
-                    #[cfg(feature = "hypervisor")]
-                    crate::object::KernelObject::HypervisorVm(_) => "HypervisorVm",
-                    #[cfg(feature = "hypervisor")]
-                    crate::object::KernelObject::HypervisorVcpu(_) => "HypervisorVcpu",
-                };
+                let kind = kernel_obj.type_name();
             }
             errno::to_result(errno::EIO)
         }

--- a/kernel/src/abi/linux/generic/mm.rs
+++ b/kernel/src/abi/linux/generic/mm.rs
@@ -80,8 +80,8 @@ pub fn sys_mmap(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     // doesn't implement that trait — the kvm_run page is managed by the KVM
     // compat layer instead.
     #[cfg(feature = "hypervisor")]
-    if let crate::object::KernelObject::HypervisorVcpu(vcpu) = &kernel_obj {
-        return handle_kvm_vcpu_mmap(task, &vcpu, addr, aligned_length, prot, flags);
+    if let Some(vcpu) = kernel_obj.as_hypervisor_vcpu() {
+        return handle_kvm_vcpu_mmap(task, vcpu, addr, aligned_length, prot, flags);
     }
 
     // Check if object supports MemoryMappingOps
@@ -161,7 +161,11 @@ pub fn sys_mmap(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     }
 
     if is_map_private_flag && !is_shared {
-        let owner = match kernel_obj.as_memory_mappable_arc() {
+        let owner = match task
+            .handle_table
+            .get_arc_clone(handle)
+            .and_then(|obj| obj.as_memory_mappable_arc())
+        {
             Some(owner) => owner,
             None => return to_result(errno::ENODEV),
         };
@@ -243,7 +247,10 @@ pub fn sys_mmap(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     let vmarea = MemoryArea::new(final_vaddr, final_vaddr + ok_len_aligned - 1);
     let pmarea = MemoryArea::new(paddr, paddr + ok_len_aligned - 1);
 
-    let owner = kernel_obj.as_memory_mappable_arc();
+    let owner = task
+        .handle_table
+        .get_arc_clone(handle)
+        .and_then(|obj| obj.as_memory_mappable_arc());
     let vm_map = VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner);
 
     let map_result = if is_fixed {
@@ -533,7 +540,7 @@ pub fn sys_mremap(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
 #[cfg(feature = "hypervisor")]
 fn handle_kvm_vcpu_mmap(
     task: &crate::task::Task,
-    vcpu: &crate::hypervisor::VcpuRef,
+    vcpu: &dyn crate::hypervisor::VcpuObject,
     addr: usize,
     aligned_length: usize,
     prot: usize,

--- a/kernel/src/abi/linux/generic/signal.rs
+++ b/kernel/src/abi/linux/generic/signal.rs
@@ -614,7 +614,7 @@ pub fn handle_event_for_task(
         SignalAction::Ignore => {}
         SignalAction::ForceTerminate | SignalAction::Terminate => {
             let exit_code = 128 + (signal as i32);
-            target_task.exit(exit_code);
+            target_task.exit_group(exit_code);
         }
         SignalAction::Stop => {
             target_task.set_state(crate::task::TaskState::Blocked(
@@ -723,7 +723,7 @@ pub fn handle_fatal_signal_immediately(signal: LinuxSignal) -> Result<(), &'stat
             exit_code
         );
 
-        task.exit(exit_code);
+        task.exit_group(exit_code);
         Ok(())
     } else {
         Err("No current task to terminate")

--- a/kernel/src/abi/linux/generic/socket.rs
+++ b/kernel/src/abi/linux/generic/socket.rs
@@ -300,7 +300,7 @@ pub fn sys_socket(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     }
 
     if set_nonblock {
-        if let Some(local_socket) = LocalSocket::from_socket_object(&socket_obj) {
+        if let Some(local_socket) = LocalSocket::from_socket_object(socket_obj.as_ref()) {
             local_socket.set_nonblocking(true);
         }
     }
@@ -374,8 +374,8 @@ pub fn sys_bind(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     };
 
     // Get the socket object from handle table
-    let socket_arc = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
+    let socket_arc = match task.handle_table.get_arc_clone(handle_id) {
+        Some(KernelObject::Socket(socket)) => socket,
         _ => {
             crate::early_println!("[linux socket] bind fd {} not socket", sockfd);
             return usize::MAX;
@@ -537,15 +537,19 @@ pub fn sys_listen(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
         }
     };
 
-    let socket_arc = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => {
+    let socket = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => {
             crate::early_println!("[linux socket] listen fd {} not socket", sockfd);
             return usize::MAX;
         }
     };
 
-    if socket_arc.listen(backlog.max(0) as usize).is_err() {
+    if socket.listen(backlog.max(0) as usize).is_err() {
         return usize::MAX;
     }
 
@@ -588,18 +592,22 @@ fn accept_with_flags(abi: &mut LinuxAbi, trapframe: &mut Trapframe, flags: i32) 
         }
     };
 
-    let socket_obj = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => {
+    let socket_obj = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => {
             crate::early_println!("[linux socket] accept fd {} not socket", sockfd);
             return usize::MAX;
         }
     };
 
     // Try LocalSocket first, then TcpSocket
-    let accepted_socket = if let Some(local_socket) = LocalSocket::from_socket_object(&socket_obj) {
+    let accepted_socket = if let Some(local_socket) = LocalSocket::from_socket_object(socket_obj) {
         local_socket.accept_blocking(task.get_id(), trapframe)
-    } else if let Some(tcp_socket) = crate::network::tcp::TcpSocket::from_socket_object(&socket_obj)
+    } else if let Some(tcp_socket) = crate::network::tcp::TcpSocket::from_socket_object(socket_obj)
     {
         tcp_socket.accept_blocking(task.get_id(), trapframe)
     } else {
@@ -625,7 +633,7 @@ fn accept_with_flags(abi: &mut LinuxAbi, trapframe: &mut Trapframe, flags: i32) 
     }
 
     if (flags & SOCK_NONBLOCK) != 0 {
-        if let Some(local_socket) = LocalSocket::from_socket_object(&accepted_socket) {
+        if let Some(local_socket) = LocalSocket::from_socket_object(accepted_socket.as_ref()) {
             local_socket.set_nonblocking(true);
         }
     }
@@ -703,9 +711,13 @@ pub fn sys_connect(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
         }
     };
 
-    let socket_arc = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => {
+    let socket_arc = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => {
             crate::early_println!("[linux socket] connect fd {} not socket", sockfd);
             return usize::MAX;
         }
@@ -821,9 +833,13 @@ pub fn sys_getsockname(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
         }
     };
 
-    let socket_arc = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => {
+    let socket_arc = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => {
             crate::early_println!("[linux socket] getsockname fd {} not socket", sockfd);
             return usize::MAX;
         }
@@ -922,9 +938,13 @@ pub fn sys_getpeername(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
         }
     };
 
-    let socket_arc = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => {
+    let socket_arc = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => {
             crate::early_println!("[linux socket] getpeername fd {} not socket", sockfd);
             return usize::MAX;
         }
@@ -1165,12 +1185,12 @@ pub fn sys_sendmsg(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     let iovecs = unsafe { core::slice::from_raw_parts(iovec_addr, iovcnt) };
 
     if msg.msg_control != 0 && msg.msg_controllen as usize >= size_of::<LinuxCmsghdr>() {
-        let socket_arc = match &kernel_obj {
-            KernelObject::Socket(socket) => Arc::clone(socket),
-            _ => return errno::to_result(errno::ENOTSOCK),
+        let socket = match kernel_obj.as_socket() {
+            Some(socket) => socket,
+            None => return errno::to_result(errno::ENOTSOCK),
         };
 
-        if let Some(local_socket) = LocalSocket::from_socket_object(&socket_arc) {
+        if let Some(local_socket) = LocalSocket::from_socket_object(socket) {
             let cmsg_addr = match task.vm_manager.translate_to_kva(msg.msg_control as usize) {
                 Some(addr) => addr as *const LinuxCmsghdr,
                 None => {
@@ -1440,14 +1460,14 @@ pub fn sys_recvmsg(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     if msg.msg_control != 0
         && (msg.msg_controllen as usize) >= size_of::<LinuxCmsghdr>() + size_of::<i32>()
     {
-        let socket_arc = match &kernel_obj {
-            KernelObject::Socket(socket) => Arc::clone(socket),
-            _ => {
+        let socket = match kernel_obj.as_socket() {
+            Some(socket) => socket,
+            None => {
                 return errno::to_result(errno::ENOTSOCK);
             }
         };
 
-        if let Some(local_socket) = LocalSocket::from_socket_object(&socket_arc) {
+        if let Some(local_socket) = LocalSocket::from_socket_object(socket) {
             match local_socket.recv_handle_and_data(total_buffer_size) {
                 Ok((obj, data)) => {
                     let new_handle = match task.handle_table.insert(obj) {
@@ -1603,9 +1623,13 @@ pub fn sys_sendto(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     };
 
     // Get socket object
-    let socket = match task.handle_table.get(handle) {
-        Some(KernelObject::Socket(s)) => s.clone(),
-        _ => return errno::to_result(errno::ENOTSOCK),
+    let socket = match task
+        .handle_table
+        .get(handle)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return errno::to_result(errno::ENOTSOCK),
     };
 
     // Translate buffer pointer
@@ -1699,9 +1723,13 @@ pub fn sys_recvfrom(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     };
 
     // Get socket object
-    let socket = match task.handle_table.get(handle) {
-        Some(KernelObject::Socket(s)) => s.clone(),
-        _ => return errno::to_result(errno::ENOTSOCK),
+    let socket = match task
+        .handle_table
+        .get(handle)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return errno::to_result(errno::ENOTSOCK),
     };
 
     // Translate buffer pointer
@@ -1940,9 +1968,13 @@ pub fn sys_shutdown(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
     };
 
     // Get socket object
-    let socket = match task.handle_table.get(handle) {
-        Some(KernelObject::Socket(s)) => s.clone(),
-        _ => return errno::to_result(errno::ENOTSOCK),
+    let socket = match task
+        .handle_table
+        .get(handle)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return errno::to_result(errno::ENOTSOCK),
     };
 
     // Convert how to ShutdownHow

--- a/kernel/src/abi/scarlet/aarch64.rs
+++ b/kernel/src/abi/scarlet/aarch64.rs
@@ -315,7 +315,7 @@ impl ScarletAbi {
                     ProcessControlType::Quit => 128 + 3,       // SIGQUIT-like
                     _ => 1,
                 };
-                task.exit(exit_code);
+                task.exit_group(exit_code);
                 Ok(())
             }
             ProcessControlType::Stop
@@ -363,7 +363,7 @@ impl ScarletAbi {
                     )
                 } else {
                     // Default: terminate with SIGINT-like exit code
-                    task.exit(128 + 2);
+                    task.exit_group(128 + 2);
                     Ok(())
                 }
             }

--- a/kernel/src/abi/scarlet/riscv64.rs
+++ b/kernel/src/abi/scarlet/riscv64.rs
@@ -315,7 +315,7 @@ impl ScarletAbi {
                     ProcessControlType::Quit => 128 + 3,       // SIGQUIT-like
                     _ => 1,
                 };
-                task.exit(exit_code);
+                task.exit_group(exit_code);
                 Ok(())
             }
             ProcessControlType::Stop
@@ -363,7 +363,7 @@ impl ScarletAbi {
                     )
                 } else {
                     // Default: terminate with SIGINT-like exit code
-                    task.exit(128 + 2);
+                    task.exit_group(128 + 2);
                     Ok(())
                 }
             }

--- a/kernel/src/arch/aarch64/hv/vm.rs
+++ b/kernel/src/arch/aarch64/hv/vm.rs
@@ -572,6 +572,12 @@ impl Aarch64VcpuObject {
     }
 }
 
+impl Drop for Aarch64VcpuObject {
+    fn drop(&mut self) {
+        crate::abi::linux::device::kvm::free_vcpu_run_page(self);
+    }
+}
+
 impl VcpuObject for Aarch64VcpuObject {
     fn id(&self) -> VcpuId {
         self.id

--- a/kernel/src/arch/riscv64/hv/vm.rs
+++ b/kernel/src/arch/riscv64/hv/vm.rs
@@ -217,6 +217,12 @@ impl Riscv64VcpuObject {
     }
 }
 
+impl Drop for Riscv64VcpuObject {
+    fn drop(&mut self) {
+        crate::abi::linux::device::kvm::free_vcpu_run_page(self);
+    }
+}
+
 impl VcpuObject for Riscv64VcpuObject {
     fn id(&self) -> VcpuId {
         self.id

--- a/kernel/src/hypervisor/syscall.rs
+++ b/kernel/src/hypervisor/syscall.rs
@@ -63,9 +63,13 @@ pub fn sys_shv_vcpu_create(trapframe: &mut Trapframe) -> usize {
     trapframe.increment_pc_next(task);
 
     // Get the VM object from the handle table
-    let vm = match task.handle_table.get(vm_handle) {
-        Some(KernelObject::HypervisorVm(vm)) => vm,
-        _ => return usize::MAX,
+    let vm = match task
+        .handle_table
+        .get(vm_handle)
+        .and_then(|obj| obj.as_hypervisor_vm_arc())
+    {
+        Some(vm) => vm,
+        None => return usize::MAX,
     };
 
     // Create a new vCPU on the VM
@@ -127,9 +131,13 @@ pub fn sys_shv_vcpu_run(trapframe: &mut Trapframe) -> usize {
     };
 
     // Get the vCPU object from the handle table
-    let vcpu = match task.handle_table.get(vcpu_handle) {
-        Some(KernelObject::HypervisorVcpu(vcpu)) => vcpu,
-        _ => return usize::MAX,
+    let vcpu = match task
+        .handle_table
+        .get(vcpu_handle)
+        .and_then(|obj| obj.as_hypervisor_vcpu())
+    {
+        Some(vcpu) => vcpu,
+        None => return usize::MAX,
     };
 
     // crate::println!("[sys_shv_vcpu_run] calling vcpu.run()");

--- a/kernel/src/ipc/syscall.rs
+++ b/kernel/src/ipc/syscall.rs
@@ -183,12 +183,16 @@ pub fn sys_event_unsubscribe(trapframe: &mut Trapframe) -> usize {
     trapframe.increment_pc_next(task);
 
     // Get the object first to extract identifiers
-    let (channel_name, subscription_id) = match task.handle_table.get(handle) {
-        Some(KernelObject::EventSubscription(sub)) => (
+    let (channel_name, subscription_id) = match task
+        .handle_table
+        .get(handle)
+        .and_then(|obj| obj.as_event_subscription())
+    {
+        Some(sub) => (
             sub.channel_name().to_string(),
             sub.subscription_id().to_string(),
         ),
-        _ => return usize::MAX,
+        None => return usize::MAX,
     };
 
     // Remove from channel registry via EventManager helper
@@ -585,13 +589,17 @@ pub fn sys_socket_send_handle(trapframe: &mut Trapframe) -> usize {
     trapframe.increment_pc_next(task);
 
     // Get the socket object (LocalSocket-only)
-    let socket_obj = match task.handle_table.get(socket_handle) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => return usize::MAX, // Invalid socket handle
+    let socket_obj = match task
+        .handle_table
+        .get(socket_handle)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return usize::MAX, // Invalid socket handle
     };
 
     use crate::network::local::LocalSocket;
-    let local_socket = match LocalSocket::from_socket_object(&socket_obj) {
+    let local_socket = match LocalSocket::from_socket_object(socket_obj) {
         Some(s) => s,
         None => return usize::MAX, // Not a LocalSocket
     };
@@ -633,15 +641,19 @@ pub fn sys_socket_recv_handle(trapframe: &mut Trapframe) -> usize {
     trapframe.increment_pc_next(task);
 
     // Get the socket object (LocalSocket-only)
-    let socket_obj = match task.handle_table.get(socket_handle) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => return usize::MAX, // Invalid socket handle
+    let socket_obj = match task
+        .handle_table
+        .get(socket_handle)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return usize::MAX, // Invalid socket handle
     };
 
     // For LocalSocket, we provide blocking semantics: if the handle queue is empty,
     // block the task until a handle arrives or the peer is closed.
     use crate::network::local::LocalSocket;
-    let local_socket = match LocalSocket::from_socket_object(&socket_obj) {
+    let local_socket = match LocalSocket::from_socket_object(socket_obj) {
         Some(s) => s,
         None => return usize::MAX, // Not a LocalSocket
     };
@@ -688,13 +700,17 @@ pub fn sys_socket_send_handle_and_data(trapframe: &mut Trapframe) -> usize {
     trapframe.increment_pc_next(task);
 
     // Get the socket object (LocalSocket-only)
-    let socket_obj = match task.handle_table.get(socket_handle) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => return usize::MAX, // Invalid socket handle
+    let socket_obj = match task
+        .handle_table
+        .get(socket_handle)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return usize::MAX, // Invalid socket handle
     };
 
     use crate::network::local::LocalSocket;
-    let local_socket = match LocalSocket::from_socket_object(&socket_obj) {
+    let local_socket = match LocalSocket::from_socket_object(socket_obj) {
         Some(s) => s,
         None => return usize::MAX, // Not a LocalSocket
     };
@@ -759,13 +775,17 @@ pub fn sys_socket_recv_handle_and_data(trapframe: &mut Trapframe) -> usize {
     trapframe.increment_pc_next(task);
 
     // Get the socket object (LocalSocket-only)
-    let socket_obj = match task.handle_table.get(socket_handle) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => return usize::MAX, // Invalid socket handle
+    let socket_obj = match task
+        .handle_table
+        .get(socket_handle)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return usize::MAX, // Invalid socket handle
     };
 
     use crate::network::local::LocalSocket;
-    let local_socket = match LocalSocket::from_socket_object(&socket_obj) {
+    let local_socket = match LocalSocket::from_socket_object(socket_obj) {
         Some(s) => s,
         None => return usize::MAX, // Not a LocalSocket
     };

--- a/kernel/src/network/icmp.rs
+++ b/kernel/src/network/icmp.rs
@@ -511,6 +511,23 @@ impl IcmpSocket {
     }
 }
 
+impl Drop for IcmpSocket {
+    fn drop(&mut self) {
+        if let Some(layer) = self.icmp_layer.upgrade() {
+            let mut sockets = layer.sockets.write();
+            if let Some(existing) = sockets.get(&self.identifier)
+                && existing.as_ptr() == self as *const Self
+            {
+                sockets.remove(&self.identifier);
+            }
+        }
+
+        self.recv_waker.wake_all();
+        crate::network::NetworkManager::get_manager()
+            .remove_socket_by_ptr(self as *const Self as usize);
+    }
+}
+
 impl SocketObject for IcmpSocket {
     fn socket_type(&self) -> SocketType {
         SocketType::Datagram

--- a/kernel/src/network/local.rs
+++ b/kernel/src/network/local.rs
@@ -144,7 +144,7 @@ impl LocalSocket {
     ///
     /// Returns None if the socket is not a LocalSocket.
     /// This is completely safe and does not use any unsafe code.
-    pub fn from_socket_object(socket: &Arc<dyn SocketObject>) -> Option<&Self> {
+    pub fn from_socket_object(socket: &dyn SocketObject) -> Option<&Self> {
         // Use SocketObject's as_any() to get &dyn Any
         socket.as_any().downcast_ref::<LocalSocket>()
     }
@@ -581,37 +581,42 @@ impl StreamOps for LocalSocket {
                 }
             } // Release locks before checking nonblocking/EOF
 
-            // Check nonblocking mode before blocking
+            {
+                let read_buf_arc = self.read_buffer.read();
+
+                // Check EOF before honoring non-blocking mode. A disconnected peer is
+                // a completed read condition, not WouldBlock.
+                let my_state = *self.state.read();
+                if my_state == SocketState::Closed {
+                    return Ok(0);
+                }
+
+                if my_state == SocketState::Connected {
+                    let peer_closed = match self.peer_socket.read().as_ref() {
+                        Some(peer_weak) => match peer_weak.upgrade() {
+                            Some(peer) => *peer.state.read() == SocketState::Closed,
+                            None => true,
+                        },
+                        None => true,
+                    };
+                    if peer_closed {
+                        return Ok(0);
+                    }
+                }
+
+                // Check if this read buffer has been closed by peer's shutdown/drop.
+                if *read_buf_arc.closed.read() {
+                    return Ok(0);
+                }
+            }
+
+            // Check nonblocking mode before blocking.
             if *self.nonblocking.read() {
                 return Err(StreamError::WouldBlock);
             }
 
             {
                 let read_buf_arc = self.read_buffer.read();
-
-                // Check if socket is closed (peer shutdown)
-                // Return 0 to indicate EOF (not an error)
-                let my_state = *self.state.read();
-                if my_state == SocketState::Closed {
-                    return Ok(0);
-                }
-
-                // Check if peer is closed (they called shutdown)
-                if let Some(peer_weak) = self.peer_socket.read().as_ref() {
-                    if let Some(peer) = peer_weak.upgrade() {
-                        let peer_state = *peer.state.read();
-                        if peer_state == SocketState::Closed {
-                            return Ok(0); // Peer closed, return EOF
-                        }
-                    } else {
-                        return Ok(0); // Peer dropped, treat as EOF
-                    }
-                }
-
-                // Check if this read buffer has been closed by peer's shutdown()
-                if *read_buf_arc.closed.read() {
-                    return Ok(0);
-                }
 
                 // Register this task as waiting to read
                 if let Some(task) = mytask() {
@@ -680,6 +685,39 @@ impl StreamIpcOps for LocalSocket {
         let local = self.local_addr.read();
         let peer = self.peer_addr.read();
         format!("LocalSocket[{:?} -> {:?}]", local.as_ref(), peer.as_ref())
+    }
+}
+
+impl Drop for LocalSocket {
+    fn drop(&mut self) {
+        let state = *self.state.read();
+
+        if matches!(state, SocketState::Bound | SocketState::Listening)
+            && let Some(path) = self.local_addr.read().as_ref()
+            && !path.is_empty()
+        {
+            NetworkManager::get_manager().unregister_named_socket(path);
+        }
+
+        if let Some(peer_buf) = self.peer_read_buffer.read().as_ref() {
+            *peer_buf.closed.write() = true;
+        }
+
+        if let Some(peer_weak) = self.peer_socket.read().as_ref()
+            && let Some(peer) = peer_weak.upgrade()
+        {
+            *peer.peer_read_buffer.write() = None;
+            *peer.peer_socket.write() = None;
+            peer.read_waker.wake_all();
+            peer.handle_waker.wake_all();
+        }
+
+        self.accept_waker.wake_all();
+        self.read_waker.wake_all();
+        self.handle_waker.wake_all();
+        *self.state.write() = SocketState::Closed;
+
+        NetworkManager::get_manager().remove_socket_by_ptr(self as *const Self as usize);
     }
 }
 
@@ -816,7 +854,7 @@ impl SocketControl for LocalSocket {
         *server_conn.peer_socket.write() = Some(Arc::downgrade(&client_arc));
 
         // Add server connection to server's backlog
-        let server_local = match Self::from_socket_object(&server_socket) {
+        let server_local = match Self::from_socket_object(server_socket.as_ref()) {
             Some(socket) => socket,
             None => return Err(SocketError::InvalidOperation), // Not a LocalSocket
         };
@@ -1161,6 +1199,35 @@ mod tests {
         let mut buf = [0u8; 4];
         sock1.read(&mut buf).unwrap();
         assert_eq!(&buf, b"pong");
+    }
+
+    #[test_case]
+    fn test_peer_observes_close_when_socket_is_dropped() {
+        let (sock1, sock2) =
+            LocalSocket::create_connected_pair("server".to_string(), "client".to_string());
+
+        drop(sock1);
+
+        let mut buffer = [0u8; 8];
+        let read = sock2.read(&mut buffer).unwrap();
+        assert_eq!(read, 0, "peer read should observe EOF");
+        assert!(
+            sock2.write(b"closed").is_err(),
+            "peer write should fail after remote drop"
+        );
+    }
+
+    #[test_case]
+    fn test_nonblocking_peer_drop_returns_eof() {
+        let (sock1, sock2) =
+            LocalSocket::create_connected_pair("server".to_string(), "client".to_string());
+
+        sock2.set_nonblocking(true);
+        drop(sock1);
+
+        let mut buffer = [0u8; 8];
+        let read = sock2.read(&mut buffer).unwrap();
+        assert_eq!(read, 0, "non-blocking peer read should observe EOF");
     }
 
     #[test_case]

--- a/kernel/src/network/mod.rs
+++ b/kernel/src/network/mod.rs
@@ -138,7 +138,7 @@ pub struct NetworkManager {
     named_sockets: spin::RwLock<BTreeMap<String, Weak<dyn SocketObject>>>,
 
     /// Active socket connections by ID
-    connections: spin::RwLock<BTreeMap<SocketId, Arc<dyn SocketObject>>>,
+    connections: spin::RwLock<BTreeMap<SocketId, Weak<dyn SocketObject>>>,
 
     /// Reverse mapping: socket pointer address -> socket ID for O(1) lookups
     socket_to_id: spin::RwLock<BTreeMap<usize, SocketId>>,
@@ -485,7 +485,7 @@ impl NetworkManager {
         if let Some(factory) = factories.get(&domain) {
             let socket = factory(socket_type, protocol)?;
             let socket_id = self.next_socket_id.fetch_add(1, Ordering::SeqCst);
-            self.connections.write().insert(socket_id, socket.clone());
+            self.register_socket_with_id(socket_id, Arc::clone(&socket))?;
             return Ok(KernelObject::Socket(socket));
         }
         drop(factories);
@@ -493,7 +493,7 @@ impl NetworkManager {
         if let Some(stack) = self.protocol_stacks.get_stack(domain) {
             let socket = stack.create_socket(socket_type, protocol)?;
             let socket_id = self.next_socket_id.fetch_add(1, Ordering::SeqCst);
-            self.connections.write().insert(socket_id, socket.clone());
+            self.register_socket_with_id(socket_id, Arc::clone(&socket))?;
             return Ok(KernelObject::Socket(socket));
         }
 
@@ -556,7 +556,10 @@ impl NetworkManager {
     }
 
     pub fn get_socket(&self, socket_id: SocketId) -> Option<Arc<dyn SocketObject>> {
-        self.connections.read().get(&socket_id).cloned()
+        self.connections
+            .read()
+            .get(&socket_id)
+            .and_then(|socket| socket.upgrade())
     }
 
     pub fn register_socket_with_id(
@@ -565,23 +568,31 @@ impl NetworkManager {
         socket: Arc<dyn SocketObject>,
     ) -> Result<(), SocketError> {
         let mut connections = self.connections.write();
-        if connections.contains_key(&socket_id) {
-            return Err(SocketError::AddressInUse);
+        if let Some(existing) = connections.get(&socket_id) {
+            if existing.upgrade().is_some() {
+                return Err(SocketError::AddressInUse);
+            }
+            connections.remove(&socket_id);
         }
         let socket_ptr = Arc::as_ptr(&socket) as *const () as usize;
-        connections.insert(socket_id, socket);
+        connections.insert(socket_id, Arc::downgrade(&socket));
         drop(connections);
         self.socket_to_id.write().insert(socket_ptr, socket_id);
         Ok(())
     }
 
     pub fn remove_socket(&self, socket_id: SocketId) {
-        let mut connections = self.connections.write();
-        if let Some(socket) = connections.get(&socket_id) {
-            let socket_ptr = Arc::as_ptr(socket) as *const () as usize;
-            drop(connections);
-            self.connections.write().remove(&socket_id);
+        let socket = self.connections.write().remove(&socket_id);
+        if let Some(socket) = socket {
+            let socket_ptr = socket.as_ptr() as *const () as usize;
             self.socket_to_id.write().remove(&socket_ptr);
+        }
+    }
+
+    pub(crate) fn remove_socket_by_ptr(&self, socket_ptr: usize) {
+        let socket_id = self.socket_to_id.write().remove(&socket_ptr);
+        if let Some(socket_id) = socket_id {
+            self.connections.write().remove(&socket_id);
         }
     }
 
@@ -634,7 +645,11 @@ impl NetworkManager {
     }
 
     pub fn connection_count(&self) -> usize {
-        self.connections.read().len()
+        self.connections
+            .read()
+            .values()
+            .filter(|socket| socket.upgrade().is_some())
+            .count()
     }
 
     pub fn named_socket_count(&self) -> usize {

--- a/kernel/src/network/socket.rs
+++ b/kernel/src/network/socket.rs
@@ -352,10 +352,12 @@ pub trait SocketObject: StreamIpcOps + SocketControl + Send + Sync {
     /// Get socket protocol
     fn socket_protocol(&self) -> SocketProtocol;
 
-    /// Cast to Any for safe downcasting
-    fn as_any(&self) -> &dyn core::any::Any
-    where
-        Self: 'static;
+    /// Cast to Any for safe downcasting.
+    ///
+    /// # Returns
+    ///
+    /// Borrowed [`core::any::Any`] view of this socket object.
+    fn as_any(&self) -> &dyn core::any::Any;
 
     /// Send data to a specific address (for datagram sockets)
     /// For stream sockets, address is ignored and data is sent to connected peer

--- a/kernel/src/network/syscall.rs
+++ b/kernel/src/network/syscall.rs
@@ -443,8 +443,8 @@ pub fn sys_socket_bind(tf: &mut Trapframe) -> usize {
     let path_len = tf.get_arg(2);
 
     // Get the socket from handle table
-    let socket_arc = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
+    let socket_arc = match task.handle_table.get_arc_clone(handle_id) {
+        Some(KernelObject::Socket(socket)) => socket,
         _ => return usize::MAX,
     };
 
@@ -563,9 +563,13 @@ pub fn sys_socket_listen(tf: &mut Trapframe) -> usize {
     let backlog = tf.get_arg(1);
 
     // Get the socket from handle table
-    let socket = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => {
+    let socket = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => {
             crate::println!("[sys_socket_listen] Invalid handle {}", handle_id);
             return usize::MAX;
         }
@@ -618,9 +622,13 @@ pub fn sys_socket_connect(tf: &mut Trapframe) -> usize {
     let path_len = tf.get_arg(2);
 
     // Get the socket from handle table
-    let socket = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => return usize::MAX,
+    let socket = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return usize::MAX,
     };
 
     if path_len == core::mem::size_of::<Inet4SocketAddress>() {
@@ -694,16 +702,19 @@ pub fn sys_socket_accept(tf: &mut Trapframe) -> usize {
     let handle_id = tf.get_arg(0) as u32;
 
     // Get the listening socket from handle table
-    let socket_obj = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        Some(_) => return usize::MAX,
+    let socket_obj = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
         None => return usize::MAX,
     };
 
     // Try to downcast to LocalSocket or TcpSocket
     use crate::network::local::LocalSocket;
 
-    let accepted_socket = if let Some(local_socket) = LocalSocket::from_socket_object(&socket_obj) {
+    let accepted_socket = if let Some(local_socket) = LocalSocket::from_socket_object(socket_obj) {
         // LocalSocket accept
         match local_socket.accept_blocking(task.get_id(), tf) {
             Ok(socket) => socket,
@@ -715,7 +726,7 @@ pub fn sys_socket_accept(tf: &mut Trapframe) -> usize {
                 return usize::MAX;
             }
         }
-    } else if let Some(tcp_socket) = crate::network::tcp::TcpSocket::from_socket_object(&socket_obj)
+    } else if let Some(tcp_socket) = crate::network::tcp::TcpSocket::from_socket_object(socket_obj)
     {
         // TcpSocket accept
         match tcp_socket.accept_blocking(task.get_id(), tf) {
@@ -851,9 +862,13 @@ pub fn sys_socket_shutdown(tf: &mut Trapframe) -> usize {
     let how_value = tf.get_arg(1);
 
     // Get the socket from handle table
-    let socket = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => return usize::MAX,
+    let socket = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return usize::MAX,
     };
 
     // Parse shutdown mode
@@ -908,9 +923,13 @@ pub fn sys_socket_recvfrom(tf: &mut Trapframe) -> usize {
     let addr_ptr = tf.get_arg(3);
 
     // Get the socket from handle table
-    let socket = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => return usize::MAX,
+    let socket = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return usize::MAX,
     };
 
     // Create a temporary buffer
@@ -995,9 +1014,13 @@ pub fn sys_socket_sendto(tf: &mut Trapframe) -> usize {
     }
 
     // Get the socket from handle table
-    let socket = match task.handle_table.get(handle_id) {
-        Some(KernelObject::Socket(socket)) => socket.clone(),
-        _ => return usize::MAX,
+    let socket = match task
+        .handle_table
+        .get(handle_id)
+        .and_then(|obj| obj.as_socket())
+    {
+        Some(socket) => socket,
+        None => return usize::MAX,
     };
 
     // Parse destination address

--- a/kernel/src/network/tcp.rs
+++ b/kernel/src/network/tcp.rs
@@ -311,7 +311,7 @@ impl TcpSocket {
     ///
     /// Returns None if socket is not a TcpSocket.
     /// This is completely safe and does not use any unsafe code.
-    pub fn from_socket_object(socket: &Arc<dyn SocketObject>) -> Option<&Self> {
+    pub fn from_socket_object(socket: &dyn SocketObject) -> Option<&Self> {
         socket.as_any().downcast_ref::<TcpSocket>()
     }
 
@@ -1877,6 +1877,19 @@ impl Drop for TcpSocket {
                 layer.unregister_socket(port, &self.self_weak);
             }
         }
+
+        if let Some(waker) = self.accept_waker.lock().as_ref() {
+            waker.wake_all();
+        }
+        if let Some(waker) = self.recv_waker.lock().as_ref() {
+            waker.wake_all();
+        }
+        if let Some(waker) = self.send_waker.lock().as_ref() {
+            waker.wake_all();
+        }
+
+        crate::network::NetworkManager::get_manager()
+            .remove_socket_by_ptr(self as *const Self as usize);
     }
 }
 

--- a/kernel/src/network/udp.rs
+++ b/kernel/src/network/udp.rs
@@ -186,6 +186,26 @@ impl UdpSocket {
     }
 }
 
+impl Drop for UdpSocket {
+    fn drop(&mut self) {
+        if let Some(SocketAddress::Inet(inet)) = self.local_addr.read().clone() {
+            self.udp_layer.unregister_socket(inet.port, &self.self_weak);
+        }
+
+        *self.state.write() = SocketState::Closed;
+
+        if let Some(waker) = self.recv_waker.lock().as_ref() {
+            waker.wake_all();
+        }
+        if let Some(waker) = self.send_waker.lock().as_ref() {
+            waker.wake_all();
+        }
+
+        crate::network::NetworkManager::get_manager()
+            .remove_socket_by_ptr(self as *const Self as usize);
+    }
+}
+
 impl SocketObject for UdpSocket {
     fn socket_type(&self) -> SocketType {
         SocketType::Datagram

--- a/kernel/src/object/capability/memory_mapping/syscall.rs
+++ b/kernel/src/object/capability/memory_mapping/syscall.rs
@@ -170,7 +170,11 @@ pub fn sys_memory_map(trapframe: &mut Trapframe) -> usize {
     prot_perm |= 0x08;
 
     if is_map_private_flag && !is_shared {
-        let owner = match kernel_obj.as_memory_mappable_arc() {
+        let owner = match task
+            .handle_table
+            .get_arc_clone(handle)
+            .and_then(|obj| obj.as_memory_mappable_arc())
+        {
             Some(owner) => owner,
             None => return usize::MAX,
         };
@@ -231,7 +235,10 @@ pub fn sys_memory_map(trapframe: &mut Trapframe) -> usize {
         perm
     } | 0x08;
 
-    let owner = kernel_obj.as_memory_mappable_arc();
+    let owner = task
+        .handle_table
+        .get_arc_clone(handle)
+        .and_then(|obj| obj.as_memory_mappable_arc());
     let vm_map = VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner);
 
     if !is_map_fixed {
@@ -245,7 +252,10 @@ pub fn sys_memory_map(trapframe: &mut Trapframe) -> usize {
             };
             let vmarea = MemoryArea::new(chosen_vaddr, chosen_vaddr + aligned_length - 1);
             let pmarea = MemoryArea::new(paddr, paddr + aligned_length - 1);
-            let owner = kernel_obj.as_memory_mappable_arc();
+            let owner = task
+                .handle_table
+                .get_arc_clone(handle)
+                .and_then(|obj| obj.as_memory_mappable_arc());
             let retry_map =
                 VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner);
             if task.vm_manager.add_memory_map(retry_map).is_err() {

--- a/kernel/src/object/handle/mod.rs
+++ b/kernel/src/object/handle/mod.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 use spin::RwLock;
 
-use crate::object::{KernelObject, introspection};
+use crate::object::{KernelObject, KernelObjectRef, introspection};
 
 pub mod syscall;
 
@@ -181,15 +181,69 @@ impl HandleTable {
         inner.handles[handle as usize].as_ref().map(f)
     }
 
-    /// O(1) access - returns an Arc-level clone of the KernelObject if it exists
+    /// O(1) borrowed access that hides `Arc` ownership from the caller.
+    ///
+    /// This method returns a borrowed view of the handle-table object without
+    /// incrementing the object's `Arc` reference count. The returned view does
+    /// not expose the underlying `Arc`, so ordinary handle lookup cannot extend
+    /// object lifetime beyond the owning handle table.
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - Handle number to access
+    ///
+    /// # Returns
+    ///
+    /// Borrowed object view if the handle exists, otherwise `None`.
+    pub fn get(&self, handle: Handle) -> Option<KernelObjectRef<'_>> {
+        if handle as usize >= Self::MAX_HANDLES {
+            return None;
+        }
+        let inner = self.inner.read();
+        let object = inner.handles[handle as usize].as_ref()? as *const KernelObject;
+        // SAFETY: The pointer refers to a handle-table slot in `self`. The view
+        // is lifetime-bound to `&self` and does not own or clone the object.
+        Some(unsafe { KernelObjectRef::from_ptr(object) })
+    }
+
+    /// O(1) borrowed access that hides `Arc` ownership from the caller.
+    ///
+    /// Since the internal data is protected by RwLock, the borrowed view is
+    /// available only for the duration of the closure. Use this for ordinary
+    /// handle operations that should not extend object lifetime beyond the
+    /// owning handle table.
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - Handle number to access
+    /// * `f` - Closure executed with a borrowed kernel object view
+    ///
+    /// # Returns
+    ///
+    /// The closure result if the handle exists, otherwise `None`.
+    pub fn with_object_ref<F, R>(&self, handle: Handle, f: F) -> Option<R>
+    where
+        F: for<'a> FnOnce(KernelObjectRef<'a>) -> R,
+    {
+        if handle as usize >= Self::MAX_HANDLES {
+            return None;
+        }
+        let inner = self.inner.read();
+        inner.handles[handle as usize]
+            .as_ref()
+            .map(|object| f(KernelObjectRef::new(object)))
+    }
+
+    /// O(1) access - returns an Arc-level clone of the KernelObject if it exists.
     ///
     /// This method returns an Arc-level clone of the KernelObject. Unlike the Clone
     /// trait which may have side effects (e.g., incrementing Pipe reader/writer counts),
     /// this performs a simple Arc reference count increment without modifying object state.
     ///
-    /// For cases where you need dup() semantics (creating a new logical file descriptor
-    /// with proper reference counting), use `clone_for_dup()` instead.
-    pub fn get(&self, handle: Handle) -> Option<KernelObject> {
+    /// Prefer [`HandleTable::get`] for ordinary handle lookup. Use this method only
+    /// when an operation must intentionally keep the object alive independently of
+    /// the owning handle table.
+    pub fn get_arc_clone(&self, handle: Handle) -> Option<KernelObject> {
         if handle as usize >= Self::MAX_HANDLES {
             return None;
         }

--- a/kernel/src/object/handle/syscall.rs
+++ b/kernel/src/object/handle/syscall.rs
@@ -149,10 +149,9 @@ pub fn sys_handle_duplicate(trapframe: &mut Trapframe) -> usize {
     let handle = trapframe.get_arg(0) as u32;
     trapframe.increment_pc_next(task);
 
-    // Check if the handle exists and get the kernel object
-    if let Some(kernel_obj) = task.handle_table.get(handle) {
-        // Insert a new handle for the same object
-        match task.handle_table.insert(kernel_obj.clone()) {
+    // Duplicate using object-specific dup semantics where available.
+    if let Some(kernel_obj) = task.handle_table.clone_for_dup(handle) {
+        match task.handle_table.insert(kernel_obj) {
             Ok(new_handle) => new_handle as usize,
             Err(_) => usize::MAX, // Handle table full
         }

--- a/kernel/src/object/handle/tests/handle_table.rs
+++ b/kernel/src/object/handle/tests/handle_table.rs
@@ -33,6 +33,24 @@ fn test_handle_table_insert_and_get() {
 }
 
 #[test_case]
+fn test_handle_table_with_object_ref_does_not_clone_arc() {
+    let table = HandleTable::new();
+    let mock_file = Arc::new(MockFileObject::new(b"borrowed".to_vec()));
+    let kernel_obj = KernelObject::File(mock_file.clone());
+
+    let handle = table.insert(kernel_obj).unwrap();
+    let count_before = Arc::strong_count(&mock_file);
+
+    let has_stream = table
+        .with_object_ref(handle, |object| object.as_stream().is_some())
+        .unwrap();
+
+    assert!(has_stream);
+    assert_eq!(Arc::strong_count(&mock_file), count_before);
+    assert!(table.with_object_ref(999, |_| true).is_none());
+}
+
+#[test_case]
 fn test_handle_table_remove() {
     let table = HandleTable::new();
     let mock_file = Arc::new(MockFileObject::new(b"test".to_vec()));

--- a/kernel/src/object/mod.rs
+++ b/kernel/src/object/mod.rs
@@ -17,6 +17,7 @@ use crate::ipc::shared_memory::SharedMemoryObject;
 use crate::object::timer::{Timer, TimerObject};
 use alloc::sync::Arc;
 use capability::{CloneOps, ControlOps, MemoryMappingOps, Selectable, StreamOps};
+use core::marker::PhantomData;
 
 #[cfg(feature = "network")]
 use crate::network::SocketObject;
@@ -45,6 +46,240 @@ pub enum KernelObject {
     // Future variants will be added here:
     // MessageQueue(Arc<dyn MessageQueueObject>),
     // CharDevice(Arc<dyn CharDevice>),
+}
+
+/// Borrowed view of a kernel object that does not expose `Arc` ownership.
+///
+/// This wrapper is intended for handle-table access paths that only need to
+/// inspect or operate on an object without extending its lifetime. It mirrors
+/// the normal capability accessors on [`KernelObject`], but intentionally omits
+/// APIs that create strong or weak references.
+#[derive(Clone, Copy)]
+pub struct KernelObjectRef<'a> {
+    object: *const KernelObject,
+    _marker: PhantomData<&'a KernelObject>,
+}
+
+impl<'a> KernelObjectRef<'a> {
+    /// Create a borrowed kernel object view.
+    ///
+    /// # Arguments
+    ///
+    /// * `object` - Kernel object borrowed from its owning handle table
+    ///
+    /// # Returns
+    ///
+    /// A borrowed view that cannot clone the underlying object.
+    pub(crate) const fn new(object: &'a KernelObject) -> Self {
+        Self {
+            object,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create a borrowed kernel object view from a stable handle-table slot.
+    ///
+    /// # Arguments
+    ///
+    /// * `object` - Pointer to a kernel object stored in a handle-table slot
+    ///
+    /// # Returns
+    ///
+    /// A borrowed view that cannot clone the underlying object.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be valid for `'a` and must point to a live
+    /// [`KernelObject`] while this borrowed view is used.
+    pub(crate) const unsafe fn from_ptr(object: *const KernelObject) -> Self {
+        Self {
+            object,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn object(&self) -> &'a KernelObject {
+        // SAFETY: KernelObjectRef is constructed only from handle-table object
+        // references or stable slot pointers whose validity is tied to 'a.
+        unsafe { &*self.object }
+    }
+
+    /// Get the underlying borrowed [`KernelObject`].
+    ///
+    /// # Returns
+    ///
+    /// Borrowed kernel object without extending object lifetime.
+    pub(crate) fn as_kernel_object(&self) -> &'a KernelObject {
+        self.object()
+    }
+
+    /// Get a human-readable object type name.
+    ///
+    /// # Returns
+    ///
+    /// Static object type name for diagnostics.
+    pub fn type_name(&self) -> &'static str {
+        match self.object() {
+            KernelObject::File(_) => "File",
+            KernelObject::Pipe(_) => "Pipe",
+            KernelObject::Counter(_) => "Counter",
+            KernelObject::Timer(_) => "Timer",
+            KernelObject::EventChannel(_) => "EventChannel",
+            KernelObject::EventSubscription(_) => "EventSubscription",
+            KernelObject::SharedMemory(_) => "SharedMemory",
+            #[cfg(feature = "network")]
+            KernelObject::Socket(_) => "Socket",
+            #[cfg(feature = "hypervisor")]
+            KernelObject::HypervisorVm(_) => "HypervisorVm",
+            #[cfg(feature = "hypervisor")]
+            KernelObject::HypervisorVcpu(_) => "HypervisorVcpu",
+        }
+    }
+
+    /// Try to get the hypervisor VM Arc by borrowed reference.
+    ///
+    /// # Returns
+    ///
+    /// Borrowed VM Arc if the object is a hypervisor VM.
+    #[cfg(feature = "hypervisor")]
+    pub(crate) fn as_hypervisor_vm_arc(&self) -> Option<&'a hypervisor::VmRef> {
+        match self.object() {
+            KernelObject::HypervisorVm(vm) => Some(vm),
+            _ => None,
+        }
+    }
+
+    /// Try to get the hypervisor vCPU object by borrowed reference.
+    ///
+    /// # Returns
+    ///
+    /// Borrowed vCPU object if the object is a hypervisor vCPU.
+    #[cfg(feature = "hypervisor")]
+    pub(crate) fn as_hypervisor_vcpu(&self) -> Option<&'a dyn hypervisor::VcpuObject> {
+        match self.object() {
+            KernelObject::HypervisorVcpu(vcpu) => Some(vcpu.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Try to get StreamOps capability.
+    ///
+    /// # Returns
+    ///
+    /// Stream capability if the borrowed object supports stream operations.
+    pub fn as_stream(&self) -> Option<&'a dyn StreamOps> {
+        self.object().as_stream()
+    }
+
+    /// Try to get StreamIpcOps capability for IPC stream operations.
+    ///
+    /// # Returns
+    ///
+    /// Stream IPC capability if the borrowed object supports IPC stream operations.
+    pub fn as_stream_ipc(&self) -> Option<&'a dyn StreamIpcOps> {
+        self.object().as_stream_ipc()
+    }
+
+    /// Try to get FileObject that provides file-like operations and stream capabilities.
+    ///
+    /// # Returns
+    ///
+    /// File capability if the borrowed object is file-like.
+    pub fn as_file(&self) -> Option<&'a dyn FileObject> {
+        self.object().as_file()
+    }
+
+    /// Try to get PipeObject that provides pipe-specific operations.
+    ///
+    /// # Returns
+    ///
+    /// Pipe capability if the borrowed object is a pipe.
+    pub fn as_pipe(&self) -> Option<&'a dyn PipeObject> {
+        self.object().as_pipe()
+    }
+
+    /// Try to get SocketObject that provides socket-specific operations.
+    ///
+    /// # Returns
+    ///
+    /// Socket capability if the borrowed object is a socket.
+    #[cfg(feature = "network")]
+    pub fn as_socket(&self) -> Option<&'a dyn SocketObject> {
+        self.object().as_socket()
+    }
+
+    /// Try to get SharedMemoryObject that provides shared memory operations.
+    ///
+    /// # Returns
+    ///
+    /// Shared memory capability if the borrowed object is shared memory.
+    pub fn as_shared_memory(&self) -> Option<&'a dyn SharedMemoryObject> {
+        self.object().as_shared_memory()
+    }
+
+    /// Try to get ControlOps capability.
+    ///
+    /// # Returns
+    ///
+    /// Control capability if the borrowed object supports control operations.
+    pub fn as_control(&self) -> Option<&'a dyn ControlOps> {
+        self.object().as_control()
+    }
+
+    /// Try to get MemoryMappingOps capability.
+    ///
+    /// # Returns
+    ///
+    /// Memory mapping capability if the borrowed object can be mapped.
+    pub fn as_memory_mappable(&self) -> Option<&'a dyn MemoryMappingOps> {
+        self.object().as_memory_mappable()
+    }
+
+    /// Try to get EventChannelObject.
+    ///
+    /// # Returns
+    ///
+    /// Event channel object if the borrowed object is an event channel.
+    pub fn as_event_channel(&self) -> Option<&'a EventChannelObject> {
+        self.object().as_event_channel()
+    }
+
+    /// Try to get EventSubscriptionObject.
+    ///
+    /// # Returns
+    ///
+    /// Event subscription object if the borrowed object is an event subscription.
+    pub fn as_event_subscription(&self) -> Option<&'a EventSubscriptionObject> {
+        self.object().as_event_subscription()
+    }
+
+    /// Try to get CounterObject.
+    ///
+    /// # Returns
+    ///
+    /// Counter capability if the borrowed object is a counter.
+    pub fn as_counter(&self) -> Option<&'a dyn CounterObject> {
+        self.object().as_counter()
+    }
+
+    /// Try to get TimerObject.
+    ///
+    /// # Returns
+    ///
+    /// Timer capability if the borrowed object is a timer.
+    pub fn as_timer(&self) -> Option<&'a dyn TimerObject> {
+        self.object().as_timer()
+    }
+
+    /// Try to get Selectable capability for pselect/select readiness.
+    ///
+    /// # Returns
+    ///
+    /// Selectable capability if the borrowed object exposes readiness state.
+    pub fn as_selectable(&self) -> Option<&'a dyn Selectable> {
+        self.object().as_selectable()
+    }
 }
 
 impl KernelObject {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -112,8 +112,8 @@ use crate::task::syscall::{
     sys_exit, sys_exit_group, sys_get_process_group_id, sys_get_session_id,
     sys_get_task_info_count, sys_get_task_info_list, sys_get_tls, sys_getchar, sys_getpid,
     sys_getppid, sys_putchar, sys_register_abi_zone, sys_sbrk, sys_set_process_group,
-    sys_set_tid_address, sys_set_tls, sys_shutdown, sys_sleep, sys_unregister_abi_zone,
-    sys_waitpid, sys_yield,
+    sys_set_tid_address, sys_set_tls, sys_shutdown, sys_sleep, sys_thread_detach,
+    sys_unregister_abi_zone, sys_waitpid, sys_yield,
 };
 
 #[macro_use]
@@ -198,6 +198,7 @@ syscall_table! {
     SetTls = 30 => sys_set_tls,
     GetTls = 31 => sys_get_tls,
     SetTidAddress = 32 => sys_set_tid_address,
+    ThreadDetach = 33 => sys_thread_detach,
 
     // ABI Zone Management
     RegisterAbiZone = 90 => sys_register_abi_zone,

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -35,8 +35,8 @@ use crate::{
     mem::page::ContiguousPages,
     object::handle::HandleTable,
     sched::scheduler::{
-        current_task, finalize_zombie, get_all_task_ids, get_task_by_id, remove_from_ready_queues,
-        schedule, setup_task_execution, unmark_blocked,
+        cleanup_zombie, current_task, finalize_zombie, get_all_task_ids, get_task_by_id,
+        remove_from_ready_queues, schedule, setup_task_execution, unmark_blocked,
     },
     timer::{TimerHandler, add_timer, get_tick},
     vm::{
@@ -50,6 +50,8 @@ use alloc::collections::BTreeMap;
 use core::ops::Range;
 use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU8, AtomicU32, AtomicUsize, Ordering};
 use spin::Once;
+
+const INIT_TASK_ID: usize = 1;
 
 /// Lock type used for the architecture kernel context.
 ///
@@ -1286,6 +1288,70 @@ impl Task {
         self.parent_id.store(parent_id, Ordering::SeqCst);
     }
 
+    /// Clear the parent task relationship.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
+    pub fn clear_parent_id(&self) {
+        self.parent_id.store(0, Ordering::SeqCst);
+    }
+
+    fn orphan_reaper(&self) -> Option<&'static Task> {
+        if self.thread_group_id != self.id
+            && let Some(leader) = get_task_by_id(self.thread_group_id)
+            && !matches!(
+                leader.get_state(),
+                TaskState::Zombie | TaskState::Terminated
+            )
+        {
+            return Some(leader);
+        }
+
+        if self.id != INIT_TASK_ID {
+            get_task_by_id(INIT_TASK_ID)
+        } else {
+            None
+        }
+    }
+
+    fn reparent_children(&self) {
+        let child_ids = {
+            let mut children = self.children.write();
+            if children.is_empty() {
+                return;
+            }
+            let child_ids = children.clone();
+            children.clear();
+            child_ids
+        };
+
+        let reaper = self.orphan_reaper();
+
+        for child_id in child_ids {
+            let Some(child) = get_task_by_id(child_id) else {
+                continue;
+            };
+            if child.get_parent_id() != Some(self.id) {
+                continue;
+            }
+
+            if let Some(reaper) = reaper {
+                child.set_parent_id(reaper.get_id());
+                reaper.add_child(child_id);
+                if child.get_state() == TaskState::Zombie {
+                    finalize_zombie(child_id, Some(reaper.get_id()));
+                }
+            } else {
+                child.clear_parent_id();
+                if child.get_state() == TaskState::Zombie {
+                    child.set_state(TaskState::Terminated);
+                    cleanup_zombie(child_id);
+                }
+            }
+        }
+    }
+
     /// Add a child task
     ///
     /// # Arguments
@@ -1736,6 +1802,7 @@ impl Task {
         // Let current ABI perform exit-time cleanup (Linux: clear_child_tid, robust list, etc.)
         // Use take/restore to avoid aliasing &mut self and &mut field
         self.with_default_abi_mut(|abi, task| abi.on_task_exit(task));
+        self.reparent_children();
 
         match self.get_parent_id() {
             Some(parent_id) => {
@@ -1791,19 +1858,34 @@ impl Task {
     pub fn exit_group(&self, status: i32) {
         let thread_group_id = self.thread_group_id;
         let my_id = self.id;
+        let leader_id = thread_group_id;
 
-        // Get all task IDs in the system
+        // The process is exiting, so shared file tables must be closed even
+        // while sibling Task objects still hold HandleTable Arc references.
+        self.handle_table.close_all();
+
         let all_task_ids = get_all_task_ids();
+        let mut leader_finalized = false;
 
-        // Terminate all tasks with the same thread group ID (except self)
+        // Terminate all tasks with the same thread group ID (except self).
+        // The thread-group leader is the process wait target, so keep it as
+        // the observable zombie even when another thread initiates exit_group.
         for task_id in all_task_ids {
             if task_id == my_id {
-                continue; // Skip self
+                continue;
             }
 
             if let Some(task) = get_task_by_id(task_id) {
                 if task.get_thread_group_id() == thread_group_id {
-                    // Terminate this thread group member
+                    if task_id == leader_id {
+                        leader_finalized = true;
+                        remove_from_ready_queues(task_id);
+                        unmark_blocked(task_id);
+                        task.exit(status);
+                        continue;
+                    }
+
+                    task.reparent_children();
                     crate::println!(
                         "[exit_group] Task {} terminating sibling task {} (thread_group_id={})",
                         my_id,
@@ -1812,7 +1894,7 @@ impl Task {
                     );
                     // Set state to Terminated directly (bypass normal exit)
                     // Use unsafe to modify state through immutable reference
-                    // This is safe because we're in a termination context
+                    // This is safe because we are in a termination context
                     let task_ptr = task as *const Task as *mut Task;
                     unsafe {
                         (*task_ptr)
@@ -1828,8 +1910,37 @@ impl Task {
             }
         }
 
-        // Now exit the current task normally
-        self.exit(status);
+        if my_id == leader_id {
+            self.exit(status);
+            return;
+        }
+
+        if !leader_finalized
+            && let Some(leader) = get_task_by_id(leader_id)
+            && leader.get_thread_group_id() == thread_group_id
+            && !matches!(
+                leader.get_state(),
+                TaskState::Zombie | TaskState::Terminated
+            )
+        {
+            remove_from_ready_queues(leader_id);
+            unmark_blocked(leader_id);
+            leader.exit(status);
+        }
+
+        self.clear_process_control_stopped();
+        self.with_default_abi_mut(|abi, task| abi.on_task_exit(task));
+        self.reparent_children();
+        self.set_exit_status(status);
+        self.state.store(TaskState::Terminated, Ordering::SeqCst);
+        remove_from_ready_queues(my_id);
+        unmark_blocked(my_id);
+
+        if mytask().is_some_and(|task| task.get_id() == self.id) {
+            if let Some(current_task) = mytask() {
+                schedule(current_task.get_trapframe());
+            }
+        }
     }
 
     /// Wait for a child task to exit and collect its status
@@ -2296,8 +2407,9 @@ mod tests {
     use alloc::sync::Arc;
     use core::sync::atomic::Ordering;
 
-    use crate::sched::scheduler::{add_task, get_task_by_id, reset};
-    use crate::task::{CloneFlags, CloneFlagsDef};
+    use super::INIT_TASK_ID;
+    use crate::sched::scheduler::{add_task, finalize_zombie, get_task_by_id, reset};
+    use crate::task::{CloneFlags, CloneFlagsDef, TaskState};
     use crate::vm::addr::{phys_to_virt, virt_to_phys};
 
     #[test_case]
@@ -2357,6 +2469,77 @@ mod tests {
             assert!(parent_task.remove_child(child_id));
             assert!(!parent_task.get_children().contains(&child_id));
         }
+    }
+
+    #[test_case]
+    fn test_task_reparents_children_to_init_on_exit() {
+        reset();
+
+        let mut init_task = super::new_user_task("InitTask".to_string(), 0);
+        init_task.init();
+        let init_id = add_task(init_task, 0);
+        assert_eq!(init_id, INIT_TASK_ID);
+
+        let mut parent_task = super::new_user_task("ParentTask".to_string(), 0);
+        parent_task.init();
+        let parent_id = add_task(parent_task, 0);
+
+        let mut child_task = super::new_user_task("ChildTask".to_string(), 0);
+        child_task.init();
+        let child_id = add_task(child_task, 0);
+
+        let parent = get_task_by_id(parent_id).unwrap();
+        let child = get_task_by_id(child_id).unwrap();
+        child.set_parent_id(parent_id);
+        parent.add_child(child_id);
+
+        parent.exit(0);
+
+        let init = get_task_by_id(init_id).unwrap();
+        let child = get_task_by_id(child_id).unwrap();
+        assert_eq!(child.get_parent_id(), Some(init_id));
+        assert!(init.get_children().contains(&child_id));
+        assert!(!parent.get_children().contains(&child_id));
+    }
+
+    #[test_case]
+    fn test_task_reparents_zombie_children_to_init_on_exit() {
+        reset();
+
+        let mut init_task = super::new_user_task("InitTask".to_string(), 0);
+        init_task.init();
+        let init_id = add_task(init_task, 0);
+        assert_eq!(init_id, INIT_TASK_ID);
+
+        let mut parent_task = super::new_user_task("ParentTask".to_string(), 0);
+        parent_task.init();
+        let parent_id = add_task(parent_task, 0);
+
+        let mut child_task = super::new_user_task("ChildTask".to_string(), 0);
+        child_task.init();
+        let child_id = add_task(child_task, 0);
+
+        let parent = get_task_by_id(parent_id).unwrap();
+        let child = get_task_by_id(child_id).unwrap();
+        child.set_parent_id(parent_id);
+        parent.add_child(child_id);
+        child.set_exit_status(7);
+        child.set_state(TaskState::Zombie);
+        finalize_zombie(child_id, Some(parent_id));
+
+        parent.exit(0);
+
+        let init = get_task_by_id(init_id).unwrap();
+        let child = get_task_by_id(child_id).unwrap();
+        assert_eq!(child.get_parent_id(), Some(init_id));
+        assert_eq!(child.get_state(), TaskState::Zombie);
+        assert!(init.get_children().contains(&child_id));
+
+        match init.wait(child_id) {
+            Ok(status) => assert_eq!(status, 7),
+            Err(error) => panic!("wait failed: {:?}", error),
+        }
+        assert!(get_task_by_id(child_id).is_none());
     }
 
     #[test_case]
@@ -2429,6 +2612,42 @@ mod tests {
         let child_id = add_task(child, 0);
         let child = get_task_by_id(child_id).unwrap();
         assert_eq!(child.get_thread_group_id(), parent.get_thread_group_id());
+    }
+
+    #[test_case]
+    fn test_exit_group_from_non_leader_makes_leader_waitable() {
+        reset();
+
+        let mut parent = super::new_user_task("WaitParent".to_string(), 0);
+        parent.init();
+        let parent_id = add_task(parent, 0);
+
+        let mut leader = super::new_user_task("ProcessLeader".to_string(), 0);
+        leader.init();
+        let leader_id = add_task(leader, 0);
+
+        let parent = get_task_by_id(parent_id).unwrap();
+        let leader = get_task_by_id(leader_id).unwrap();
+        leader.set_parent_id(parent_id);
+        parent.add_child(leader_id);
+
+        let mut flags = CloneFlags::default();
+        flags.set(CloneFlagsDef::Thread);
+        let worker = leader.clone_task(flags).unwrap();
+        let worker_id = add_task(worker, 0);
+
+        let worker = get_task_by_id(worker_id).unwrap();
+        worker.exit_group(130);
+
+        let leader = get_task_by_id(leader_id).unwrap();
+        assert_eq!(leader.get_state(), TaskState::Zombie);
+        assert_eq!(worker.get_state(), TaskState::Terminated);
+
+        match parent.wait(leader_id) {
+            Ok(status) => assert_eq!(status, 130),
+            Err(error) => panic!("wait failed: {:?}", error),
+        }
+        assert!(get_task_by_id(leader_id).is_none());
     }
 
     #[test_case]

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -26,8 +26,8 @@ use crate::library::std::string::{
 
 use crate::arch::Trapframe;
 use crate::sched::scheduler::{
-    enqueue_task, get_all_task_ids, get_task_by_id, register_task, remove_task_from_queues,
-    schedule,
+    cleanup_zombie, enqueue_task, get_all_task_ids, get_task_by_id, register_task,
+    remove_task_from_queues, schedule,
 };
 use crate::task::{
     CloneFlags, CloneFlagsDef, TaskState, WaitError, get_parent_waitpid_waker, get_waitpid_waker,
@@ -189,6 +189,79 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
             usize::MAX /* Return -1 on error */
         }
     }
+}
+
+/// Detach a child thread from the caller's wait set.
+///
+/// Dropping a user-space JoinHandle calls this syscall. Detached threads must
+/// not remain as zombies owned by the spawning thread; if the thread already
+/// exited, it is reaped immediately.
+///
+/// # Arguments
+///
+/// * `trapframe.arg(0)` - Namespace-local thread ID to detach.
+///
+/// # Returns
+///
+/// 0 on success, or `usize::MAX` on failure.
+pub fn sys_thread_detach(trapframe: &mut Trapframe) -> usize {
+    let caller = mytask().unwrap();
+    let local_thread_id = trapframe.get_arg(0);
+    trapframe.increment_pc_next(caller);
+
+    let target_id = match caller.get_namespace().resolve_global_id(local_thread_id) {
+        Some(id) => id,
+        None => return usize::MAX,
+    };
+
+    if target_id == caller.get_id() {
+        return usize::MAX;
+    }
+
+    let Some(target) = get_task_by_id(target_id) else {
+        return usize::MAX;
+    };
+
+    // Only allow detaching threads in the caller's thread group. This keeps the
+    // syscall scoped to std::thread JoinHandle semantics, not arbitrary waitpid.
+    if target.get_thread_group_id() != caller.get_thread_group_id() {
+        return usize::MAX;
+    }
+
+    let Some(parent_id) = target.get_parent_id() else {
+        if target.get_state() == TaskState::Zombie {
+            target.set_state(TaskState::Terminated);
+            remove_task_from_queues(target_id);
+            cleanup_zombie(target_id);
+        }
+        return 0;
+    };
+
+    let Some(parent) = get_task_by_id(parent_id) else {
+        target.clear_parent_id();
+        if target.get_state() == TaskState::Zombie {
+            target.set_state(TaskState::Terminated);
+            remove_task_from_queues(target_id);
+            cleanup_zombie(target_id);
+        }
+        return 0;
+    };
+
+    if parent_id != caller.get_id() && parent.get_thread_group_id() != caller.get_thread_group_id()
+    {
+        return usize::MAX;
+    }
+
+    parent.remove_child(target_id);
+    target.clear_parent_id();
+
+    if target.get_state() == TaskState::Zombie {
+        target.set_state(TaskState::Terminated);
+        remove_task_from_queues(target_id);
+        cleanup_zombie(target_id);
+    }
+
+    0
 }
 
 /// Set the TLS pointer for the current task

--- a/user/bin/src/sws/compositor.rs
+++ b/user/bin/src/sws/compositor.rs
@@ -7,6 +7,7 @@ use super::window::WindowManager;
 use core::sync::atomic::{AtomicU8, Ordering};
 use framebuffer::Framebuffer;
 use std::env;
+use std::handle::Handle;
 use std::println;
 use std::vec::Vec;
 use sws_protocol;
@@ -47,6 +48,7 @@ pub struct Compositor {
     framebuffer: Framebuffer,
     window_manager: WindowManager,
     ipc_server: IpcServer,
+    wake_read: Handle,
     cursor: Cursor,
     screen_width: u32,
     screen_height: u32,
@@ -122,6 +124,10 @@ impl Compositor {
             var_info.bits_per_pixel, fix_info.line_length, fix_info.smem_len
         );
 
+        let (wake_read, wake_write) =
+            std::task::pipe().map_err(|_| "Failed to create compositor wake pipe")?;
+        super::ipc::set_compositor_wake_handle(wake_write);
+
         // Start input thread
         InputManager::start_input_thread(screen_width, screen_height)?;
 
@@ -151,6 +157,7 @@ impl Compositor {
             framebuffer,
             window_manager,
             ipc_server,
+            wake_read,
             cursor,
             screen_width,
             screen_height,
@@ -1560,6 +1567,13 @@ impl Compositor {
         self.send_mouse_position_to_window_coords(window_id, window, window_x, window_y);
     }
 
+    fn wait_for_wake(&mut self) {
+        let mut buf = [0u8; 1];
+        if let Ok(stream) = self.wake_read.as_stream() {
+            let _ = stream.read(&mut buf);
+        }
+    }
+
     /// Main event loop
     pub fn run(&mut self) -> Result<(), &'static str> {
         println!("[Compositor] Starting main loop (multithreaded)");
@@ -1605,10 +1619,8 @@ impl Compositor {
                 self.event_counter += 1;
             }
 
-            // Sleep briefly to limit frame rate and reduce CPU usage
-            // 16ms = ~60fps, adjust as needed
-            std::thread::sleep(core::time::Duration::from_millis(16));
-            // yield_now();
+            // Sleep until IPC/input explicitly wakes the compositor.
+            self.wait_for_wake();
 
             // Periodically print Z-order (every 100 redraws)
             // if self.event_counter % 100 == 0 && self.event_counter > 0 {
@@ -2019,6 +2031,132 @@ impl Compositor {
         }
     }
 
+    fn window_id_in(window_ids: &[u32], window_id: u32) -> bool {
+        window_ids.iter().any(|&id| id == window_id)
+    }
+
+    fn broadcast_empty_active_app_changed(&mut self) {
+        let empty_payload = sws_protocol::payload_active_app_changed(
+            0,   // dummy window_id
+            b"", // empty app_id
+            b"", // empty app_name
+            b"", // empty title
+            b"", // empty menu_titles
+        );
+        println!("[Compositor] Broadcasting empty ACTIVE_APP_CHANGED to clear TaskBar menu");
+        super::ipc::broadcast_message_to_all_clients(
+            sws_protocol::server_msg::ACTIVE_APP_CHANGED,
+            empty_payload,
+        );
+    }
+
+    fn clear_interaction_state_for_removed_windows(&mut self, window_ids: &[u32]) {
+        if let Some(window_id) = self.pointer_grab_window_id {
+            if Self::window_id_in(window_ids, window_id) {
+                self.pointer_grab_window_id = None;
+                self.last_left_down_cursor = None;
+            }
+        }
+
+        if let Some(state) = self.move_drag {
+            if Self::window_id_in(window_ids, state.window_id) {
+                self.move_drag = None;
+            }
+        }
+
+        if let Some(state) = self.resize_drag {
+            if Self::window_id_in(window_ids, state.window_id) {
+                if let Some(outline) = self.resize_outline.take() {
+                    self.add_pending_damage(outline);
+                }
+                self.resize_drag = None;
+            }
+        }
+    }
+
+    fn close_client_windows(
+        &mut self,
+        client_id: usize,
+        window_ids: &[u32],
+        notify_client: bool,
+    ) -> bool {
+        let mut removed_windows: Vec<(u32, (i32, i32, u32, u32), Vec<u8>)> = Vec::new();
+        for &window_id in window_ids {
+            if let Some(window) = self.window_manager.get_window(window_id) {
+                removed_windows.push((
+                    window_id,
+                    (window.x, window.y, window.width, window.height),
+                    window.app_id.clone().unwrap_or_default(),
+                ));
+            }
+        }
+
+        if removed_windows.is_empty() {
+            return false;
+        }
+
+        let removed_ids: Vec<u32> = removed_windows
+            .iter()
+            .map(|(window_id, _, _)| *window_id)
+            .collect();
+        self.clear_interaction_state_for_removed_windows(&removed_ids);
+
+        let mut active_app_removed = false;
+        for (window_id, rect, app_id) in &removed_windows {
+            if notify_client {
+                let payload = sws_protocol::payload_window_destroyed(*window_id);
+                send_message_to_client(
+                    client_id,
+                    sws_protocol::server_msg::WINDOW_DESTROYED,
+                    payload.to_vec(),
+                );
+                println!(
+                    "[Compositor] Sent WINDOW_DESTROYED for window #{} to client {}",
+                    window_id, client_id
+                );
+            }
+
+            if self.last_focused_window_id == Some(*window_id) {
+                println!(
+                    "[Compositor] Focused window destroyed, resetting last_focused_window_id (was={})",
+                    window_id
+                );
+                self.last_focused_window_id = None;
+            }
+
+            if self.active_app_id.as_ref().map_or(false, |current_app_id| {
+                current_app_id.as_slice() == app_id.as_slice()
+            }) {
+                println!(
+                    "[Compositor] Active app window destroyed, resetting active_app_id (was={})",
+                    core::str::from_utf8(app_id).unwrap_or("")
+                );
+                active_app_removed = true;
+            }
+
+            self.window_manager.close_window(*window_id);
+            self.add_pending_damage(*rect);
+        }
+
+        if active_app_removed {
+            self.active_app_id = None;
+        }
+
+        if let Some(new_focus) = self.window_manager.get_focused_window_id() {
+            if active_app_removed || self.last_focused_window_id != Some(new_focus) {
+                self.last_focused_window_id = None;
+                self.broadcast_focus_change(new_focus);
+            }
+        }
+
+        if active_app_removed && self.active_app_id.is_none() {
+            self.broadcast_empty_active_app_changed();
+        }
+
+        self.full_redraw_needed = true;
+        true
+    }
+
     /// Handle IPC events from clients
     ///
     /// Returns `Ok(true)` if an immediate redraw is required (e.g., window created/destroyed).
@@ -2244,62 +2382,25 @@ impl Compositor {
                     client_id, window_id
                 );
 
-                // Check if the destroyed window was the active application
-                if let Some(window) = self.window_manager.get_window(window_id) {
-                    let window_app_id = window.app_id.as_deref().unwrap_or(b"");
-
-                    // Reset last_focused_window_id if the destroyed window was focused
-                    if self.last_focused_window_id == Some(window_id) {
-                        println!(
-                            "[Compositor] Focused window destroyed, resetting last_focused_window_id (was={})",
-                            window_id
-                        );
-                        self.last_focused_window_id = None;
-                    }
-
-                    if let Some(current_app_id) = &self.active_app_id {
-                        if current_app_id == window_app_id {
-                            println!(
-                                "[Compositor] Active app window destroyed, resetting active_app_id (was={})",
-                                core::str::from_utf8(window_app_id).unwrap_or("")
-                            );
-                            self.active_app_id = None;
-
-                            // Broadcast ACTIVE_APP_CHANGED with empty menu to clear TaskBar
-                            let empty_payload = sws_protocol::payload_active_app_changed(
-                                0,   // dummy window_id
-                                b"", // empty app_id
-                                b"", // empty app_name
-                                b"", // empty title
-                                b"", // empty menu_titles
-                            );
-                            println!(
-                                "[Compositor] Broadcasting empty ACTIVE_APP_CHANGED to clear TaskBar menu"
-                            );
-                            super::ipc::broadcast_message_to_all_clients(
-                                sws_protocol::server_msg::ACTIVE_APP_CHANGED,
-                                empty_payload,
-                            );
-                        }
-                    }
+                if self.close_client_windows(client_id, &[window_id], true) {
+                    self.dump_memory_layout("after IPC DestroyWindow");
+                    return Ok(true);
                 }
-
-                // Send WINDOW_DESTROYED event to client before closing
-                let payload = sws_protocol::payload_window_destroyed(window_id);
-                send_message_to_client(
-                    client_id,
-                    sws_protocol::server_msg::WINDOW_DESTROYED,
-                    payload.to_vec(),
-                );
+            }
+            IpcEvent::ClientDisconnected {
+                client_id,
+                window_ids,
+            } => {
                 println!(
-                    "[Compositor] Sent WINDOW_DESTROYED for window #{} to client {}",
-                    window_id, client_id
+                    "[Compositor] Client {} disconnected; removing {} windows",
+                    client_id,
+                    window_ids.len()
                 );
 
-                self.window_manager.close_window(window_id);
-                self.full_redraw_needed = true;
-
-                self.dump_memory_layout("after IPC DestroyWindow");
+                if self.close_client_windows(client_id, &window_ids, false) {
+                    self.dump_memory_layout("after IPC ClientDisconnected");
+                    return Ok(true);
+                }
             }
             IpcEvent::BufferUpdated {
                 window_id,

--- a/user/bin/src/sws/input.rs
+++ b/user/bin/src/sws/input.rs
@@ -44,7 +44,12 @@ pub fn set_screen_size(width: u32, height: u32) {
 /// Add an input event to the global queue
 pub fn push_input_event(event: CompositorInputEvent) {
     let mut queue = INPUT_EVENT_QUEUE.lock();
+    let should_wake = queue.is_empty();
     queue.push(event);
+    drop(queue);
+    if should_wake {
+        super::ipc::wake_compositor();
+    }
 }
 
 /// Get all pending input events from the queue

--- a/user/bin/src/sws/ipc.rs
+++ b/user/bin/src/sws/ipc.rs
@@ -3,6 +3,7 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 use std::collections::BTreeMap;
 use std::env;
+use std::handle::Handle;
 use std::handle::capability::memory_mapping::flags as mmap_flags;
 use std::ipc::{SharedMemory, permissions};
 use std::println;
@@ -282,6 +283,33 @@ fn push_input_event_coalesced(events: &mut Vec<PendingInputEvent>, event: Pendin
     }
 }
 
+/// Wake pipe used by worker threads to interrupt the compositor event loop.
+static COMPOSITOR_WAKE_WRITE: Mutex<Option<Handle>> = Mutex::new(None);
+
+/// Install the compositor wake pipe write handle.
+///
+/// # Arguments
+///
+/// * `write_handle` - Write side of the compositor wake pipe.
+pub fn set_compositor_wake_handle(write_handle: Handle) {
+    let mut wake = COMPOSITOR_WAKE_WRITE.lock();
+    *wake = Some(write_handle);
+}
+
+/// Wake the compositor if it is sleeping on the wake pipe.
+pub fn wake_compositor() {
+    let wake = COMPOSITOR_WAKE_WRITE.lock();
+    let Some(handle) = wake.as_ref() else {
+        return;
+    };
+
+    let Ok(stream) = handle.as_stream() else {
+        return;
+    };
+
+    let _ = stream.write(&[1]);
+}
+
 /// Global event queue for IPC events
 static EVENT_QUEUE: Mutex<Vec<IpcEvent>> = Mutex::new(Vec::new());
 
@@ -357,6 +385,7 @@ pub fn push_ipc_event(event: IpcEvent) {
                 }
             }
         }
+        let should_wake = queue.is_empty();
         queue.push(IpcEvent::ExtensionUpdateBuffer {
             external_client_id,
             window_id,
@@ -365,9 +394,18 @@ pub fn push_ipc_event(event: IpcEvent) {
             damage_width,
             damage_height,
         });
+        drop(queue);
+        if should_wake {
+            wake_compositor();
+        }
         return;
     }
+    let should_wake = queue.is_empty();
     queue.push(event);
+    drop(queue);
+    if should_wake {
+        wake_compositor();
+    }
 }
 
 /// Get all pending events from the queue
@@ -400,6 +438,13 @@ fn unregister_window(window_id: u32) {
         let mut pending = PENDING_SERVER_FRAMES.lock();
         pending.remove(&window_id);
     }
+}
+
+fn cleanup_window_state(window_id: u32) {
+    unregister_window(window_id);
+
+    let mut sessions = APP_SESSIONS.lock();
+    sessions.remove(&window_id);
 }
 
 /// Queue an input event for a specific window (O(log n) lookup)
@@ -466,6 +511,11 @@ pub fn pop_extension_input_events(
     } else {
         Vec::new()
     }
+}
+
+fn cleanup_extension_input_events(extension_id: u32, external_client_id: u32) {
+    let mut pending = PENDING_EXTENSION_INPUT_EVENTS.lock();
+    pending.remove(&(extension_id, external_client_id));
 }
 
 /// Queue a server->client protocol message for a specific window.
@@ -1129,15 +1179,10 @@ fn client_thread_main(client_id: usize, mut socket: Socket) {
                     client_id, window_id
                 );
 
-                // Unregister window from input routing
-                unregister_window(window_id);
-
+                cleanup_window_state(window_id);
                 window_resizable.remove(&window_id);
-
-                // Remove AppSession
-                {
-                    let mut sessions = APP_SESSIONS.lock();
-                    sessions.remove(&window_id);
+                if let Some(external_client_id) = window_to_external_client.remove(&window_id) {
+                    cleanup_extension_input_events(extension_id, external_client_id);
                 }
 
                 // Remove from managed windows
@@ -1709,16 +1754,20 @@ fn client_thread_main(client_id: usize, mut socket: Socket) {
     }
 
     // Cleanup: ensure per-window routing queues don't leak when the client disappears.
-    // Also notify the compositor so orphaned windows don't stick around.
-    for window_id in managed_windows.drain(..) {
-        unregister_window(window_id);
-        push_ipc_event(IpcEvent::DestroyWindow {
-            client_id,
-            window_id,
-        });
+    // Also notify the compositor so orphaned windows don't stick around. A disconnected
+    // client cannot receive WINDOW_DESTROYED, so use a separate event that only updates
+    // server-side state and other live clients.
+    let disconnected_windows = core::mem::take(&mut managed_windows);
+    for &window_id in &disconnected_windows {
+        cleanup_window_state(window_id);
+        window_resizable.remove(&window_id);
+        if let Some(external_client_id) = window_to_external_client.remove(&window_id) {
+            cleanup_extension_input_events(extension_id, external_client_id);
+        }
     }
 
-    // Unregister client from broadcast messages
+    // Unregister client from broadcast messages before publishing the disconnect event;
+    // broadcasts produced by window removal must not recreate this dead client's queue.
     {
         let mut pending = PENDING_CLIENT_RESPONSES.lock();
         pending.remove(&client_id);
@@ -1726,6 +1775,18 @@ fn client_thread_main(client_id: usize, mut socket: Socket) {
             "[ClientThread {}] Unregistered client {} from broadcast messages",
             client_id, client_id
         );
+    }
+
+    if !disconnected_windows.is_empty() {
+        println!(
+            "[ClientThread {}] Scheduling cleanup for {} disconnected windows",
+            client_id,
+            disconnected_windows.len()
+        );
+        push_ipc_event(IpcEvent::ClientDisconnected {
+            client_id,
+            window_ids: disconnected_windows,
+        });
     }
 
     println!("[ClientThread {}] Exiting", client_id);
@@ -1774,6 +1835,11 @@ pub enum IpcEvent {
     DestroyWindow {
         client_id: usize,
         window_id: u32,
+    },
+    /// Client connection was lost; all windows owned by that client must be removed.
+    ClientDisconnected {
+        client_id: usize,
+        window_ids: Vec<u32>,
     },
     /// Client updated their window buffer (damage region only)
     BufferUpdated {

--- a/user/lib/std/src/syscall.rs
+++ b/user/lib/std/src/syscall.rs
@@ -35,6 +35,7 @@ pub enum Syscall {
     SetTls = 30,
     GetTls = 31,
     SetTidAddress = 32,
+    ThreadDetach = 33,
 
     // ABI Zone Management
     RegisterAbiZone = 90,

--- a/user/lib/std/src/thread.rs
+++ b/user/lib/std/src/thread.rs
@@ -118,18 +118,34 @@ where
 
 /// Join handle for waiting on thread completion
 pub struct JoinHandle {
-    thread_id: u32,
+    thread_id: Option<u32>,
 }
 
 impl JoinHandle {
-    /// Wait for the thread to finish
-    pub fn join(self) -> Result<(), &'static str> {
+    /// Wait for the thread to finish.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when the thread was reaped successfully, otherwise an error.
+    pub fn join(mut self) -> Result<(), &'static str> {
+        let Some(thread_id) = self.thread_id.take() else {
+            return Err("Thread handle is detached");
+        };
+
         // Wait for child thread to exit
-        let (pid, _status) = crate::task::waitpid(self.thread_id as i32, 0);
+        let (pid, _status) = crate::task::waitpid(thread_id as i32, 0);
         if pid < 0 {
             Err("Failed to join thread")
         } else {
             Ok(())
+        }
+    }
+}
+
+impl Drop for JoinHandle {
+    fn drop(&mut self) {
+        if let Some(thread_id) = self.thread_id.take() {
+            let _ = syscall1(Syscall::ThreadDetach, thread_id as usize);
         }
     }
 }
@@ -198,7 +214,7 @@ where
 
     // Parent: return join handle
     Ok(JoinHandle {
-        thread_id: result as u32,
+        thread_id: Some(result as u32),
     })
 }
 


### PR DESCRIPTION
This pull request refactors how vCPU objects are referenced and managed in the KVM AArch64 and generic KVM device code. The main change is replacing the use of `Arc<Vcpu>` (`VcpuRef`) with trait-object references (`&dyn VcpuObject`) and switching from pointer equality to unique integer keys for vCPU and VM identification. This improves abstraction, avoids unnecessary reference counting, and simplifies resource management. Several functions and data structures are updated to use these new keys, and a new cleanup function is introduced for vCPU state.

Key changes include:

**vCPU Reference Abstraction and Keying:**
- All functions and structs that previously took or stored `VcpuRef` now use `&dyn VcpuObject` references and store a unique `usize` key for each vCPU, generated by the new `vcpu_key` helper. This removes reliance on `Arc` and pointer equality, making the code more flexible and less error-prone. [[1]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L3-R8) [[2]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL23-R23) [[3]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL389-R404) [[4]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL406-R414)

**State Management Refactoring:**
- vCPU and VM state tracking structs (`KvmArmVcpuSysregEntry`, `KvmArmVcpuInitEntry`, `KvmRunPageEntry`, and `KvmIoEvent`) now use integer keys instead of storing `Arc` references. All lookup and update logic is updated to use these keys. [[1]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L218-R217) [[2]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L747-R750) [[3]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL189-R189) [[4]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL418-R438)

**API and Function Signature Changes:**
- All public and internal APIs that operated on vCPUs are updated to accept `&dyn VcpuObject` instead of `VcpuRef`. This includes register access, MMIO completion, firmware calls, and KVM ioctl handlers. [[1]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L108-R107) [[2]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L250-R253) [[3]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L268-R271) [[4]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L277-R280) [[5]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L291-R294) [[6]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L302-R305) [[7]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L332-R335) [[8]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L355-R358) [[9]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L383-R386) [[10]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L422-R425) [[11]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L467-R470) [[12]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L505-R508) [[13]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L813-R831) [[14]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL406-R414) [[15]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL438-R451) [[16]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL473-R487) [[17]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL503-R528) [[18]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL535-R555) [[19]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL555-R576)

**Resource Cleanup and State Freeing:**
- A new `free_vcpu_state` function is added to clean up both sysreg and init state for a vCPU when it is freed, ensuring no memory leaks or stale state. The vCPU run page cleanup also calls this new function. [[1]](diffhunk://#diff-70d996c99b2abda2da61a8191d88d97b9dc1a50d1d68728a697c80384ec1ed95L757-R782) [[2]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL555-R576)

**Internal Helper Functions:**
- Introduced `vcpu_key` and `vm_key` helper functions to consistently generate unique identifiers for vCPU and VM objects, replacing pointer comparison with integer key comparison throughout the codebase. [[1]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL389-R404) [[2]](diffhunk://#diff-5cef35a01aaa3ba4195a959fb83c5a30e7709ff282b2ef24d3e1cd6abfc21f1cL418-R438)

These changes collectively improve the code's safety, maintainability, and abstraction by decoupling resource management from reference counting and pointer identity, making the KVM device code more robust and easier to extend.- Updated `sys_handle_duplicate` to utilize object-specific duplication semantics, improving handle management efficiency.
- Introduced `KernelObjectRef` to provide a borrowed view of kernel objects without extending their lifetimes, enhancing safety and clarity in handle table access.
- Implemented `sys_thread_detach` to allow threads to be detached from their parent without leaving zombies, ensuring proper cleanup of thread resources.
- Enhanced task reparenting logic to ensure orphaned child tasks are correctly assigned to the init task upon parent exit, maintaining system stability.
- Added tests to verify the correct behavior of task reparenting and thread detachment, ensuring robustness in task lifecycle management.
- Updated IPC mechanisms in the compositor to handle client disconnections and window management more effectively, improving responsiveness and resource management.