### PR TITLE
Feature/pci device intx

### DIFF
--- a/kernel/src/device/pci/config.rs
+++ b/kernel/src/device/pci/config.rs
@@ -58,6 +58,8 @@ pub mod command {
     pub const MEMORY_SPACE: u16 = 1 << 1;
     /// Enable bus mastering for DMA-capable devices.
     pub const BUS_MASTER: u16 = 1 << 2;
+    /// Disable legacy INTx assertion when set.
+    pub const INTERRUPT_DISABLE: u16 = 1 << 10;
 }
 
 /// PCI status register bits.

--- a/kernel/src/device/pci/scan.rs
+++ b/kernel/src/device/pci/scan.rs
@@ -11,6 +11,9 @@ use alloc::vec::Vec;
 use super::config::{PciBar, PciBarKind, PciConfig, offset, vendor};
 use super::device::PciDeviceInfo;
 use super::{PciAddress, PciBus};
+use crate::device::platform::resource::{
+    IrqMetadata, PlatformDeviceResource, PlatformDeviceResourceType,
+};
 use crate::{early_println, println};
 
 /// PCI scanner
@@ -103,20 +106,37 @@ impl<'a> PciScanner<'a> {
         None
     }
 
-    fn decode_parent_irq(parent_irq_cells: &[u32]) -> Option<u32> {
+    fn decode_parent_irq_resource(parent_irq_cells: &[u32]) -> Option<PlatformDeviceResource> {
         match parent_irq_cells.len() {
             0 => None,
-            3 => parent_irq_cells.get(1).copied(),
-            _ => parent_irq_cells.first().copied(),
+            3 => Some(PlatformDeviceResource {
+                res_type: PlatformDeviceResourceType::IRQ,
+                start: parent_irq_cells[1] as usize,
+                end: parent_irq_cells[1] as usize,
+                irq_metadata: Some(IrqMetadata {
+                    irq_type: parent_irq_cells[0],
+                    irq_number: parent_irq_cells[1],
+                    irq_flags: parent_irq_cells[2],
+                }),
+            }),
+            _ => {
+                let irq = *parent_irq_cells.first()? as usize;
+                Some(PlatformDeviceResource {
+                    res_type: PlatformDeviceResourceType::IRQ,
+                    start: irq,
+                    end: irq,
+                    irq_metadata: None,
+                })
+            }
         }
     }
 
-    fn parse_routed_irq_from_map<F>(
+    fn parse_routed_irq_resource_from_map<F>(
         mask: &[u8],
         map: &[u8],
         child_cells: &[u32],
         mut parent_cell_counts: F,
-    ) -> Option<u32>
+    ) -> Option<PlatformDeviceResource>
     where
         F: FnMut(u32) -> Option<(usize, usize)>,
     {
@@ -164,7 +184,7 @@ impl<'a> PciScanner<'a> {
                     let cell_offset = parent_irq_offset + index * 4;
                     *parent_irq_cell = Self::read_be_u32(&map[cell_offset..cell_offset + 4])?;
                 }
-                return Self::decode_parent_irq(&parent_irq_cells);
+                return Self::decode_parent_irq_resource(&parent_irq_cells);
             }
 
             offset += entry_bytes;
@@ -206,13 +226,28 @@ impl<'a> PciScanner<'a> {
         child_cells[0] = ((addr.device as u32) << 11) | ((addr.function as u32) << 8);
         child_cells[child_addr_cells] = interrupt_pin as u32;
 
-        Self::parse_routed_irq_from_map(mask, map, &child_cells, |phandle| {
-            let parent = Self::find_node_by_phandle(fdt, phandle)?;
-            let parent_addr_cells = Self::get_u32_prop(&parent, "#address-cells").unwrap_or(0);
-            let parent_interrupt_cells =
-                Self::get_u32_prop(&parent, "#interrupt-cells").unwrap_or(1);
-            Some((parent_addr_cells as usize, parent_interrupt_cells as usize))
-        })
+        let resource =
+            Self::parse_routed_irq_resource_from_map(mask, map, &child_cells, |phandle| {
+                let parent = Self::find_node_by_phandle(fdt, phandle)?;
+                let parent_addr_cells = Self::get_u32_prop(&parent, "#address-cells").unwrap_or(0);
+                let parent_interrupt_cells =
+                    Self::get_u32_prop(&parent, "#interrupt-cells").unwrap_or(1);
+                Some((parent_addr_cells as usize, parent_interrupt_cells as usize))
+            })?;
+
+        match crate::interrupt::resolve_platform_irq(&resource) {
+            Ok(irq) => Some(irq),
+            Err(e) => {
+                early_println!(
+                    "[PCI] Failed to translate routed IRQ for {:02x}:{:02x}.{}: {}",
+                    addr.bus,
+                    addr.device,
+                    addr.function,
+                    e
+                );
+                None
+            }
+        }
     }
 
     /// Create a new PCI scanner
@@ -432,6 +467,25 @@ impl<'a> PciScanner<'a> {
         for bar in device_info.bars() {
             Self::log_bar(&addr, bar);
         }
+        if interrupt_pin != 0 {
+            let pin_name = match interrupt_pin {
+                1 => "A",
+                2 => "B",
+                3 => "C",
+                4 => "D",
+                _ => "?",
+            };
+            match routed_irq {
+                Some(irq) => println!(
+                    "pci 0000:{:02x}:{:02x}.{}: INT{} -> IRQ {}",
+                    bus, device, function, pin_name, irq
+                ),
+                None => println!(
+                    "pci 0000:{:02x}:{:02x}.{}: INT{} unassigned",
+                    bus, device, function, pin_name
+                ),
+            }
+        }
 
         Some(device_info)
     }
@@ -532,12 +586,14 @@ mod tests {
         ];
         let child_cells = [0x0000_0800, 0, 0, 1];
 
-        let routed_irq =
-            PciScanner::parse_routed_irq_from_map(&mask, &map, &child_cells, |phandle| {
+        let irq_resource =
+            PciScanner::parse_routed_irq_resource_from_map(&mask, &map, &child_cells, |phandle| {
                 if phandle == 0x2a { Some((0, 1)) } else { None }
-            });
+            })
+            .expect("expected routed IRQ resource");
 
-        assert_eq!(routed_irq, Some(0x15));
+        assert_eq!(irq_resource.start, 0x15);
+        assert!(irq_resource.irq_metadata.is_none());
     }
 
     #[test_case]
@@ -553,12 +609,19 @@ mod tests {
         ];
         let child_cells = [0x0000_0800, 0, 0, 1];
 
-        let routed_irq =
-            PciScanner::parse_routed_irq_from_map(&mask, &map, &child_cells, |phandle| {
+        let irq_resource =
+            PciScanner::parse_routed_irq_resource_from_map(&mask, &map, &child_cells, |phandle| {
                 if phandle == 0x33 { Some((1, 3)) } else { None }
-            });
+            })
+            .expect("expected routed IRQ resource");
+        let metadata = irq_resource
+            .irq_metadata
+            .expect("expected GIC-style IRQ metadata");
 
-        assert_eq!(routed_irq, Some(0x24));
+        assert_eq!(irq_resource.start, 0x24);
+        assert_eq!(metadata.irq_type, 1);
+        assert_eq!(metadata.irq_number, 0x24);
+        assert_eq!(metadata.irq_flags, 0x04);
     }
 
     #[test_case]

--- a/kernel/src/drivers/network/virtio_net.rs
+++ b/kernel/src/drivers/network/virtio_net.rs
@@ -45,6 +45,7 @@ use crate::{
     },
     drivers::virtio::{
         device::{Register, VirtioDevice},
+        pci::VirtioPciTransport,
         queue::{DescriptorFlag, VirtQueue},
     },
     object::capability::ControlOps,
@@ -147,6 +148,7 @@ impl VirtioNetHdrBasic {
 /// VirtIO Network Device
 pub struct VirtioNetDevice {
     base_addr: usize,
+    pci_transport: Option<VirtioPciTransport>,
     virtqueues: Mutex<[VirtQueue<'static>; 2]>, // RX queue (0) and TX queue (1)
     config: RwLock<Option<NetworkInterfaceConfig>>,
     features: RwLock<u64>,
@@ -168,8 +170,26 @@ impl VirtioNetDevice {
     ///
     /// A new instance of `VirtioNetDevice`
     pub fn new(base_addr: usize) -> Self {
+        Self::new_with_transport(base_addr, None)
+    }
+
+    /// Create a new VirtIO Network device backed by PCI transport.
+    ///
+    /// # Arguments
+    ///
+    /// * `transport` - Mapped VirtIO PCI configuration regions
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `VirtioNetDevice`
+    pub fn new_pci(transport: VirtioPciTransport) -> Self {
+        Self::new_with_transport(transport.common_cfg, Some(transport))
+    }
+
+    fn new_with_transport(base_addr: usize, pci_transport: Option<VirtioPciTransport>) -> Self {
         let mut device = Self {
             base_addr,
+            pci_transport,
             virtqueues: Mutex::new([VirtQueue::new(32), VirtQueue::new(32)]), // RX and TX queues
             config: RwLock::new(None),
             features: RwLock::new(0),
@@ -630,6 +650,10 @@ impl InterruptCapableDevice for VirtioNetDevice {
 }
 
 impl VirtioDevice for VirtioNetDevice {
+    fn pci_transport(&self) -> Option<VirtioPciTransport> {
+        self.pci_transport
+    }
+
     fn get_base_addr(&self) -> usize {
         self.base_addr
     }

--- a/kernel/src/drivers/usb/xhci/mod.rs
+++ b/kernel/src/drivers/usb/xhci/mod.rs
@@ -1489,12 +1489,20 @@ fn probe_xhci(device: &PciDeviceInfo) -> Result<(), &'static str> {
 
     // Enable bus mastering
     let command = config.read_u16(&addr, config::offset::COMMAND);
-    config.write_u16(&addr, config::offset::COMMAND, command | 0x0004); // Bus Master Enable
+    config.write_u16(
+        &addr,
+        config::offset::COMMAND,
+        (command | config::command::BUS_MASTER) & !config::command::INTERRUPT_DISABLE,
+    );
     early_println!("[xHCI] Bus mastering enabled");
 
     // Enable memory access
     let command = config.read_u16(&addr, config::offset::COMMAND);
-    config.write_u16(&addr, config::offset::COMMAND, command | 0x0002); // Memory Access Enable
+    config.write_u16(
+        &addr,
+        config::offset::COMMAND,
+        (command | config::command::MEMORY_SPACE) & !config::command::INTERRUPT_DISABLE,
+    );
     early_println!("[xHCI] Memory access enabled");
 
     // Read BAR0 (and BAR1 if 64-bit)
@@ -1524,9 +1532,7 @@ fn probe_xhci(device: &PciDeviceInfo) -> Result<(), &'static str> {
     early_println!("[xHCI] MMIO mapped at {:#x}", mmio_vaddr);
 
     let routed_irq = device.routed_irq();
-    let interrupt_line = routed_irq
-        .map(|irq| irq as u8)
-        .unwrap_or_else(|| device.interrupt_line());
+    let interrupt_line = routed_irq.unwrap_or_else(|| device.interrupt_line() as InterruptId);
     let interrupt_pin = device.interrupt_pin();
     early_println!(
         "[xHCI] IRQ routing: config_line={} pin={} routed_irq={:?}",
@@ -1540,7 +1546,7 @@ fn probe_xhci(device: &PciDeviceInfo) -> Result<(), &'static str> {
             interrupt_line,
             interrupt_pin
         );
-        Some(interrupt_line as InterruptId)
+        Some(interrupt_line)
     } else {
         early_println!("[xHCI] No usable legacy IRQ routing for controller");
         None

--- a/kernel/src/drivers/virtio/pci.rs
+++ b/kernel/src/drivers/virtio/pci.rs
@@ -21,6 +21,8 @@ use crate::device::pci::driver::{PciDeviceDriver, PciDeviceId};
 use crate::driver_initcall;
 use crate::drivers::block::virtio_blk::VirtioBlockDevice;
 use crate::drivers::graphics::virtio_gpu::VirtioGpuDevice;
+use crate::drivers::network::virtio_net::VirtioNetDevice;
+use crate::interrupt::{InterruptId, InterruptManager};
 use crate::vm;
 use crate::{early_println, println};
 
@@ -38,12 +40,14 @@ const VIRTIO_PCI_CAP_OFFSET: usize = 0x08;
 const VIRTIO_PCI_CAP_LENGTH: usize = 0x0c;
 const VIRTIO_PCI_NOTIFY_CAP_MULTIPLIER: usize = 0x10;
 
+const VIRTIO_PCI_TRANSITIONAL_NET_DEVICE_ID: u16 = 0x1000;
 const VIRTIO_PCI_TRANSITIONAL_BLOCK_DEVICE_ID: u16 = 0x1001;
 const VIRTIO_PCI_MODERN_BLOCK_DEVICE_ID: u16 = 0x1042;
 const VIRTIO_PCI_TRANSITIONAL_GPU_DEVICE_ID: u16 = 0x1010;
 const VIRTIO_PCI_MODERN_GPU_DEVICE_ID: u16 = 0x1050;
 
 static BLOCK_COUNTER: AtomicUsize = AtomicUsize::new(0);
+static NET_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static GPU_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Mapped register blocks for a VirtIO PCI function.
@@ -208,8 +212,59 @@ fn enable_pci_device(config: &PciConfig, device: &PciDeviceInfo) {
     config.write_u16(
         &addr,
         config::offset::COMMAND,
-        command_bits | command::MEMORY_SPACE | command::BUS_MASTER,
+        (command_bits | command::MEMORY_SPACE | command::BUS_MASTER) & !command::INTERRUPT_DISABLE,
     );
+}
+
+fn register_legacy_intx(
+    device: &PciDeviceInfo,
+    handler: Arc<dyn crate::device::events::InterruptCapableDevice>,
+) -> Option<InterruptId> {
+    let interrupt_pin = device.interrupt_pin();
+    let interrupt_id = device.routed_irq().or_else(|| {
+        let line = device.interrupt_line();
+        (line != 0 && line != 0xff).then_some(line as InterruptId)
+    })?;
+
+    if interrupt_pin == 0 {
+        return None;
+    }
+
+    let manager = InterruptManager::global();
+    if let Err(e) = manager.register_interrupt_device(interrupt_id, handler) {
+        early_println!(
+            "[virtio-pci] Failed to register INTx IRQ {} for {:02x}:{:02x}.{}: {:?}",
+            interrupt_id,
+            device.address().bus,
+            device.address().device,
+            device.address().function,
+            e
+        );
+        return None;
+    }
+    if let Err(e) =
+        manager.enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
+    {
+        early_println!(
+            "[virtio-pci] Failed to enable INTx IRQ {} for {:02x}:{:02x}.{}: {:?}",
+            interrupt_id,
+            device.address().bus,
+            device.address().device,
+            device.address().function,
+            e
+        );
+        return None;
+    }
+
+    early_println!(
+        "[virtio-pci] Registered INTx IRQ {} pin {} for {:02x}:{:02x}.{}",
+        interrupt_id,
+        interrupt_pin,
+        device.address().bus,
+        device.address().device,
+        device.address().function
+    );
+    Some(interrupt_id)
 }
 
 fn probe_virtio_pci(device: &PciDeviceInfo) -> Result<(), &'static str> {
@@ -225,6 +280,27 @@ fn probe_virtio_pci(device: &PciDeviceInfo) -> Result<(), &'static str> {
     let transport = parse_virtio_pci_caps(&config, device)?;
 
     match device.device_id() {
+        VIRTIO_PCI_TRANSITIONAL_NET_DEVICE_ID => {
+            let name = format!("veth{}", NET_COUNTER.fetch_add(1, Ordering::SeqCst));
+            let dev = Arc::new(VirtioNetDevice::new_pci(transport));
+            dev.register_interface(&name);
+
+            if let Some(interrupt_id) = register_legacy_intx(device, dev.clone()) {
+                if let Err(e) = dev.enable_interrupts(interrupt_id) {
+                    early_println!("[virtio-pci] Failed to enable net INTx: {}", e);
+                }
+            } else {
+                early_println!(
+                    "[virtio-pci] No usable INTx routing for net device {}",
+                    name
+                );
+            }
+
+            let registered: Arc<dyn Device> = dev;
+            DeviceManager::get_manager().register_device_with_name(name.clone(), registered);
+            println!("[virtio-pci] Registered net device {}", name);
+            Ok(())
+        }
         VIRTIO_PCI_TRANSITIONAL_BLOCK_DEVICE_ID | VIRTIO_PCI_MODERN_BLOCK_DEVICE_ID => {
             let name = format!("vblk{}", BLOCK_COUNTER.fetch_add(1, Ordering::SeqCst));
             let dev: Arc<dyn Device> = Arc::new(VirtioBlockDevice::new_pci(transport));
@@ -261,6 +337,7 @@ fn remove_virtio_pci(_device: &PciDeviceInfo) -> Result<(), &'static str> {
 
 fn register_driver() {
     let id_table = vec![
+        PciDeviceId::new(vendor::REDHAT, VIRTIO_PCI_TRANSITIONAL_NET_DEVICE_ID),
         PciDeviceId::new(vendor::REDHAT, VIRTIO_PCI_TRANSITIONAL_BLOCK_DEVICE_ID),
         PciDeviceId::new(vendor::REDHAT, VIRTIO_PCI_MODERN_BLOCK_DEVICE_ID),
         PciDeviceId::new(vendor::REDHAT, VIRTIO_PCI_TRANSITIONAL_GPU_DEVICE_ID),

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -72,7 +72,12 @@ pub struct InterruptManager {
     controllers: spin::Once<spin::Mutex<controllers::InterruptControllers>>,
     external_handlers: spin::Lazy<spin::Mutex<HashMap<InterruptId, ExternalInterruptHandler>>>,
     interrupt_devices: spin::Lazy<
-        spin::Mutex<HashMap<InterruptId, Arc<dyn crate::device::events::InterruptCapableDevice>>>,
+        spin::Mutex<
+            HashMap<
+                InterruptId,
+                alloc::vec::Vec<Arc<dyn crate::device::events::InterruptCapableDevice>>,
+            >,
+        >,
     >,
 }
 
@@ -166,8 +171,10 @@ impl InterruptManager {
             devices.get(&interrupt_id).cloned()
         };
 
-        if let Some(device) = device {
-            device.handle_interrupt()?;
+        if let Some(devices) = device {
+            for device in devices {
+                device.handle_interrupt()?;
+            }
             self.complete_external_interrupt(cpu_id, interrupt_id)
         } else {
             let handler = {
@@ -365,10 +372,7 @@ impl InterruptManager {
         device: Arc<dyn crate::device::events::InterruptCapableDevice>,
     ) -> InterruptResult<()> {
         let mut devices = self.interrupt_devices.lock();
-        if devices.contains_key(&interrupt_id) {
-            return Err(InterruptError::HandlerAlreadyRegistered);
-        }
-        devices.insert(interrupt_id, device);
+        devices.entry(interrupt_id).or_default().push(device);
         Ok(())
     }
 

--- a/kernel/tools/run.sh
+++ b/kernel/tools/run.sh
@@ -126,7 +126,7 @@ qemu-system-riscv64 \
     -display vnc=:0 \
     -device virtio-gpu-device,bus=virtio-mmio-bus.1 \
     -netdev user,id=net0,hostfwd=tcp::8080-:8080,hostfwd=udp::8080-:8080,hostfwd=udp::1234-:1234 \
-    -device virtio-net-device,netdev=net0,bus=virtio-mmio-bus.2 \
+    -device virtio-net-pci,netdev=net0,bus=pcie.0 \
     -device virtio-keyboard-device,bus=virtio-mmio-bus.3 \
     -device virtio-mouse-device,bus=virtio-mmio-bus.4 \
     -device virtio-rng-device,bus=virtio-mmio-bus.5 \

--- a/kernel/tools/run_aarch64.sh
+++ b/kernel/tools/run_aarch64.sh
@@ -191,7 +191,7 @@ qemu-system-aarch64 \
     -display vnc=:0 \
     "${QEMU_GPU_ARGS[@]}" \
     -netdev user,id=net0 \
-    -device virtio-net-device,netdev=net0,bus=virtio-mmio-bus.3 \
+    -device virtio-net-pci,netdev=net0,bus=pcie.0 \
     -device virtio-keyboard-device,bus=virtio-mmio-bus.4 \
     -device virtio-mouse-device,bus=virtio-mmio-bus.5 \
     -device virtio-rng-device,bus=virtio-mmio-bus.6 \

--- a/projects/aarch64-limine-full/tools/run_aarch64.sh
+++ b/projects/aarch64-limine-full/tools/run_aarch64.sh
@@ -290,7 +290,7 @@ esac
 
 QEMU_NET_ARGS=()
 if [ "$QEMU_NET" = "1" ] || [ "$QEMU_NET" = "true" ]; then
-    QEMU_NET_ARGS=(-netdev user,id=net0 -device virtio-net-device,netdev=net0,bus=virtio-mmio-bus.3)
+    QEMU_NET_ARGS=(-netdev user,id=net0 -device virtio-net-pci,netdev=net0,bus=pcie.0)
 fi
 
 QEMU_INPUT_ARGS=()

--- a/projects/riscv64-limine-full/tools/run.sh
+++ b/projects/riscv64-limine-full/tools/run.sh
@@ -221,7 +221,7 @@ qemu-system-riscv64 \
     -device virtio-blk-device,drive=rootfs,bus=virtio-mmio-bus.0 \
     "${QEMU_GPU_ARGS[@]}" \
     -netdev user,id=net0,hostfwd=tcp::8080-:8080,hostfwd=udp::8080-:8080,hostfwd=udp::1234-:1234 \
-    -device virtio-net-device,netdev=net0,bus=virtio-mmio-bus.2 \
+    -device virtio-net-pci,netdev=net0,bus=pcie.0 \
     -device virtio-keyboard-device,bus=virtio-mmio-bus.3 \
     -device virtio-mouse-device,bus=virtio-mmio-bus.4 \
     -device virtio-rng-device,bus=virtio-mmio-bus.5 \


### PR DESCRIPTION
This pull request adds support for VirtIO network devices over PCI, improves PCI interrupt routing and handling, and enhances device probing and registration for network devices. It also updates the interrupt manager to support multiple devices per IRQ and adjusts QEMU run scripts to use PCI-based VirtIO network devices. The changes are grouped below by theme.

**VirtIO Network Device PCI Support:**

* Adds support for VirtIO network devices (`VirtioNetDevice`) using PCI transport, including new constructors and integration with the PCI device probing path. (`kernel/src/drivers/network/virtio_net.rs`, `kernel/src/drivers/virtio/pci.rs`) [[1]](diffhunk://#diff-a0f55028b346a181a10cf6163865d5a48fa79a48c43146f9a859537aee8ceb41R48) [[2]](diffhunk://#diff-a0f55028b346a181a10cf6163865d5a48fa79a48c43146f9a859537aee8ceb41R151) [[3]](diffhunk://#diff-a0f55028b346a181a10cf6163865d5a48fa79a48c43146f9a859537aee8ceb41R173-R192) [[4]](diffhunk://#diff-a0f55028b346a181a10cf6163865d5a48fa79a48c43146f9a859537aee8ceb41R653-R656) [[5]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69R24-R25) [[6]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69R43-R50) [[7]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69R283-R303) [[8]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69R340)

**PCI Interrupt Routing and Handling:**

* Refactors PCI IRQ routing to use a richer `PlatformDeviceResource` structure, improving support for both legacy and GIC-style interrupts, and updates related tests. (`kernel/src/device/pci/scan.rs`) [[1]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417R14-R16) [[2]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L106-R139) [[3]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L167-R187) [[4]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L209-R250) [[5]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417R470-R488) [[6]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L535-R596) [[7]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L556-R624)
* Adds a new helper to register legacy INTx interrupts for PCI devices, and ensures correct registration and enabling of interrupts for VirtIO network devices. (`kernel/src/drivers/virtio/pci.rs`)

**Interrupt Manager Enhancements:**

* Updates the interrupt manager to support multiple devices per IRQ, allowing several devices to register for the same interrupt line. (`kernel/src/interrupt/mod.rs`) [[1]](diffhunk://#diff-d4bb844b1bef4fb0d46ca02a0aec97b470447421fc6d9c8da6402922225ad4c8L75-R80) [[2]](diffhunk://#diff-d4bb844b1bef4fb0d46ca02a0aec97b470447421fc6d9c8da6402922225ad4c8L169-R177) [[3]](diffhunk://#diff-d4bb844b1bef4fb0d46ca02a0aec97b470447421fc6d9c8da6402922225ad4c8L368-R375)

**PCI Command Register Improvements:**

* Adds a constant for the PCI `INTERRUPT_DISABLE` bit and ensures that bus mastering and memory space enables clear this bit when enabling devices, improving interrupt delivery. (`kernel/src/device/pci/config.rs`, `kernel/src/drivers/usb/xhci/mod.rs`, `kernel/src/drivers/virtio/pci.rs`) [[1]](diffhunk://#diff-ddc04c3d05e31ec2c4ba1921ac904ef820f5e403007da0e00c6a8fbacd4b766fR61-R62) [[2]](diffhunk://#diff-5e0f95bba0e9779a7da7a685094626e8a1fc7277bd1dc986d143544f6f83eb81L1492-R1505) [[3]](diffhunk://#diff-5e0f95bba0e9779a7da7a685094626e8a1fc7277bd1dc986d143544f6f83eb81L1527-R1535) [[4]](diffhunk://#diff-5e0f95bba0e9779a7da7a685094626e8a1fc7277bd1dc986d143544f6f83eb81L1543-R1549) [[5]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69L211-R269)

**QEMU Run Script Updates:**

* Modifies QEMU run scripts to use the PCI version of the VirtIO network device (`virtio-net-pci`), matching the new PCI-based driver support. (`kernel/tools/run.sh`, `kernel/tools/run_aarch64.sh`) [[1]](diffhunk://#diff-859576085213ed38a1c6919b295ad5e5f03569fb56de7ca34454f3d855547c73L129-R129) [[2]](diffhunk://#diff-4d41e3d1f5894eefe73c77b23c69d95b0faf773bc697605ff94c8c4cda899e12L194-R194)This pull request adds support for VirtIO network devices over PCI, improves PCI interrupt routing and handling, and enhances the robustness and flexibility of the interrupt management subsystem. It also updates QEMU run scripts to use PCI-based VirtIO network devices. The most important changes are grouped below:

### VirtIO Network Device PCI Support

* Added support for VirtIO network devices (`virtio-net`) using PCI transport, including device creation, registration, and interrupt handling. The `VirtioNetDevice` struct and related methods now support PCI-backed transport, and the PCI probe logic registers and enables these devices. (`[[1]](diffhunk://#diff-a0f55028b346a181a10cf6163865d5a48fa79a48c43146f9a859537aee8ceb41R48)`, `[[2]](diffhunk://#diff-a0f55028b346a181a10cf6163865d5a48fa79a48c43146f9a859537aee8ceb41R151)`, `[[3]](diffhunk://#diff-a0f55028b346a181a10cf6163865d5a48fa79a48c43146f9a859537aee8ceb41R173-R192)`, `[[4]](diffhunk://#diff-a0f55028b346a181a10cf6163865d5a48fa79a48c43146f9a859537aee8ceb41R653-R656)`, `[[5]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69R24-R25)`, `[[6]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69R43-R50)`, `[[7]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69R283-R303)`, `[[8]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69R340)`)

### PCI Interrupt Routing and Handling Improvements

* Refactored PCI IRQ routing logic to use a richer `PlatformDeviceResource` type, enabling more accurate and flexible IRQ metadata handling. The PCI scan code and tests were updated accordingly, and improved logging for PCI interrupt routing was added. (`[[1]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417R14-R16)`, `[[2]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L106-R139)`, `[[3]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L167-R187)`, `[[4]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L209-R250)`, `[[5]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417R470-R488)`, `[[6]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L535-R596)`, `[[7]](diffhunk://#diff-940dc15860fc538c9b8ffa298122e517cf0d6bb669994b6ebf7b9977a7f69417L556-R624)`)
* Added the `INTERRUPT_DISABLE` bit constant to PCI config and ensured that enabling bus mastering or memory space for PCI devices (including xHCI and VirtIO) clears this bit, improving device initialization reliability. (`[[1]](diffhunk://#diff-ddc04c3d05e31ec2c4ba1921ac904ef820f5e403007da0e00c6a8fbacd4b766fR61-R62)`, `[[2]](diffhunk://#diff-5e0f95bba0e9779a7da7a685094626e8a1fc7277bd1dc986d143544f6f83eb81L1492-R1505)`, `[[3]](diffhunk://#diff-5e0f95bba0e9779a7da7a685094626e8a1fc7277bd1dc986d143544f6f83eb81L1527-R1535)`, `[[4]](diffhunk://#diff-5e0f95bba0e9779a7da7a685094626e8a1fc7277bd1dc986d143544f6f83eb81L1543-R1549)`, `[[5]](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69L211-R269)`)

### Interrupt Manager Enhancements

* Modified the interrupt manager to allow multiple devices to register for the same IRQ, enabling shared interrupt lines and improving compatibility with PCI devices. The handler invocation logic was updated to call all registered devices. (`[[1]](diffhunk://#diff-d4bb844b1bef4fb0d46ca02a0aec97b470447421fc6d9c8da6402922225ad4c8L75-R80)`, `[[2]](diffhunk://#diff-d4bb844b1bef4fb0d46ca02a0aec97b470447421fc6d9c8da6402922225ad4c8L169-R177)`, `[[3]](diffhunk://#diff-d4bb844b1bef4fb0d46ca02a0aec97b470447421fc6d9c8da6402922225ad4c8L368-R375)`)
* Added a helper function to register legacy PCI INTx interrupts, including error handling and debug output. (`[kernel/src/drivers/virtio/pci.rsL211-R269](diffhunk://#diff-3c86ecaa17c5abde981b38779b665c1d6281fcf2a0708e8bea11a0a836105f69L211-R269)`)

### QEMU Run Script Updates

* Updated QEMU run scripts to use PCI-based VirtIO network devices (`virtio-net-pci`) instead of MMIO-based devices, aligning with the new PCI support in the kernel. (`[[1]](diffhunk://#diff-859576085213ed38a1c6919b295ad5e5f03569fb56de7ca34454f3d855547c73L129-R129)`, `[[2]](diffhunk://#diff-4d41e3d1f5894eefe73c77b23c69d95b0faf773bc697605ff94c8c4cda899e12L194-R194)`)