### PR TITLE
fix: virtio-net tests - handle persistent QueueReady state

### DIFF
--- a/kernel/src/drivers/virtio/device/mod.rs
+++ b/kernel/src/drivers/virtio/device/mod.rs
@@ -580,8 +580,15 @@ pub trait VirtioDevice {
             let common = transport.common_cfg;
             unsafe {
                 crate::arch::mmio::write16(common + 0x16, queue_idx as u16);
+                // Check if the queue is ready - if so, try to reset it for reconfiguration
                 if crate::arch::mmio::read16(common + 0x1c) != 0 {
-                    return false;
+                    // Queue appears to be already set up from a previous run.
+                    // Attempt to reset it by writing 0 to QueueReady so we can reconfigure.
+                    crate::arch::mmio::write16(common + 0x1c, 0);
+                    crate::arch::io_mb();
+                    if crate::arch::mmio::read16(common + 0x1c) != 0 {
+                        return false; // Queue still marked as ready, cannot reconfigure
+                    }
                 }
 
                 let queue_size_max = crate::arch::mmio::read16(common + 0x18) as usize;
@@ -612,10 +619,19 @@ pub trait VirtioDevice {
 
         // Select the queue
         self.write32_register(Register::QueueSel, queue_idx as u32);
-        // Check if the queue is ready
+        // Check if the queue is ready - if so, try to reset it for reconfiguration
         let ready = self.read32_register(Register::QueueReady);
         if ready != 0 {
-            return false; // Queue already set up
+            // Queue appears to be already set up from a previous run.
+            // Attempt to reset it by writing 0 to QueueReady so we can reconfigure.
+            // This handles cases where QEMU doesn't fully reset device state between tests.
+            self.write32_register(Register::QueueReady, 0);
+            io_mb();
+            // Re-check after reset attempt
+            let ready_after_reset = self.read32_register(Register::QueueReady);
+            if ready_after_reset != 0 {
+                return false; // Queue still marked as ready, cannot reconfigure
+            }
         }
 
         // Get maximum queue size


### PR DESCRIPTION
Fixes #429.

## Issue
VirtIO network tests were failing after the PCI configuration space access refactor.

## Root Cause
The `setup_queue()` function would fail when QEMU doesn't fully reset device state between test runs. The `QueueReady` register could remain set from a previous test, causing queue setup to return `false`.

## Fix
Added queue reset logic to attempt clearing `QueueReady` before giving up. This handles cases where device state persists between tests.

## Changes
- Modified `setup_queue()` in both PCI and MMIO transport paths
- Added proper memory barriers to ensure reset takes effect
- Added fallback to return `false` only if queue cannot be reset

Generated with [Claude Code](https://claude.ai/code)