### PR TITLE
Support HiDPI (SWS, ScarletUI)

### DIFF
--- a/user/bin/src/scarlet_desktop/taskbar/scarlet_ui.rs
+++ b/user/bin/src/scarlet_desktop/taskbar/scarlet_ui.rs
@@ -37,18 +37,52 @@ use sws_protocol::window_types;
 const SWS_CONNECT_RETRIES: usize = 100;
 const SWS_RETRY_DELAY_MS: u64 = 50;
 
-fn connect_sws_with_screen_size_retry() -> core::result::Result<(sws::Connection, u32, u32), ()> {
+type SwsScreenConnection = (sws::Connection, u32, u32, u32);
+
+fn scale_milli_or_default(scale_milli: u32) -> u32 {
+    scale_milli.max(1)
+}
+
+fn scale_u32(value: u32, scale_milli: u32) -> u32 {
+    let scale_milli = scale_milli_or_default(scale_milli) as u64;
+    (((value as u64) * scale_milli + 999) / 1000).max(1) as u32
+}
+
+fn scale_i32(value: i32, scale_milli: u32) -> i32 {
+    let scale_milli = scale_milli_or_default(scale_milli) as i64;
+    ((value as i64) * scale_milli / 1000) as i32
+}
+
+fn unscale_u32(value: u32, scale_milli: u32) -> u32 {
+    let scale_milli = scale_milli_or_default(scale_milli) as u64;
+    (((value as u64) * 1000 + scale_milli - 1) / scale_milli).max(1) as u32
+}
+
+fn unscale_i32(value: i32, scale_milli: u32) -> i32 {
+    let scale_milli = scale_milli_or_default(scale_milli) as i64;
+    ((value as i64) * 1000 / scale_milli) as i32
+}
+
+fn query_output_scale(conn: &mut sws::Connection) -> u32 {
+    conn.get_output_scale().unwrap_or(1000).max(1)
+}
+
+fn connect_sws_with_screen_size_retry() -> core::result::Result<SwsScreenConnection, ()> {
     for attempt in 0..SWS_CONNECT_RETRIES {
         if let Ok(mut conn) = sws::Connection::connect("/tmp/sws.sock")
-            && let Ok((width, height)) = conn.get_screen_size()
+            && let Ok((physical_width, physical_height)) = conn.get_screen_size()
         {
+            let scale_milli = query_output_scale(&mut conn);
+            let width = unscale_u32(physical_width, scale_milli);
+            let height = unscale_u32(physical_height, scale_milli);
             println!(
-                "[TaskBar] Connected to SWS after {} attempt(s); screen={}x{}",
+                "[TaskBar] Connected to SWS after {} attempt(s); screen={}x{} scale_milli={}",
                 attempt + 1,
                 width,
-                height
+                height,
+                scale_milli
             );
-            return Ok((conn, width, height));
+            return Ok((conn, width, height, scale_milli));
         }
 
         std::thread::sleep(Duration::from_millis(SWS_RETRY_DELAY_MS));
@@ -495,10 +529,12 @@ fn build_menu_items(
 struct PopupMenuRenderer {
     render_object: MenuRenderObject,
     size: Size,
+    scale_milli: u32,
 }
 
 impl PopupMenuRenderer {
-    fn new(items: Vec<MenuItemContent>, item_height: f32, width: f32) -> Self {
+    fn new(items: Vec<MenuItemContent>, item_height: f32, width: f32, scale_milli: u32) -> Self {
+        graphics::set_current_scale_milli(scale_milli);
         let mut render_object = MenuRenderObject::new(items, item_height, width);
         let constraints = LayoutConstraints {
             min_width: width,
@@ -511,6 +547,7 @@ impl PopupMenuRenderer {
         Self {
             render_object,
             size,
+            scale_milli,
         }
     }
 
@@ -535,6 +572,7 @@ impl PopupMenuRenderer {
     }
 
     fn render(&mut self) {
+        graphics::set_current_scale_milli(self.scale_milli);
         self.render_object.render();
     }
 
@@ -590,7 +628,7 @@ impl Application for TaskBarApp {
         println!("[TaskBar] on_resize: width={}, height={}", width, height);
         self.screen_width.set(width as f32);
         self.open_menu_index.set(None);
-        self.update_workarea_from_screen_query(width, height);
+        self.update_workarea_from_screen_query(width, TASKBAR_HEIGHT);
     }
 
     fn on_screen_size_changed(&mut self, width: u32, height: u32) -> Option<Size> {
@@ -663,22 +701,28 @@ impl Application for TaskBarApp {
 
 impl TaskBarApp {
     fn update_workarea(&self, screen_width: u32, screen_height: u32, bar_height: u32) {
-        let workarea_y = bar_height as i32;
-        let workarea_height = screen_height.saturating_sub(bar_height);
         if let Ok(mut conn) = sws::Connection::connect("/tmp/sws.sock") {
-            let _ = conn.set_workarea(0, workarea_y, screen_width, workarea_height);
+            let scale_milli = query_output_scale(&mut conn);
+            let physical_width = scale_u32(screen_width, scale_milli);
+            let physical_height = scale_u32(screen_height, scale_milli);
+            let workarea_y = scale_i32(bar_height as i32, scale_milli);
+            let workarea_height =
+                physical_height.saturating_sub(scale_u32(bar_height, scale_milli));
+            let _ = conn.set_workarea(0, workarea_y, physical_width, workarea_height);
+            println!(
+                "[TaskBar] Workarea: x=0, y={}, width={}, height={}",
+                workarea_y, physical_width, workarea_height
+            );
         }
-        println!(
-            "[TaskBar] Workarea: x=0, y={}, width={}, height={}",
-            workarea_y, screen_width, workarea_height
-        );
     }
 
     fn update_workarea_from_screen_query(&self, fallback_width: u32, bar_height: u32) {
         if let Ok(mut conn) = sws::Connection::connect("/tmp/sws.sock") {
             if let Ok((screen_width, screen_height)) = conn.get_screen_size() {
-                let workarea_y = bar_height as i32;
-                let workarea_height = screen_height.saturating_sub(bar_height);
+                let scale_milli = query_output_scale(&mut conn);
+                let physical_bar_height = scale_u32(bar_height, scale_milli);
+                let workarea_y = physical_bar_height as i32;
+                let workarea_height = screen_height.saturating_sub(physical_bar_height);
                 let _ = conn.set_workarea(0, workarea_y, screen_width, workarea_height);
                 println!(
                     "[TaskBar] Workarea: x=0, y={}, width={}, height={}",
@@ -717,13 +761,16 @@ impl TaskBarApp {
 
         // Menu popup handling thread (still needed for interactive menu popup)
         std::thread::spawn(move || {
-            let mut conn = match connect_sws_with_screen_size_retry() {
-                Ok((conn, _, _)) => conn,
-                Err(()) => {
-                    println!("[TaskBar] Failed to connect to SWS for menu popup after retries");
-                    return;
-                }
-            };
+            let (mut conn, popup_screen_width, _, mut scale_milli) =
+                match connect_sws_with_screen_size_retry() {
+                    Ok((conn, width, height, scale_milli)) => (conn, width, height, scale_milli),
+                    Err(()) => {
+                        println!("[TaskBar] Failed to connect to SWS for menu popup after retries");
+                        return;
+                    }
+                };
+            graphics::set_current_scale_milli(scale_milli);
+            screen_width_popup.set(popup_screen_width as f32);
 
             let mut popup_surface_id: Option<u32> = None;
             let mut popup_renderer: Option<PopupMenuRenderer> = None;
@@ -759,14 +806,17 @@ impl TaskBarApp {
                             );
                             let item_height = 28.0;
                             let menu_width = 220.0;
-                            let renderer = PopupMenuRenderer::new(items, item_height, menu_width);
+                            let renderer =
+                                PopupMenuRenderer::new(items, item_height, menu_width, scale_milli);
                             let size = renderer.size();
                             let width = size.width as u32;
                             let height = size.height as u32;
+                            let physical_width = scale_u32(width, scale_milli);
+                            let physical_height = scale_u32(height, scale_milli);
                             popup_renderer = Some(renderer);
                             needs_render = true;
 
-                            let bar_height = 40;
+                            let bar_height = TASKBAR_HEIGHT as i32;
                             let screen_width = screen_width_popup.get().max(1.0);
                             let popup_x = menu_bar_popup_x(&menu_tree_value.items, index)
                                 .min((screen_width - width as f32).max(0.0));
@@ -777,14 +827,14 @@ impl TaskBarApp {
                                         "org.scarlet-os.popup.menu",
                                         "Menu",
                                         "",
-                                        width,
-                                        height,
+                                        physical_width,
+                                        physical_height,
                                         window_types::ALWAYS_ON_TOP,
                                         false,
                                         true,
                                         false,
-                                        popup_x as i32,
-                                        bar_height,
+                                        scale_i32(popup_x as i32, scale_milli),
+                                        scale_i32(bar_height, scale_milli),
                                     ) {
                                         Ok(id) => {
                                             popup_surface_id = Some(id);
@@ -842,11 +892,11 @@ impl TaskBarApp {
                             }
                             match (input.type_, input.code) {
                                 (sws::event::event_type::EV_ABS, sws::event::abs_code::ABS_X) => {
-                                    pointer_x = input.value;
+                                    pointer_x = unscale_i32(input.value, scale_milli);
                                     pending_move = true;
                                 }
                                 (sws::event::event_type::EV_ABS, sws::event::abs_code::ABS_Y) => {
-                                    pointer_y = input.value;
+                                    pointer_y = unscale_i32(input.value, scale_milli);
                                     pending_move = true;
                                 }
                                 (
@@ -855,11 +905,8 @@ impl TaskBarApp {
                                 ) => {
                                     if input.value == 1 {
                                         // pressed
-                                    } else {
-                                        if let Some(renderer) = popup_renderer.as_ref() {
-                                            renderer
-                                                .handle_click(pointer_x as f32, pointer_y as f32);
-                                        }
+                                    } else if let Some(renderer) = popup_renderer.as_ref() {
+                                        renderer.handle_click(pointer_x as f32, pointer_y as f32);
                                     }
                                 }
                                 (sws::event::event_type::EV_SYN, _) => {
@@ -877,7 +924,20 @@ impl TaskBarApp {
                             }
                         }
                         sws::event::Event::ScreenSizeChanged { width, .. } => {
-                            screen_width_popup.set(width as f32);
+                            screen_width_popup.set(unscale_u32(width, scale_milli) as f32);
+                            open_menu_index_popup.set(None);
+                            if let Some(surface_id) = popup_surface_id.take() {
+                                let _ = conn.destroy_surface(surface_id);
+                            }
+                            popup_surface_id_popup.set(None);
+                            popup_renderer = None;
+                            last_open_index = None;
+                        }
+                        sws::event::Event::OutputScaleChanged {
+                            scale_milli: next_scale_milli,
+                        } => {
+                            scale_milli = next_scale_milli.max(1);
+                            graphics::set_current_scale_milli(scale_milli);
                             open_menu_index_popup.set(None);
                             if let Some(surface_id) = popup_surface_id.take() {
                                 let _ = conn.destroy_surface(surface_id);
@@ -982,13 +1042,16 @@ pub extern "C" fn main() {
 
     // Get screen size from SWS before creating the app
     let screen_width = match connect_sws_with_screen_size_retry() {
-        Ok((mut conn, width, height)) => {
-            let workarea_y = bar_height as i32;
-            let workarea_height = height.saturating_sub(bar_height);
-            let _ = conn.set_workarea(0, workarea_y, width, workarea_height);
+        Ok((mut conn, width, height, scale_milli)) => {
+            let physical_width = scale_u32(width, scale_milli);
+            let physical_height = scale_u32(height, scale_milli);
+            let workarea_y = scale_i32(bar_height as i32, scale_milli);
+            let workarea_height =
+                physical_height.saturating_sub(scale_u32(bar_height, scale_milli));
+            let _ = conn.set_workarea(0, workarea_y, physical_width, workarea_height);
             println!(
                 "[TaskBar] Workarea: x=0, y={}, width={}, height={}",
-                workarea_y, width, workarea_height
+                workarea_y, physical_width, workarea_height
             );
 
             width as f32

--- a/user/bin/src/settings.rs
+++ b/user/bin/src/settings.rs
@@ -29,6 +29,8 @@ pub struct PresetColor {
 
 const DEFAULT_BG_PREVIEW: [u8; 3] = [40, 40, 50];
 const DEFAULT_STYLE: BackgroundStyle = BackgroundStyle::GradientLines;
+const SWS_CONFIG_DIR: &str = "/etc/sws";
+const SWS_CONFIG_PATH: &str = "/etc/sws/config.toml";
 
 const PRESET_COLORS: &[PresetColor] = &[
     PresetColor {
@@ -64,6 +66,28 @@ const PRESET_COLORS: &[PresetColor] = &[
         color: [90, 200, 250],
     },
 ];
+
+fn save_output_scale_config(scale_milli: u32) {
+    let config_content = match scale_milli {
+        1000 => "[output]\nscale = 1.0\n",
+        _ => "[output]\nscale = 2.0\n",
+    };
+
+    let _ = fs::create_directory(SWS_CONFIG_DIR);
+
+    match fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(SWS_CONFIG_PATH)
+    {
+        Ok(mut file) => match file.write(config_content.as_bytes()) {
+            Ok(_) => println!("[settings] Saved output scale: {}", scale_milli),
+            Err(e) => println!("[settings] Write SWS config error: {:?}", e),
+        },
+        Err(e) => println!("[settings] Create SWS config error: {:?}", e),
+    }
+}
 
 #[derive(View, Clone)]
 struct SettingsApp {
@@ -455,6 +479,28 @@ fn network_page() -> impl View {
     .frame(f32::INFINITY, f32::INFINITY)
 }
 
+fn display_page() -> impl View {
+    vstack! {
+        Text::new("Display").font_size(28.0),
+        Text::new("Output").font_size(13.0),
+        Divider::new(),
+
+        vstack! {
+            Text::new("Scaling").font_size(14.0),
+            hstack! {
+                Text::new("Scale").font_size(13.0).frame_width(80.0),
+                Button::new("x1.0").on_click(|| { save_output_scale_config(1000); }),
+                Spacer::new().frame_width(8.0),
+                Button::new("x2.0").on_click(|| { save_output_scale_config(2000); }),
+            }
+            .padding(10.0),
+        }
+        .padding(10.0),
+    }
+    .padding(10.0)
+    .frame(f32::INFINITY, f32::INFINITY)
+}
+
 impl Application for SettingsApp {
     fn body(&self) -> impl View {
         let app = self.clone();
@@ -524,6 +570,7 @@ impl Application for SettingsApp {
                         app.clone()
                     )
                 }),
+                NavigationLink::new("Display", Icon::Search, display_page),
                 NavigationLink::new("Network", Icon::Search, network_page),
                 NavigationLink::new("About", Icon::Info, about_page),
             }

--- a/user/bin/src/sws/compositor.rs
+++ b/user/bin/src/sws/compositor.rs
@@ -7,8 +7,10 @@ use super::window::WindowManager;
 use core::sync::atomic::{AtomicU8, Ordering};
 use framebuffer::Framebuffer;
 use std::env;
+use std::fs::File;
 use std::handle::Handle;
 use std::println;
+use std::string::String;
 use std::vec::Vec;
 use sws_protocol;
 
@@ -42,6 +44,133 @@ const LOG_RENDER_VALIDATION: bool = false;
 const ENABLE_DIRTY_RECT: bool = true;
 const MAX_PENDING_DAMAGE_RECTS: usize = 8;
 const DAMAGE_MERGE_AREA_FACTOR: u64 = 2;
+const DEFAULT_OUTPUT_SCALE_MILLI: u32 = 2000;
+const SWS_CONFIG_PATH: &str = "/etc/sws/config.toml";
+
+fn load_output_scale_milli() -> u32 {
+    match read_sws_config(SWS_CONFIG_PATH) {
+        Ok(content) => parse_output_scale_milli(&content).unwrap_or_else(|| {
+            println!(
+                "[Compositor] No output scale in {}; using default {}",
+                SWS_CONFIG_PATH, DEFAULT_OUTPUT_SCALE_MILLI
+            );
+            DEFAULT_OUTPUT_SCALE_MILLI
+        }),
+        Err(_) => DEFAULT_OUTPUT_SCALE_MILLI,
+    }
+}
+
+fn read_sws_config(path: &str) -> Result<String, &'static str> {
+    let mut file = File::open(path).map_err(|_| "Failed to open SWS config")?;
+    let mut content = String::new();
+    let mut buffer = [0u8; 1024];
+
+    loop {
+        let bytes = file
+            .read(&mut buffer)
+            .map_err(|_| "Failed to read SWS config")?;
+        if bytes == 0 {
+            break;
+        }
+        let chunk =
+            core::str::from_utf8(&buffer[..bytes]).map_err(|_| "SWS config is not valid UTF-8")?;
+        content.push_str(chunk);
+    }
+
+    Ok(content)
+}
+
+fn parse_output_scale_milli(content: &str) -> Option<u32> {
+    let mut accepts_output_scale = true;
+
+    for raw_line in content.lines() {
+        let line = strip_toml_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if line.starts_with('[') && line.ends_with(']') {
+            let section = line[1..line.len() - 1].trim();
+            accepts_output_scale = section == "output" || section == "display";
+            continue;
+        }
+
+        let Some(eq_pos) = line.find('=') else {
+            continue;
+        };
+        let key = line[..eq_pos].trim();
+        let value = line[eq_pos + 1..].trim();
+
+        if key == "scale_milli" && accepts_output_scale {
+            if let Some(scale_milli) = parse_u32_value(value) {
+                return Some(normalize_scale_milli(scale_milli));
+            }
+        }
+
+        if key == "scale" && accepts_output_scale {
+            if let Some(scale_milli) = parse_scale_value_milli(value) {
+                return Some(normalize_scale_milli(scale_milli));
+            }
+        }
+    }
+
+    None
+}
+
+fn strip_toml_comment(line: &str) -> &str {
+    let mut in_string = false;
+    for (index, ch) in line.char_indices() {
+        match ch {
+            '"' => in_string = !in_string,
+            '#' if !in_string => return &line[..index],
+            _ => {}
+        }
+    }
+    line
+}
+
+fn trim_toml_string(value: &str) -> &str {
+    let value = value.trim();
+    if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        value[1..value.len() - 1].trim()
+    } else {
+        value
+    }
+}
+
+fn parse_u32_value(value: &str) -> Option<u32> {
+    trim_toml_string(value).parse::<u32>().ok()
+}
+
+fn parse_scale_value_milli(value: &str) -> Option<u32> {
+    let value = trim_toml_string(value);
+    if value.is_empty() {
+        return None;
+    }
+
+    let mut parts = value.split('.');
+    let whole = parts.next()?.parse::<u32>().ok()?;
+    let frac = parts.next();
+    if parts.next().is_some() {
+        return None;
+    }
+
+    let mut frac_milli = 0u32;
+    if let Some(frac) = frac {
+        let mut factor = 100;
+        for ch in frac.chars().take(3) {
+            let digit = ch.to_digit(10)?;
+            frac_milli = frac_milli.saturating_add(digit.saturating_mul(factor));
+            factor /= 10;
+        }
+    }
+
+    Some(whole.saturating_mul(1000).saturating_add(frac_milli))
+}
+
+fn normalize_scale_milli(scale_milli: u32) -> u32 {
+    scale_milli.clamp(250, 8000)
+}
 
 /// Compositor - the main window server with proper layer compositing
 pub struct Compositor {
@@ -52,6 +181,7 @@ pub struct Compositor {
     cursor: Cursor,
     screen_width: u32,
     screen_height: u32,
+    output_scale_milli: u32,
     bg_color: [u8; 4],
     bytes_per_pixel: u32,
     backbuffer: Vec<u8>,
@@ -116,9 +246,15 @@ impl Compositor {
 
         let screen_width = var_info.xres;
         let screen_height = var_info.yres;
+        let output_scale_milli = load_output_scale_milli();
         let bytes_per_pixel = 4; // BGRA
 
         println!("[Compositor] Screen: {}x{}", screen_width, screen_height);
+        println!(
+            "[Compositor] Output scale: {}.{}",
+            output_scale_milli / 1000,
+            output_scale_milli % 1000
+        );
         println!(
             "[Compositor] Framebuffer: bpp={} line_length={} smem_len={}",
             var_info.bits_per_pixel, fix_info.line_length, fix_info.smem_len
@@ -139,7 +275,7 @@ impl Compositor {
         let window_manager = WindowManager::new();
 
         // Initialize cursor at center
-        let mut cursor = Cursor::new();
+        let mut cursor = Cursor::new(output_scale_milli);
         cursor.x = (screen_width / 2) as i32;
         cursor.y = (screen_height / 2) as i32;
         // Keep prev position consistent to avoid an oversized first dirty region.
@@ -161,6 +297,7 @@ impl Compositor {
             cursor,
             screen_width,
             screen_height,
+            output_scale_milli,
             bg_color,
             bytes_per_pixel,
             backbuffer,
@@ -3110,6 +3247,22 @@ impl Compositor {
                 println!(
                     "[Compositor] Sent SCREEN_SIZE: {}x{} to client {}",
                     self.screen_width, self.screen_height, client_id
+                );
+            }
+            IpcEvent::GetOutputScale { client_id } => {
+                println!(
+                    "[Compositor] GetOutputScale request from client {}",
+                    client_id
+                );
+                let payload = sws_protocol::payload_output_scale(self.output_scale_milli);
+                super::ipc::send_message_to_client(
+                    client_id,
+                    sws_protocol::server_msg::OUTPUT_SCALE,
+                    payload.to_vec(),
+                );
+                println!(
+                    "[Compositor] Sent OUTPUT_SCALE: {} to client {}",
+                    self.output_scale_milli, client_id
                 );
             }
             IpcEvent::GetWindowList { client_id } => {

--- a/user/bin/src/sws/cursor.rs
+++ b/user/bin/src/sws/cursor.rs
@@ -40,6 +40,22 @@ const CURSOR_BITMAP: [[u8; CURSOR_WIDTH]; CURSOR_HEIGHT] = [
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0],
 ];
 
+fn scale_milli_or_default(scale_milli: u32) -> u32 {
+    scale_milli.max(1)
+}
+
+fn scaled_len(value: usize, scale_milli: u32) -> u32 {
+    let scale_milli = scale_milli_or_default(scale_milli) as usize;
+    ((value * scale_milli + 999) / 1000).max(1) as u32
+}
+
+fn scaled_cell_bounds(index: usize, scale_milli: u32) -> (u32, u32) {
+    let scale_milli = scale_milli_or_default(scale_milli) as usize;
+    let start = index * scale_milli / 1000;
+    let end = ((index + 1) * scale_milli + 999) / 1000;
+    (start as u32, end.max(start + 1) as u32)
+}
+
 /// Cursor state
 pub struct Cursor {
     pub x: i32,
@@ -48,19 +64,22 @@ pub struct Cursor {
     prev_y: i32,
     pub width: u32,
     pub height: u32,
+    scale_milli: u32,
     needs_redraw: bool,
 }
 
 impl Cursor {
     /// Create a new cursor
-    pub fn new() -> Self {
+    pub fn new(scale_milli: u32) -> Self {
+        let scale_milli = scale_milli_or_default(scale_milli);
         Self {
             x: 0,
             y: 0,
             prev_x: 0,
             prev_y: 0,
-            width: CURSOR_WIDTH as u32,
-            height: CURSOR_HEIGHT as u32,
+            width: scaled_len(CURSOR_WIDTH, scale_milli),
+            height: scaled_len(CURSOR_HEIGHT, scale_milli),
+            scale_milli,
             needs_redraw: true,
         }
     }
@@ -122,8 +141,8 @@ impl Cursor {
                     continue;
                 }
 
-                let px = cx.saturating_add(x as u32);
-                let py = cy.saturating_add(y as u32);
+                let (x0, x1) = scaled_cell_bounds(x, self.scale_milli);
+                let (y0, y1) = scaled_cell_bounds(y, self.scale_milli);
 
                 let color = if pixel == 2 {
                     CURSOR_BORDER
@@ -131,7 +150,11 @@ impl Cursor {
                     CURSOR_COLOR
                 };
 
-                let _ = fb.write_pixel(px, py, color);
+                for dy in y0..y1 {
+                    for dx in x0..x1 {
+                        let _ = fb.write_pixel(cx.saturating_add(dx), cy.saturating_add(dy), color);
+                    }
+                }
             }
         }
     }
@@ -168,32 +191,39 @@ impl Cursor {
                     continue;
                 }
 
-                let screen_x = cx + x as i32;
-                let screen_y = cy + y as i32;
-
-                // Bounds check
-                if screen_x < 0
-                    || screen_x >= screen_width as i32
-                    || screen_y < 0
-                    || screen_y >= screen_height as i32
-                {
-                    continue;
-                }
-
-                let offset =
-                    ((screen_y as u32 * stride) + (screen_x as u32 * bytes_per_pixel)) as usize;
-
                 let color = if pixel == 2 {
                     CURSOR_BORDER
                 } else {
                     CURSOR_COLOR
                 };
 
-                if offset + 4 <= buffer.len() {
-                    buffer[offset] = color[0]; // B
-                    buffer[offset + 1] = color[1]; // G
-                    buffer[offset + 2] = color[2]; // R
-                    buffer[offset + 3] = color[3]; // A
+                let (x0, x1) = scaled_cell_bounds(x, self.scale_milli);
+                let (y0, y1) = scaled_cell_bounds(y, self.scale_milli);
+                for dy in y0..y1 {
+                    for dx in x0..x1 {
+                        let screen_x = cx + dx as i32;
+                        let screen_y = cy + dy as i32;
+
+                        // Bounds check
+                        if screen_x < 0
+                            || screen_x >= screen_width as i32
+                            || screen_y < 0
+                            || screen_y >= screen_height as i32
+                        {
+                            continue;
+                        }
+
+                        let offset = ((screen_y as u32 * stride)
+                            + (screen_x as u32 * bytes_per_pixel))
+                            as usize;
+
+                        if offset + 4 <= buffer.len() {
+                            buffer[offset] = color[0]; // B
+                            buffer[offset + 1] = color[1]; // G
+                            buffer[offset + 2] = color[2]; // R
+                            buffer[offset + 3] = color[3]; // A
+                        }
+                    }
                 }
             }
         }

--- a/user/bin/src/sws/ipc.rs
+++ b/user/bin/src/sws/ipc.rs
@@ -1732,6 +1732,13 @@ fn client_thread_main(client_id: usize, mut socket: Socket) {
                 );
                 push_ipc_event(IpcEvent::GetScreenSize { client_id });
             }
+            Ok(ClientMessageRef::GetOutputScale {}) => {
+                println!(
+                    "[ClientThread {}] GetOutputScale: forwarding to compositor",
+                    client_id
+                );
+                push_ipc_event(IpcEvent::GetOutputScale { client_id });
+            }
             Ok(ClientMessageRef::GetWindowList {}) => {
                 println!(
                     "[ClientThread {}] GetWindowList: requesting window list",
@@ -2000,6 +2007,11 @@ pub enum IpcEvent {
 
     /// Get the screen size
     GetScreenSize {
+        client_id: usize,
+    },
+
+    /// Get the output scale
+    GetOutputScale {
         client_id: usize,
     },
 

--- a/user/lib/scarlet-ui/src/application.rs
+++ b/user/lib/scarlet-ui/src/application.rs
@@ -116,6 +116,9 @@ pub trait Application: View {
         // 3. Initialize the application
         self.init();
 
+        let output_scale_milli = SWSPlatformWindow::query_output_scale();
+        pipeline.set_scale_milli(output_scale_milli);
+
         // 4. Perform initial layout to determine window size and extract window properties
         let (
             app_id,

--- a/user/lib/scarlet-ui/src/buffer.rs
+++ b/user/lib/scarlet-ui/src/buffer.rs
@@ -17,6 +17,9 @@ use crate::color::Color;
 pub struct Buffer {
     width: u32,
     height: u32,
+    logical_width: u32,
+    logical_height: u32,
+    scale_milli: u32,
     data: Vec<u32>,
 }
 
@@ -28,6 +31,9 @@ impl Buffer {
         Self {
             width,
             height,
+            logical_width: width,
+            logical_height: height,
+            scale_milli: 1000,
             data: vec![0; (width * height) as usize],
         }
     }
@@ -37,8 +43,47 @@ impl Buffer {
         Self {
             width,
             height,
+            logical_width: width,
+            logical_height: height,
+            scale_milli: 1000,
             data: vec![0; (width * height) as usize],
         }
+    }
+
+    /// Create a physical buffer for a logical size using the current UI scale.
+    pub fn from_logical_dimensions(logical_width: u32, logical_height: u32) -> Self {
+        Self::from_logical_dimensions_with_scale(
+            logical_width,
+            logical_height,
+            crate::graphics::current_scale_milli(),
+        )
+    }
+
+    /// Create a physical buffer for a logical size using an explicit UI scale.
+    pub fn from_logical_dimensions_with_scale(
+        logical_width: u32,
+        logical_height: u32,
+        scale_milli: u32,
+    ) -> Self {
+        let scale_milli = scale_milli.max(1);
+        let width = Self::scale_len(logical_width, scale_milli);
+        let height = Self::scale_len(logical_height, scale_milli);
+        Self {
+            width,
+            height,
+            logical_width,
+            logical_height,
+            scale_milli,
+            data: vec![0; (width * height) as usize],
+        }
+    }
+
+    fn scale_len(value: u32, scale_milli: u32) -> u32 {
+        ((value as u64)
+            .saturating_mul(scale_milli as u64)
+            .saturating_add(999)
+            / 1000)
+            .max(1) as u32
     }
 
     /// Get the buffer width
@@ -49,6 +94,21 @@ impl Buffer {
     /// Get the buffer height
     pub fn height(&self) -> u32 {
         self.height
+    }
+
+    /// Get the logical buffer width.
+    pub fn logical_width(&self) -> u32 {
+        self.logical_width
+    }
+
+    /// Get the logical buffer height.
+    pub fn logical_height(&self) -> u32 {
+        self.logical_height
+    }
+
+    /// Get the scale used to create this buffer in milli-units.
+    pub fn scale_milli(&self) -> u32 {
+        self.scale_milli
     }
 
     /// Get the buffer size

--- a/user/lib/scarlet-ui/src/compositor.rs
+++ b/user/lib/scarlet-ui/src/compositor.rs
@@ -20,16 +20,36 @@ struct ClipRegion {
 /// Compositor for rendering element trees to buffers
 pub struct Compositor {
     window_buffer: Buffer,
+    scale_milli: u32,
     last_bounds: BTreeMap<ElementId, Rect>,
 }
 
 impl Compositor {
     /// Create a new compositor with the given window size
-    pub fn new(window_size: Size) -> Self {
+    pub fn new(window_size: Size, scale_milli: u32) -> Self {
         Self {
-            window_buffer: Buffer::new(window_size),
+            window_buffer: Buffer::from_logical_dimensions_with_scale(
+                libm::ceilf(window_size.width.max(1.0)) as u32,
+                libm::ceilf(window_size.height.max(1.0)) as u32,
+                scale_milli,
+            ),
+            scale_milli: scale_milli.max(1),
             last_bounds: BTreeMap::new(),
         }
+    }
+
+    fn scale_pos(&self, value: f32) -> i32 {
+        libm::floorf(value * self.scale_milli as f32 / 1000.0) as i32
+    }
+
+    fn scale_len(&self, value: f32) -> i32 {
+        libm::ceilf(value.max(0.0) * self.scale_milli as f32 / 1000.0) as i32
+    }
+
+    /// Set the output scale and recreate the physical window buffer.
+    pub fn set_scale_milli(&mut self, scale_milli: u32, logical_size: Size) {
+        self.scale_milli = scale_milli.max(1);
+        self.resize(logical_size);
     }
 
     /// Clear the window buffer with a color
@@ -77,7 +97,8 @@ impl Compositor {
 
         self.merge_overlapping_rects(&mut rects);
 
-        let window_area = (self.window_buffer.width() as f32) * (self.window_buffer.height() as f32);
+        let window_area = (self.window_buffer.logical_width() as f32)
+            * (self.window_buffer.logical_height() as f32);
         let dirty_area: f32 = rects.iter().map(|r| r.size.width * r.size.height).sum();
         if dirty_area >= window_area * 0.6 {
             self.composite_elements(root);
@@ -121,7 +142,8 @@ impl Compositor {
 
         self.merge_overlapping_rects(&mut rects);
 
-        let window_area = (self.window_buffer.width() as f32) * (self.window_buffer.height() as f32);
+        let window_area = (self.window_buffer.logical_width() as f32)
+            * (self.window_buffer.logical_height() as f32);
         let dirty_area: f32 = rects.iter().map(|r| r.size.width * r.size.height).sum();
         if dirty_area >= window_area * 0.6 {
             self.composite_tree(tree);
@@ -169,8 +191,8 @@ impl Compositor {
 
                 self.window_buffer.composite(
                     buffer,
-                    absolute_origin.x as i32,
-                    absolute_origin.y as i32,
+                    self.scale_pos(absolute_origin.x),
+                    self.scale_pos(absolute_origin.y),
                     opacity,
                 );
             }
@@ -236,20 +258,20 @@ impl Compositor {
                 let (x, y, w, h) = self.rect_to_i32(active_clip.rect);
                 self.window_buffer.composite_clipped_rounded(
                     buffer,
-                    absolute_origin.x as i32,
-                    absolute_origin.y as i32,
+                    self.scale_pos(absolute_origin.x),
+                    self.scale_pos(absolute_origin.y),
                     opacity,
                     x,
                     y,
                     w,
                     h,
-                    active_clip.radius,
+                    self.scale_len(active_clip.radius) as f32,
                 );
             } else {
                 self.window_buffer.composite(
                     buffer,
-                    absolute_origin.x as i32,
-                    absolute_origin.y as i32,
+                    self.scale_pos(absolute_origin.x),
+                    self.scale_pos(absolute_origin.y),
                     opacity,
                 );
             }
@@ -325,20 +347,20 @@ impl Compositor {
                 if clip_radius > 0.0 {
                     self.window_buffer.composite_clipped_rounded(
                         buffer,
-                        absolute_origin.x as i32,
-                        absolute_origin.y as i32,
+                        self.scale_pos(absolute_origin.x),
+                        self.scale_pos(absolute_origin.y),
                         opacity,
                         x,
                         y,
                         w,
                         h,
-                        clip_radius,
+                        self.scale_len(clip_radius) as f32,
                     );
                 } else {
                     self.window_buffer.composite_clipped(
                         buffer,
-                        absolute_origin.x as i32,
-                        absolute_origin.y as i32,
+                        self.scale_pos(absolute_origin.x),
+                        self.scale_pos(absolute_origin.y),
                         opacity,
                         x,
                         y,
@@ -376,8 +398,8 @@ impl Compositor {
                         let (x, y, w, h) = self.rect_to_i32(*rect);
                         self.window_buffer.composite_clipped(
                             buffer,
-                            absolute_origin.x as i32,
-                            absolute_origin.y as i32,
+                            self.scale_pos(absolute_origin.x),
+                            self.scale_pos(absolute_origin.y),
                             opacity,
                             x,
                             y,
@@ -497,10 +519,12 @@ impl Compositor {
     }
 
     fn rect_to_u32(&self, rect: Rect) -> (u32, u32, u32, u32) {
-        let x0 = libm::floorf(rect.origin.x).max(0.0);
-        let y0 = libm::floorf(rect.origin.y).max(0.0);
-        let x1 = libm::ceilf(rect.origin.x + rect.size.width).min(self.window_buffer.width() as f32);
-        let y1 = libm::ceilf(rect.origin.y + rect.size.height).min(self.window_buffer.height() as f32);
+        let x0 = libm::floorf(rect.origin.x * self.scale_milli as f32 / 1000.0).max(0.0);
+        let y0 = libm::floorf(rect.origin.y * self.scale_milli as f32 / 1000.0).max(0.0);
+        let x1 = libm::ceilf((rect.origin.x + rect.size.width) * self.scale_milli as f32 / 1000.0)
+            .min(self.window_buffer.width() as f32);
+        let y1 = libm::ceilf((rect.origin.y + rect.size.height) * self.scale_milli as f32 / 1000.0)
+            .min(self.window_buffer.height() as f32);
         let w = (x1 - x0).max(0.0);
         let h = (y1 - y0).max(0.0);
         (x0 as u32, y0 as u32, w as u32, h as u32)
@@ -535,7 +559,11 @@ impl Compositor {
 
     /// Resize the window buffer
     pub fn resize(&mut self, new_size: Size) {
-        self.window_buffer = Buffer::new(new_size);
+        self.window_buffer = Buffer::from_logical_dimensions_with_scale(
+            libm::ceilf(new_size.width.max(1.0)) as u32,
+            libm::ceilf(new_size.height.max(1.0)) as u32,
+            self.scale_milli,
+        );
         self.last_bounds.clear();
     }
 

--- a/user/lib/scarlet-ui/src/graphics.rs
+++ b/user/lib/scarlet-ui/src/graphics.rs
@@ -4,12 +4,25 @@
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 use ab_glyph::{point, Font, FontRef, Glyph, InvalidFont, PxScale, PxScaleFont, ScaleFont};
 
 use crate::color::Color;
+use crate::buffer::Buffer;
 use scarlet_std::{println, sync::Mutex, fs::File};
+
+static CURRENT_SCALE_MILLI: AtomicU32 = AtomicU32::new(1000);
+
+/// Return the current UI scale in milli-units.
+pub fn current_scale_milli() -> u32 {
+    CURRENT_SCALE_MILLI.load(Ordering::Relaxed).max(1)
+}
+
+/// Set the current UI scale in milli-units.
+pub fn set_current_scale_milli(scale_milli: u32) {
+    CURRENT_SCALE_MILLI.store(scale_milli.max(1), Ordering::Relaxed);
+}
 
 /// Glyph cache key
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -575,6 +588,9 @@ pub struct Canvas<'a> {
     buffer: &'a mut [u8],
     width: u32,
     height: u32,
+    physical_width: u32,
+    physical_height: u32,
+    scale_milli: u32,
 }
 
 impl<'a> Canvas<'a> {
@@ -584,6 +600,26 @@ impl<'a> Canvas<'a> {
             buffer,
             width,
             height,
+            physical_width: width,
+            physical_height: height,
+            scale_milli: 1000,
+        }
+    }
+
+    /// Create a canvas that draws logical coordinates into a scaled buffer.
+    pub fn for_buffer(buffer: &'a mut Buffer) -> Self {
+        let width = buffer.logical_width();
+        let height = buffer.logical_height();
+        let physical_width = buffer.width();
+        let physical_height = buffer.height();
+        let scale_milli = buffer.scale_milli();
+        Self {
+            buffer: buffer.data_mut(),
+            width,
+            height,
+            physical_width,
+            physical_height,
+            scale_milli,
         }
     }
 
@@ -605,13 +641,44 @@ impl<'a> Canvas<'a> {
         self.height
     }
 
+    fn scale_floor_i32(&self, value: i32) -> i32 {
+        ((value as i64).saturating_mul(self.scale_milli as i64) / 1000) as i32
+    }
+
+    fn scale_ceil_i32(&self, value: i32) -> i32 {
+        ((value as i64)
+            .saturating_mul(self.scale_milli as i64)
+            .saturating_add(999)
+            / 1000) as i32
+    }
+
+    fn scale_len_u32(&self, value: u32) -> u32 {
+        ((value as u64)
+            .saturating_mul(self.scale_milli as u64)
+            .saturating_add(999)
+            / 1000)
+            .max(1) as u32
+    }
+
     /// Draw a single pixel
     pub fn put_pixel(&mut self, x: i32, y: i32, color: Color) {
-        if x < 0 || x >= self.width as i32 || y < 0 || y >= self.height as i32 {
+        let px = self.scale_floor_i32(x);
+        let py = self.scale_floor_i32(y);
+        let w = self.scale_len_u32(1);
+        let h = self.scale_len_u32(1);
+        self.fill_physical_rect(px, py, w, h, color);
+    }
+
+    fn put_pixel_physical(&mut self, x: i32, y: i32, color: Color) {
+        if x < 0
+            || x >= self.physical_width as i32
+            || y < 0
+            || y >= self.physical_height as i32
+        {
             return;
         }
 
-        let offset = ((y as u32 * self.width + x as u32) * 4) as usize;
+        let offset = ((y as u32 * self.physical_width + x as u32) * 4) as usize;
         if offset + 4 <= self.buffer.len() {
             // Convert to BGRA and use little-endian bytes
             // to_bgra() produces 0xAARRGGBB which becomes [BB, GG, RR, AA] in little-endian
@@ -620,11 +687,15 @@ impl<'a> Canvas<'a> {
         }
     }
 
-    fn get_pixel(&self, x: i32, y: i32) -> Color {
-        if x < 0 || x >= self.width as i32 || y < 0 || y >= self.height as i32 {
+    fn get_pixel_physical(&self, x: i32, y: i32) -> Color {
+        if x < 0
+            || x >= self.physical_width as i32
+            || y < 0
+            || y >= self.physical_height as i32
+        {
             return Color::BLACK;
         }
-        let offset = ((y as u32 * self.width + x as u32) * 4) as usize;
+        let offset = ((y as u32 * self.physical_width + x as u32) * 4) as usize;
         if offset + 4 > self.buffer.len() {
             return Color::BLACK;
         }
@@ -634,16 +705,16 @@ impl<'a> Canvas<'a> {
         Color::from_bgra(u32::from_le_bytes(bgra_bytes))
     }
 
-    fn put_pixel_alpha(&mut self, x: i32, y: i32, color: Color, alpha: f32) {
+    fn put_pixel_physical_alpha(&mut self, x: i32, y: i32, color: Color, alpha: f32) {
         if alpha <= 0.0 {
             return;
         }
         if alpha >= 1.0 {
-            self.put_pixel(x, y, color);
+            self.put_pixel_physical(x, y, color);
             return;
         }
 
-        let dst = self.get_pixel(x, y);
+        let dst = self.get_pixel_physical(x, y);
 
         // color.a is already in 0.0-1.0 range, not 0-255
         let src_a = (alpha * color.a).clamp(0.0, 1.0);
@@ -651,7 +722,7 @@ impl<'a> Canvas<'a> {
         let out_a = src_a + dst_a * (1.0 - src_a);
 
         if out_a <= 0.0 {
-            self.put_pixel(x, y, Color::rgba(0.0, 0.0, 0.0, 0.0));
+            self.put_pixel_physical(x, y, Color::rgba(0.0, 0.0, 0.0, 0.0));
             return;
         }
 
@@ -660,11 +731,21 @@ impl<'a> Canvas<'a> {
         let out_b = (color.b * src_a + dst.b * dst_a * (1.0 - src_a)) / out_a;
         let out_a_f32 = out_a;
 
-        self.put_pixel(x, y, Color::rgba(out_r, out_g, out_b, out_a_f32));
+        self.put_pixel_physical(x, y, Color::rgba(out_r, out_g, out_b, out_a_f32));
     }
 
     /// Fill a rectangle with a solid color
     pub fn fill_rect(&mut self, x: i32, y: i32, width: u32, height: u32, color: Color) {
+        let x0 = self.scale_floor_i32(x);
+        let y0 = self.scale_floor_i32(y);
+        let x1 = self.scale_ceil_i32(x.saturating_add(width as i32));
+        let y1 = self.scale_ceil_i32(y.saturating_add(height as i32));
+        let physical_width = (x1 - x0).max(0) as u32;
+        let physical_height = (y1 - y0).max(0) as u32;
+        self.fill_physical_rect(x0, y0, physical_width, physical_height, color);
+    }
+
+    fn fill_physical_rect(&mut self, x: i32, y: i32, width: u32, height: u32, color: Color) {
         // Convert to BGRA and use little-endian bytes
         // to_bgra() produces 0xAARRGGBB which becomes [BB, GG, RR, AA] in little-endian
         let bgra = color.to_bgra();
@@ -675,11 +756,15 @@ impl<'a> Canvas<'a> {
                 let px = x + dx as i32;
                 let py = y + dy as i32;
 
-                if px < 0 || px >= self.width as i32 || py < 0 || py >= self.height as i32 {
+                if px < 0
+                    || px >= self.physical_width as i32
+                    || py < 0
+                    || py >= self.physical_height as i32
+                {
                     continue;
                 }
 
-                let offset = ((py as u32 * self.width + px as u32) * 4) as usize;
+                let offset = ((py as u32 * self.physical_width + px as u32) * 4) as usize;
                 if offset + 4 <= self.buffer.len() {
                     self.buffer[offset..offset + 4].copy_from_slice(&bgra_bytes);
                 }
@@ -722,15 +807,17 @@ impl<'a> Canvas<'a> {
         font_size_px: f32,
         font_stack: &FontStack,
     ) {
-        let scale = PxScale::from(font_size_px);
+        let ui_scale = (self.scale_milli as f32) / 1000.0;
+        let scale = PxScale::from(font_size_px * ui_scale);
         let base_scaled = font_stack.primary.as_scaled(scale);
 
-        let mut caret_x = x as f32;
-        let mut caret_y = y as f32 + base_scaled.ascent();
+        let origin_x = self.scale_floor_i32(x) as f32;
+        let mut caret_x = origin_x;
+        let mut caret_y = self.scale_floor_i32(y) as f32 + base_scaled.ascent();
 
         for ch in text.chars() {
             if ch == '\n' {
-                caret_x = x as f32;
+                caret_x = origin_x;
                 caret_y += base_scaled.height() + base_scaled.line_gap();
                 continue;
             }
@@ -754,7 +841,7 @@ impl<'a> Canvas<'a> {
                         let alpha = (a as f32) / 255.0;
                         let px = base_x + ox + gx as i32;
                         let py = base_y + oy + gy as i32;
-                        self.put_pixel_alpha(px, py, color, alpha);
+                        self.put_pixel_physical_alpha(px, py, color, alpha);
                     }
                 }
             }
@@ -769,21 +856,18 @@ impl<'a> Canvas<'a> {
             return;
         }
 
-        // Top and bottom edges
-        for dx in 0..width {
-            self.put_pixel(x + dx as i32, y, color);
-            self.put_pixel(x + dx as i32, y + height as i32 - 1, color);
-        }
-
-        // Left and right edges
-        for dy in 0..height {
-            self.put_pixel(x, y + dy as i32, color);
-            self.put_pixel(x + width as i32 - 1, y + dy as i32, color);
-        }
+        self.fill_rect(x, y, width, 1, color);
+        self.fill_rect(x, y + height as i32 - 1, width, 1, color);
+        self.fill_rect(x, y, 1, height, color);
+        self.fill_rect(x + width as i32 - 1, y, 1, height, color);
     }
 
     /// Draw line using Bresenham's algorithm
     pub fn draw_line(&mut self, mut x0: i32, mut y0: i32, x1: i32, y1: i32, color: Color) {
+        x0 = self.scale_floor_i32(x0);
+        y0 = self.scale_floor_i32(y0);
+        let x1 = self.scale_floor_i32(x1);
+        let y1 = self.scale_floor_i32(y1);
         let dx = (x1 - x0).abs();
         let sx = if x0 < x1 { 1 } else { -1 };
         let dy = -(y1 - y0).abs();
@@ -791,7 +875,7 @@ impl<'a> Canvas<'a> {
 
         let mut err = dx + dy;
         loop {
-            self.put_pixel(x0, y0, color);
+            self.put_pixel_physical(x0, y0, color);
             if x0 == x1 && y0 == y1 {
                 break;
             }

--- a/user/lib/scarlet-ui/src/pipeline/rendering.rs
+++ b/user/lib/scarlet-ui/src/pipeline/rendering.rs
@@ -28,6 +28,8 @@ pub struct RenderingPipeline {
     compositor: Option<Compositor>,
     /// Current window size
     window_size: Size,
+    /// Current output scale in milli-units.
+    scale_milli: u32,
     /// Event dispatcher
     event_dispatcher: EventDispatcher,
 }
@@ -40,7 +42,23 @@ impl RenderingPipeline {
             pipeline_owner: PipelineOwner::new(),
             compositor: None,
             window_size: Size::new(800.0, 600.0),
+            scale_milli: 1000,
             event_dispatcher: EventDispatcher::new(),
+        }
+    }
+
+    /// Set the output scale in milli-units.
+    pub fn set_scale_milli(&mut self, scale_milli: u32) {
+        self.scale_milli = scale_milli.max(1);
+        crate::graphics::set_current_scale_milli(self.scale_milli);
+        if let Some(ref mut compositor) = self.compositor {
+            compositor.set_scale_milli(self.scale_milli, self.window_size);
+        }
+        if let Some(root) = self.element_tree.root_mut() {
+            root.clear_buffers();
+        }
+        if let Some(root) = self.element_tree.root() {
+            self.pipeline_owner.mark_needs_layout(root.id());
         }
     }
 
@@ -188,7 +206,8 @@ impl RenderingPipeline {
         let _layout_size = self.element_tree.layout(constraints);
 
         // Create compositor with the window size (not layout size)
-        self.compositor = Some(Compositor::new(window_size));
+        crate::graphics::set_current_scale_milli(self.scale_milli);
+        self.compositor = Some(Compositor::new(window_size, self.scale_milli));
         self.window_size = window_size;
 
         // Mark root as dirty for initial paint
@@ -210,6 +229,7 @@ impl RenderingPipeline {
     /// Set window size and resize compositor
     pub fn resize(&mut self, new_size: Size) {
         self.window_size = new_size;
+        crate::graphics::set_current_scale_milli(self.scale_milli);
         if let Some(ref mut compositor) = self.compositor {
             compositor.resize(new_size);
         }
@@ -233,6 +253,7 @@ impl RenderingPipeline {
             scarlet_std::println!("[RenderingPipeline] render() starting...");
         }
         // Flush all dirty phases (build, layout, paint)
+        crate::graphics::set_current_scale_milli(self.scale_milli);
         self.pipeline_owner.flush(&mut self.element_tree, self.window_size);
         if crate::debug::is_enabled() {
             scarlet_std::println!("[RenderingPipeline] flush() completed");

--- a/user/lib/scarlet-ui/src/platform/sws.rs
+++ b/user/lib/scarlet-ui/src/platform/sws.rs
@@ -11,6 +11,8 @@ use alloc::vec::Vec;
 use sws::event::{Event as SwsEvent, abs_code, event_type, key_code};
 use sws_client as sws;
 
+const DEFAULT_SCALE_MILLI: u32 = 1000;
+
 const KEY_LEFTCTRL: u16 = 0x1d;
 const KEY_LEFTSHIFT: u16 = 0x2a;
 const KEY_RIGHTSHIFT: u16 = 0x36;
@@ -22,6 +24,7 @@ const KEY_RIGHTALT: u16 = 0x64;
 pub struct SWSPlatformWindow {
     conn: sws::Connection,
     surface_id: u32,
+    scale_milli: u32,
     current_size: Size,
     pending_events: Vec<Event>,
     pending_head: usize,
@@ -37,6 +40,47 @@ pub struct SWSPlatformWindow {
 }
 
 impl SWSPlatformWindow {
+    fn sanitize_scale(scale_milli: u32) -> u32 {
+        scale_milli.max(1)
+    }
+
+    pub fn query_output_scale() -> u32 {
+        let Ok(mut conn) = sws::Connection::connect("/tmp/sws.sock") else {
+            return DEFAULT_SCALE_MILLI;
+        };
+        conn.get_output_scale()
+            .map(Self::sanitize_scale)
+            .unwrap_or(DEFAULT_SCALE_MILLI)
+    }
+
+    fn logical_to_physical_len_with_scale(value: u32, scale_milli: u32) -> u32 {
+        ((value as u64)
+            .saturating_mul(scale_milli as u64)
+            .saturating_add(999)
+            / 1000)
+            .max(1) as u32
+    }
+
+    fn logical_to_physical_len(&self, value: u32) -> u32 {
+        Self::logical_to_physical_len_with_scale(value, self.scale_milli)
+    }
+
+    fn physical_to_logical_len(&self, value: u32) -> u32 {
+        ((value as u64)
+            .saturating_mul(1000)
+            .saturating_add(self.scale_milli as u64 - 1)
+            / self.scale_milli as u64)
+            .max(1) as u32
+    }
+
+    fn logical_to_physical_pos(&self, value: i32) -> i32 {
+        ((value as i64).saturating_mul(self.scale_milli as i64) / 1000) as i32
+    }
+
+    fn physical_to_logical_pos(&self, value: i32) -> i32 {
+        ((value as i64).saturating_mul(1000) / self.scale_milli as i64) as i32
+    }
+
     /// Get the connection
     pub fn connection(&self) -> &sws::Connection {
         &self.conn
@@ -97,6 +141,14 @@ impl SWSPlatformWindow {
         // Connect to SWS
         let mut conn = sws::Connection::connect("/tmp/sws.sock")
             .map_err(|_| crate::error::Error::ConnectionFailed)?;
+        let scale_milli = conn
+            .get_output_scale()
+            .map(Self::sanitize_scale)
+            .unwrap_or(DEFAULT_SCALE_MILLI);
+        let physical_width =
+            Self::logical_to_physical_len_with_scale(size.width.max(1.0) as u32, scale_milli);
+        let physical_height =
+            Self::logical_to_physical_len_with_scale(size.height.max(1.0) as u32, scale_milli);
 
         // Create surface with type
         let surface_id = conn
@@ -104,8 +156,8 @@ impl SWSPlatformWindow {
                 app_id,
                 title,
                 menu_titles,
-                size.width as u32,
-                size.height as u32,
+                physical_width,
+                physical_height,
                 window_type,
                 true,
                 focus_on_create,
@@ -116,6 +168,7 @@ impl SWSPlatformWindow {
         Ok(Self {
             conn,
             surface_id,
+            scale_milli,
             current_size: size,
             pending_events: Vec::new(),
             pending_head: 0,
@@ -371,15 +424,24 @@ impl PlatformWindow for SWSPlatformWindow {
         // Connect to SWS
         let mut conn = sws::Connection::connect("/tmp/sws.sock")
             .map_err(|_| crate::error::Error::ConnectionFailed)?;
+        let scale_milli = conn
+            .get_output_scale()
+            .map(Self::sanitize_scale)
+            .unwrap_or(DEFAULT_SCALE_MILLI);
+        let physical_width =
+            Self::logical_to_physical_len_with_scale(size.width.max(1.0) as u32, scale_milli);
+        let physical_height =
+            Self::logical_to_physical_len_with_scale(size.height.max(1.0) as u32, scale_milli);
 
         // Create surface
         let surface_id = conn
-            .create_surface(app_id, title, "", size.width as u32, size.height as u32)
+            .create_surface(app_id, title, "", physical_width, physical_height)
             .map_err(|_| crate::error::Error::SurfaceCreationFailed)?;
 
         Ok(Self {
             conn,
             surface_id,
+            scale_milli,
             current_size: size,
             pending_events: Vec::new(),
             pending_head: 0,
@@ -487,8 +549,11 @@ impl PlatformWindow for SWSPlatformWindow {
             return Ok(());
         }
 
+        let physical_width = self.logical_to_physical_len(width);
+        let physical_height = self.logical_to_physical_len(height);
+
         self.conn
-            .resize_window(self.surface_id, width, height)
+            .resize_window(self.surface_id, physical_width, physical_height)
             .map_err(|_| crate::error::Error::IoError)?;
 
         self.current_size = new_size;
@@ -536,8 +601,8 @@ impl PlatformWindow for SWSPlatformWindow {
                 "org.scarlet-os.popup",
                 "Popup",
                 "",
-                size.width as u32,
-                size.height as u32,
+                self.logical_to_physical_len(size.width.max(1.0) as u32),
+                self.logical_to_physical_len(size.height.max(1.0) as u32),
                 sws_protocol::window_types::ALWAYS_ON_TOP,
                 true,
                 true,
@@ -547,7 +612,11 @@ impl PlatformWindow for SWSPlatformWindow {
 
         // Position the popup
         self.conn
-            .move_window(popup_surface_id, position.x as i32, position.y as i32)
+            .move_window(
+                popup_surface_id,
+                self.logical_to_physical_pos(position.x as i32),
+                self.logical_to_physical_pos(position.y as i32),
+            )
             .map_err(|_| crate::error::Error::IoError)?;
 
         Ok(popup_surface_id)
@@ -561,7 +630,12 @@ impl PlatformWindow for SWSPlatformWindow {
 
     fn set_workarea(&mut self, x: i32, y: i32, width: u32, height: u32) -> Result<()> {
         self.conn
-            .set_workarea(x, y, width, height)
+            .set_workarea(
+                self.logical_to_physical_pos(x),
+                self.logical_to_physical_pos(y),
+                self.logical_to_physical_len(width),
+                self.logical_to_physical_len(height),
+            )
             .map_err(|_| crate::error::Error::IoError)
     }
 
@@ -577,14 +651,22 @@ impl PlatformWindow for SWSPlatformWindow {
     {
         let mut conn = sws::Connection::connect("/tmp/sws.sock")
             .map_err(|_| crate::error::Error::ConnectionFailed)?;
+        let scale_milli = conn
+            .get_output_scale()
+            .map(Self::sanitize_scale)
+            .unwrap_or(DEFAULT_SCALE_MILLI);
+        let physical_width =
+            Self::logical_to_physical_len_with_scale(size.width.max(1.0) as u32, scale_milli);
+        let physical_height =
+            Self::logical_to_physical_len_with_scale(size.height.max(1.0) as u32, scale_milli);
 
         let surface_id = conn
             .create_surface_with_type(
                 app_id,
                 title,
                 "",
-                size.width as u32,
-                size.height as u32,
+                physical_width,
+                physical_height,
                 window_type,
             )
             .map_err(|_| crate::error::Error::SurfaceCreationFailed)?;
@@ -592,6 +674,7 @@ impl PlatformWindow for SWSPlatformWindow {
         Ok(Self {
             conn,
             surface_id,
+            scale_milli,
             current_size: size,
             pending_events: Vec::new(),
             pending_head: 0,
@@ -609,7 +692,11 @@ impl PlatformWindow for SWSPlatformWindow {
 
     fn move_window(&mut self, x: i32, y: i32) -> Result<()> {
         self.conn
-            .move_window(self.surface_id, x, y)
+            .move_window(
+                self.surface_id,
+                self.logical_to_physical_pos(x),
+                self.logical_to_physical_pos(y),
+            )
             .map_err(|_| crate::error::Error::IoError)
     }
 
@@ -620,9 +707,14 @@ impl PlatformWindow for SWSPlatformWindow {
     }
 
     fn get_screen_size(&mut self) -> Result<(u32, u32)> {
-        self.conn
+        let (width, height) = self
+            .conn
             .get_screen_size()
-            .map_err(|_| crate::error::Error::IoError)
+            .map_err(|_| crate::error::Error::IoError)?;
+        Ok((
+            self.physical_to_logical_len(width),
+            self.physical_to_logical_len(height),
+        ))
     }
 
     fn surface_id(&self) -> u32 {
@@ -640,10 +732,10 @@ impl PlatformWindow for SWSPlatformWindow {
                 .set_window_size_limits(self.surface_id, sws::WindowSizeLimits::NONE);
         } else {
             let limits = sws::WindowSizeLimits {
-                min_width: self.current_size.width.max(0.0) as u32,
-                min_height: self.current_size.height.max(0.0) as u32,
-                max_width: self.current_size.width.max(0.0) as u32,
-                max_height: self.current_size.height.max(0.0) as u32,
+                min_width: self.logical_to_physical_len(self.current_size.width.max(1.0) as u32),
+                min_height: self.logical_to_physical_len(self.current_size.height.max(1.0) as u32),
+                max_width: self.logical_to_physical_len(self.current_size.width.max(1.0) as u32),
+                max_height: self.logical_to_physical_len(self.current_size.height.max(1.0) as u32),
             };
             let _ = self.conn.set_window_size_limits(self.surface_id, limits);
         }
@@ -688,14 +780,14 @@ impl SWSPlatformWindow {
 
                 match (input.type_, input.code) {
                     (event_type::EV_ABS, abs_code::ABS_X) => {
-                        self.pointer_x = input.value;
+                        self.pointer_x = self.physical_to_logical_pos(input.value);
                         self.pending_move = true;
                         if debug {
                             scarlet_std::println!("[SWSPlatformWindow] ABS_X: {}", input.value);
                         }
                     }
                     (event_type::EV_ABS, abs_code::ABS_Y) => {
-                        self.pointer_y = input.value;
+                        self.pointer_y = self.physical_to_logical_pos(input.value);
                         self.pending_move = true;
                         if debug {
                             scarlet_std::println!("[SWSPlatformWindow] ABS_Y: {}", input.value);
@@ -850,18 +942,35 @@ impl SWSPlatformWindow {
                 height,
             } => {
                 if surface_id == self.surface_id {
-                    self.push_event(Event::Resize { width, height });
+                    let logical_width = self.physical_to_logical_len(width);
+                    let logical_height = self.physical_to_logical_len(height);
+                    self.push_event(Event::Resize {
+                        width: logical_width,
+                        height: logical_height,
+                    });
                     if debug {
                         scarlet_std::println!(
-                            "[SWSPlatformWindow] SurfaceConfigure: {}x{}",
+                            "[SWSPlatformWindow] SurfaceConfigure: physical={}x{} logical={}x{}",
                             width,
-                            height
+                            height,
+                            logical_width,
+                            logical_height
                         );
                     }
                 }
             }
             SwsEvent::ScreenSizeChanged { width, height } => {
-                self.push_event(Event::ScreenSizeChanged { width, height });
+                self.push_event(Event::ScreenSizeChanged {
+                    width: self.physical_to_logical_len(width),
+                    height: self.physical_to_logical_len(height),
+                });
+            }
+            SwsEvent::OutputScaleChanged { scale_milli } => {
+                self.scale_milli = Self::sanitize_scale(scale_milli);
+                self.push_event(Event::Resize {
+                    width: self.current_size.width.max(1.0) as u32,
+                    height: self.current_size.height.max(1.0) as u32,
+                });
             }
             SwsEvent::SurfaceDestroyed { surface_id } => {
                 if surface_id == self.surface_id {

--- a/user/lib/scarlet-ui/src/views/button.rs
+++ b/user/lib/scarlet-ui/src/views/button.rs
@@ -276,9 +276,9 @@ impl ElementRenderObject for ButtonRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         self.size
@@ -306,10 +306,9 @@ impl ElementRenderObject for ButtonRenderObject {
         let border = self.current_border();
         let highlight = self.highlight_color(background);
         if let Some(ref mut buffer) = self.buffer {
-            let width = buffer.width();
-            let height = buffer.height();
-            let mut data = buffer.data_mut();
-            let mut canvas = graphics::Canvas::new(&mut data, width, height);
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let width = canvas.width();
+            let height = canvas.height();
 
             // Fill background
             canvas.fill_rect(0, 0, width, height, background);

--- a/user/lib/scarlet-ui/src/views/canvas.rs
+++ b/user/lib/scarlet-ui/src/views/canvas.rs
@@ -162,9 +162,9 @@ impl ElementRenderObject for CanvasRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         size

--- a/user/lib/scarlet-ui/src/views/divider.rs
+++ b/user/lib/scarlet-ui/src/views/divider.rs
@@ -158,9 +158,9 @@ impl ElementRenderObject for DividerRenderObject {
                 let needs_resize = self
                     .buffer
                     .as_ref()
-                    .map_or(true, |b| b.width() != w || b.height() != h);
+                    .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
                 if needs_resize {
-                    self.buffer = Some(Buffer::from_dimensions(w, h));
+                    self.buffer = Some(Buffer::from_logical_dimensions(w, h));
                 }
             }
             DividerOrientation::Vertical => {
@@ -181,9 +181,9 @@ impl ElementRenderObject for DividerRenderObject {
                 let needs_resize = self
                     .buffer
                     .as_ref()
-                    .map_or(true, |b| b.width() != w || b.height() != h);
+                    .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
                 if needs_resize {
-                    self.buffer = Some(Buffer::from_dimensions(w, h));
+                    self.buffer = Some(Buffer::from_logical_dimensions(w, h));
                 }
             }
         }
@@ -205,10 +205,9 @@ impl ElementRenderObject for DividerRenderObject {
 
     fn render(&mut self) {
         if let Some(ref mut buffer) = self.buffer {
-            let width = buffer.width();
-            let height = buffer.height();
-            let mut data = buffer.data_mut();
-            let mut canvas = graphics::Canvas::new(&mut data, width, height);
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let width = canvas.width();
+            let height = canvas.height();
 
             // Fill with the divider color
             canvas.fill_rect(0, 0, width, height, self.color);

--- a/user/lib/scarlet-ui/src/views/menu/menu.rs
+++ b/user/lib/scarlet-ui/src/views/menu/menu.rs
@@ -257,9 +257,9 @@ impl crate::element::ElementRenderObject for MenuRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         self.size
@@ -292,10 +292,9 @@ impl crate::element::ElementRenderObject for MenuRenderObject {
         let separator_color = Color::rgb(0.784, 0.784, 0.784);
 
         if let Some(ref mut buffer) = self.buffer {
-            let width = buffer.width();
-            let height = buffer.height();
-            let mut data = buffer.data_mut();
-            let mut canvas = graphics::Canvas::new(&mut data, width, height);
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let width = canvas.width();
+            let height = canvas.height();
 
             // Fill background
             canvas.fill_rect(0, 0, width, height, bg_color);

--- a/user/lib/scarlet-ui/src/views/menu/menu_item.rs
+++ b/user/lib/scarlet-ui/src/views/menu/menu_item.rs
@@ -243,9 +243,9 @@ impl ElementRenderObject for MenuItemRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         self.size
@@ -286,10 +286,9 @@ impl ElementRenderObject for MenuItemRenderObject {
         let text_color = palette.text_primary();
 
         if let Some(ref mut buffer) = self.buffer {
-            let width = buffer.width();
-            let height = buffer.height();
-            let mut data = buffer.data_mut();
-            let mut canvas = graphics::Canvas::new(&mut data, width, height);
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let width = canvas.width();
+            let height = canvas.height();
 
             // Clear to avoid blending text on top of previous frames.
             canvas.fill_rect(0, 0, width, height, Color::TRANSPARENT);

--- a/user/lib/scarlet-ui/src/views/navigation/render.rs
+++ b/user/lib/scarlet-ui/src/views/navigation/render.rs
@@ -237,10 +237,10 @@ impl ElementRenderObject for NavigationViewRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != sidebar_width_px || b.height() != sidebar_height_px);
+            .map_or(true, |b| b.logical_width() != sidebar_width_px || b.logical_height() != sidebar_height_px);
 
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(sidebar_width_px, sidebar_height_px));
+            self.buffer = Some(Buffer::from_logical_dimensions(sidebar_width_px, sidebar_height_px));
         }
 
         self.size
@@ -264,10 +264,9 @@ impl ElementRenderObject for NavigationViewRenderObject {
         }
 
         if let Some(ref mut buffer) = self.buffer {
-            let width = buffer.width();
-            let height = buffer.height();
-            let mut data = buffer.data_mut();
-            let mut canvas = graphics::Canvas::new(&mut data, width, height);
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let width = canvas.width();
+            let height = canvas.height();
 
             // Fill background (lighter, semi-transparent look)
             let palette = ColorPalette::default();

--- a/user/lib/scarlet-ui/src/views/progress.rs
+++ b/user/lib/scarlet-ui/src/views/progress.rs
@@ -99,13 +99,15 @@ impl ProgressViewRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         if let Some(ref mut buffer) = self.buffer {
-            let mut canvas = graphics::Canvas::new(buffer.data_mut(), w, h);
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let w = canvas.width();
+            let h = canvas.height();
 
             let palette = ColorPalette::default();
             let bg_color = palette.surface_variant();
@@ -142,9 +144,9 @@ impl ElementRenderObject for ProgressViewRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         self.size

--- a/user/lib/scarlet-ui/src/views/rectangle.rs
+++ b/user/lib/scarlet-ui/src/views/rectangle.rs
@@ -203,9 +203,9 @@ impl ElementRenderObject for RectangleRenderObject {
             let needs_resize = self
                 .buffer
                 .as_ref()
-                .map_or(true, |b| b.width() != w2 || b.height() != h2);
+                .map_or(true, |b| b.logical_width() != w2 || b.logical_height() != h2);
             if needs_resize {
-                self.buffer = Some(Buffer::from_dimensions(w2, h2));
+                self.buffer = Some(Buffer::from_logical_dimensions(w2, h2));
             }
             self.size = Size { width: constraints.min_width.max(1.0), height: constraints.min_height.max(1.0) };
             return self.size;
@@ -214,9 +214,9 @@ impl ElementRenderObject for RectangleRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         self.size
@@ -241,16 +241,15 @@ impl ElementRenderObject for RectangleRenderObject {
                 self.color, self.buffer.is_some());
         }
         if let Some(ref mut buffer) = self.buffer {
-            let width = buffer.width();
-            let height = buffer.height();
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let width = canvas.width();
+            let height = canvas.height();
             if crate::debug::is_enabled() {
                 scarlet_std::println!("[RectangleRenderObject] buffer {}x{}", width, height);
             }
-            let mut data = buffer.data_mut();
             if crate::debug::is_enabled() {
                 scarlet_std::println!("[RectangleRenderObject] creating canvas...");
             }
-            let mut canvas = graphics::Canvas::new(&mut data, width, height);
             if crate::debug::is_enabled() {
                 scarlet_std::println!("[RectangleRenderObject] filling rect...");
             }

--- a/user/lib/scarlet-ui/src/views/slider.rs
+++ b/user/lib/scarlet-ui/src/views/slider.rs
@@ -214,13 +214,15 @@ impl SliderRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         if let Some(ref mut buffer) = self.buffer {
-            let mut canvas = graphics::Canvas::new(buffer.data_mut(), w, h);
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let w = canvas.width();
+            let h = canvas.height();
             canvas.fill_rect(0, 0, w, h, Color::rgba(0.0, 0.0, 0.0, 0.0));
 
             let center_y = (height as f32 / 2.0) as i32;
@@ -296,9 +298,9 @@ impl ElementRenderObject for SliderRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         self.size

--- a/user/lib/scarlet-ui/src/views/text.rs
+++ b/user/lib/scarlet-ui/src/views/text.rs
@@ -153,9 +153,9 @@ impl ElementRenderObject for TextRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         self.size
@@ -184,16 +184,14 @@ impl ElementRenderObject for TextRenderObject {
     fn render(&mut self) {
         // Render text to buffer
         if let Some(ref mut buffer) = self.buffer {
-            let width = buffer.width();
-            let height = buffer.height();
+            let mut canvas = graphics::Canvas::for_buffer(buffer);
+            let width = canvas.width();
+            let height = canvas.height();
 
             if crate::debug::is_enabled() {
                 scarlet_std::println!("[TextRenderObject] render: buffer {}x{}, data.len()={}",
-                    width, height, buffer.data().len());
+                    width, height, width.saturating_mul(height).saturating_mul(4));
             }
-
-            let mut data = buffer.data_mut();
-            let mut canvas = graphics::Canvas::new(&mut data, width, height);
 
             // Clear to avoid blending text on top of previous frames.
             canvas.fill_rect(0, 0, width, height, Color::TRANSPARENT);

--- a/user/lib/scarlet-ui/src/views/text_grid.rs
+++ b/user/lib/scarlet-ui/src/views/text_grid.rs
@@ -733,9 +733,9 @@ impl ElementRenderObject for TextGridRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |buffer| buffer.width() != w || buffer.height() != h);
+            .map_or(true, |buffer| buffer.logical_width() != w || buffer.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
             self.full_repaint = true;
         }
 
@@ -755,11 +755,10 @@ impl ElementRenderObject for TextGridRenderObject {
             return;
         };
 
-        let width = buffer.width();
-        let height = buffer.height();
+        let width = buffer.logical_width();
+        let height = buffer.logical_height();
         {
-            let mut data = buffer.data_mut();
-            let mut canvas = graphics::Canvas::new(&mut data, width, height);
+            let mut canvas = graphics::Canvas::for_buffer(&mut buffer);
             if self.full_repaint {
                 canvas.fill_rect(0, 0, width, height, self.background_color);
                 let visible_columns = self.visible_columns(width);

--- a/user/lib/scarlet-ui/src/views/toggle.rs
+++ b/user/lib/scarlet-ui/src/views/toggle.rs
@@ -238,12 +238,15 @@ impl ToggleRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         if let Some(ref mut buffer) = self.buffer {
+            let physical_w = buffer.width();
+            let physical_h = buffer.height();
+            let ui_scale = (buffer.scale_milli() as f32) / 1000.0;
             let palette = ColorPalette::default();
             let bg_color = if self.is_on {
                 palette.green().base
@@ -256,15 +259,15 @@ impl ToggleRenderObject {
             let data = buffer.data_mut();
             data.fill(0);
 
-            let scale = 2u32;
-            let w_hi = w * scale;
-            let h_hi = h * scale;
+            let aa_scale = 2u32;
+            let w_hi = physical_w * aa_scale;
+            let h_hi = physical_h * aa_scale;
             let mut track_hi = alloc::vec![0u8; (w_hi * h_hi * 4) as usize];
             let mut canvas_hi = graphics::Canvas::new(&mut track_hi, w_hi, h_hi);
             let radius_hi = (h_hi / 2).max(1);
             Self::fill_rounded_rect(&mut canvas_hi, 0, 0, w_hi, h_hi, radius_hi, border_color);
 
-            let inset = scale;
+            let inset = aa_scale;
             let inner_w = w_hi.saturating_sub(inset * 2);
             let inner_h = h_hi.saturating_sub(inset * 2);
             if inner_w > 0 && inner_h > 0 {
@@ -280,8 +283,8 @@ impl ToggleRenderObject {
                 );
             }
 
-            let mut track = alloc::vec![0u8; (w * h * 4) as usize];
-            Self::downsample_2x(&track_hi, w_hi, h_hi, &mut track, w, h);
+            let mut track = alloc::vec![0u8; (physical_w * physical_h * 4) as usize];
+            Self::downsample_2x(&track_hi, w_hi, h_hi, &mut track, physical_w, physical_h);
             data.copy_from_slice(&track);
 
             // Thumb position: on = right side, off = left side
@@ -291,9 +294,9 @@ impl ToggleRenderObject {
             } else {
                 0.0
             };
-            let thumb_x = ((thumb_offset + 2.0) * scale as f32) as i32;
-            let thumb_y = (2.0 * scale as f32) as i32;
-            let thumb_size = libm::ceilf(thumb_diameter * scale as f32) as i32;
+            let thumb_x = ((thumb_offset + 2.0) * ui_scale * aa_scale as f32) as i32;
+            let thumb_y = (2.0 * ui_scale * aa_scale as f32) as i32;
+            let thumb_size = libm::ceilf(thumb_diameter * ui_scale * aa_scale as f32) as i32;
             let radius = (thumb_size / 2).max(1);
             let center_x = thumb_x + radius;
             let center_y = thumb_y + radius;
@@ -301,16 +304,16 @@ impl ToggleRenderObject {
             let mut thumb_canvas = graphics::Canvas::new(&mut thumb_hi, w_hi, h_hi);
             Self::fill_circle(&mut thumb_canvas, center_x, center_y, radius, thumb_color);
 
-            let mut thumb = alloc::vec![0u8; (w * h * 4) as usize];
+            let mut thumb = alloc::vec![0u8; (physical_w * physical_h * 4) as usize];
             Self::downsample_2x(
                 &thumb_hi,
                 w_hi,
                 h_hi,
                 &mut thumb,
-                w,
-                h,
+                physical_w,
+                physical_h,
             );
-            Self::blend_bgra_over(data, &thumb, w, h);
+            Self::blend_bgra_over(data, &thumb, physical_w, physical_h);
         }
     }
 }
@@ -329,9 +332,9 @@ impl ElementRenderObject for ToggleRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         self.size

--- a/user/lib/scarlet-ui/src/views/window.rs
+++ b/user/lib/scarlet-ui/src/views/window.rs
@@ -860,17 +860,19 @@ impl WindowRenderObject {
         let needs_resize = self
             .buffer
             .as_ref()
-            .map_or(true, |b| b.width() != w || b.height() != h);
+            .map_or(true, |b| b.logical_width() != w || b.logical_height() != h);
         if needs_resize {
             if crate::debug::is_enabled() {
                 scarlet_std::println!("[WindowRenderObject] Creating buffer: {}x{}", width, height);
             }
-            self.buffer = Some(Buffer::from_dimensions(w, h));
+            self.buffer = Some(Buffer::from_logical_dimensions(w, h));
         }
 
         if let Some(ref mut buffer) = self.buffer {
             use crate::graphics::Canvas;
-            let mut canvas = Canvas::new(buffer.data_mut(), w, h);
+            let mut canvas = Canvas::for_buffer(buffer);
+            let w = canvas.width();
+            let h = canvas.height();
 
             // Fill background with specified color (or skip if None for transparent)
             if let Some(bg_color) = self.background_color {
@@ -883,8 +885,8 @@ impl WindowRenderObject {
                     &title,
                     focused,
                     &mut canvas,
-                    width as u32,
-                    height as u32,
+                    w,
+                    h,
                     close_state,
                     maximize_state,
                     minimize_state,
@@ -921,11 +923,16 @@ impl WindowRenderObject {
         };
 
         for child_buffer in child_buffers {
+            let scale_milli = buffer.scale_milli();
+            let physical_x =
+                ((border_offset as i64).saturating_mul(scale_milli as i64) / 1000) as i32;
+            let physical_y =
+                ((titlebar_height as i64).saturating_mul(scale_milli as i64) / 1000) as i32;
             // Composite child inside border, below titlebar
             buffer.composite(
                 child_buffer,
-                border_offset,
-                titlebar_height,
+                physical_x,
+                physical_y,
                 1.0, // Full opacity
             );
         }

--- a/user/lib/slint-scarlet/src/event_loop.rs
+++ b/user/lib/slint-scarlet/src/event_loop.rs
@@ -180,6 +180,9 @@ impl EventLoop {
             SwsEvent::ScreenSizeChanged { .. } => {
                 // SurfaceConfigure carries the per-window resize request.
             }
+            SwsEvent::OutputScaleChanged { .. } => {
+                // slint-scarlet keeps its existing physical-size behavior for now.
+            }
             SwsEvent::MenuItemActivated { .. } => {
                 // Menu item activated - not used in slint apps
             }

--- a/user/lib/sws-client/src/connection.rs
+++ b/user/lib/sws-client/src/connection.rs
@@ -935,6 +935,10 @@ impl Connection {
                     self.pending_events
                         .push(Event::ScreenSizeChanged { width, height });
                 }
+                ServerMessage::OutputScaleChanged { scale_milli } => {
+                    self.pending_events
+                        .push(Event::OutputScaleChanged { scale_milli });
+                }
                 ServerMessage::WindowConfigure {
                     window_id,
                     width,
@@ -1045,6 +1049,11 @@ impl Connection {
                             ServerMessage::ScreenSizeChanged { width, height } => {
                                 self.pending_events
                                     .push(Event::ScreenSizeChanged { width, height });
+                                count += 1;
+                            }
+                            ServerMessage::OutputScaleChanged { scale_milli } => {
+                                self.pending_events
+                                    .push(Event::OutputScaleChanged { scale_milli });
                                 count += 1;
                             }
                             ServerMessage::Error { code } => {
@@ -1178,6 +1187,128 @@ impl Connection {
         }
     }
 
+    fn queue_async_message(&mut self, message: ServerMessage) -> bool {
+        match message {
+            ServerMessage::InputEvent {
+                window_id,
+                time,
+                type_,
+                code,
+                value,
+            } => {
+                self.pending_events.push(Event::Input(InputEvent {
+                    surface_id: window_id,
+                    time,
+                    type_,
+                    code,
+                    value,
+                }));
+                true
+            }
+            ServerMessage::WindowDestroyed { window_id } => {
+                self.surfaces.remove(&window_id);
+                self.pending_events.push(Event::SurfaceDestroyed {
+                    surface_id: window_id,
+                });
+                true
+            }
+            ServerMessage::WindowResized { .. } => true,
+            ServerMessage::WindowConfigure {
+                window_id,
+                width,
+                height,
+            } => {
+                self.pending_events.push(Event::SurfaceConfigure {
+                    surface_id: window_id,
+                    width,
+                    height,
+                });
+                true
+            }
+            ServerMessage::ScreenSizeChanged { width, height } => {
+                self.pending_events
+                    .push(Event::ScreenSizeChanged { width, height });
+                true
+            }
+            ServerMessage::OutputScaleChanged { scale_milli } => {
+                self.pending_events
+                    .push(Event::OutputScaleChanged { scale_milli });
+                true
+            }
+            ServerMessage::Error { code } => {
+                self.pending_events.push(Event::Error { code });
+                true
+            }
+            ServerMessage::FocusChanged {
+                window_id,
+                app_id,
+                app_id_len,
+                app_name,
+                app_name_len,
+                title,
+                title_len,
+                menu_titles,
+                menu_titles_len,
+            } => {
+                let app_id = String::from_utf8_lossy(&app_id[..app_id_len as usize]).into_owned();
+                let app_name =
+                    String::from_utf8_lossy(&app_name[..app_name_len as usize]).into_owned();
+                let title = String::from_utf8_lossy(&title[..title_len as usize]).into_owned();
+                let menu_titles =
+                    String::from_utf8_lossy(&menu_titles[..menu_titles_len as usize]).into_owned();
+                self.pending_events.push(Event::FocusChanged {
+                    window_id,
+                    app_id,
+                    app_name,
+                    title,
+                    menu_titles,
+                });
+                true
+            }
+            ServerMessage::ActiveAppChanged {
+                window_id,
+                app_id,
+                app_id_len,
+                app_name,
+                app_name_len,
+                title,
+                title_len,
+                menu_titles,
+                menu_titles_len,
+            } => {
+                let app_id = String::from_utf8_lossy(&app_id[..app_id_len as usize]).into_owned();
+                let app_name =
+                    String::from_utf8_lossy(&app_name[..app_name_len as usize]).into_owned();
+                let title = String::from_utf8_lossy(&title[..title_len as usize]).into_owned();
+                let menu_titles =
+                    String::from_utf8_lossy(&menu_titles[..menu_titles_len as usize]).into_owned();
+                self.pending_events.push(Event::ActiveAppChanged {
+                    window_id,
+                    app_id,
+                    app_name,
+                    title,
+                    menu_titles,
+                });
+                true
+            }
+            ServerMessage::MenuItemActivated {
+                window_id,
+                menu_item_id,
+                menu_item_id_len,
+            } => {
+                let menu_item_id =
+                    String::from_utf8_lossy(&menu_item_id[..menu_item_id_len as usize])
+                        .into_owned();
+                self.pending_events.push(Event::MenuItemActivated {
+                    window_id,
+                    menu_item_id,
+                });
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Get the screen size.
     ///
     /// This is a synchronous request: it blocks until the server responds with SCREEN_SIZE.
@@ -1203,12 +1334,40 @@ impl Connection {
                     let _ = self.socket.set_nonblocking(true);
                     return Ok((width, height));
                 }
-                ServerMessage::ScreenSizeChanged { width, height } => {
-                    self.pending_events
-                        .push(Event::ScreenSizeChanged { width, height });
-                }
+                message if self.queue_async_message(message) => {}
                 _ => {
                     // Restore non-blocking mode
+                    let _ = self.socket.set_nonblocking(true);
+                    return Err(Error::InvalidResponse);
+                }
+            }
+        }
+    }
+
+    /// Get the output scale in milli-units.
+    ///
+    /// This is a synchronous request: it blocks until the server responds with OUTPUT_SCALE.
+    pub fn get_output_scale(&mut self) -> Result<u32, Error> {
+        write_frame(&mut self.socket, protocol::client_msg::GET_OUTPUT_SCALE, &[])
+            .map_err(|_| Error::SendFailed)?;
+
+        self.socket
+            .set_nonblocking(false)
+            .map_err(|_| Error::SocketConfig)?;
+
+        loop {
+            let msg_type = read_frame_into(&mut self.socket, &mut self.read_payload)
+                .map_err(|_| Error::ReceiveFailed)?;
+            let response = protocol::parse_server_message(msg_type, &self.read_payload)
+                .map_err(|_| Error::InvalidResponse)?;
+
+            match response {
+                ServerMessage::OutputScale { scale_milli } => {
+                    let _ = self.socket.set_nonblocking(true);
+                    return Ok(scale_milli.max(1));
+                }
+                message if self.queue_async_message(message) => {}
+                _ => {
                     let _ = self.socket.set_nonblocking(true);
                     return Err(Error::InvalidResponse);
                 }

--- a/user/lib/sws-client/src/event.rs
+++ b/user/lib/sws-client/src/event.rs
@@ -31,6 +31,8 @@ pub enum Event {
     },
     /// Display size changed.
     ScreenSizeChanged { width: u32, height: u32 },
+    /// Output scale changed.
+    OutputScaleChanged { scale_milli: u32 },
     /// Window was destroyed by server
     SurfaceDestroyed { surface_id: u32 },
     /// Focus changed to a different window

--- a/user/lib/sws_protocol/src/lib.rs
+++ b/user/lib/sws_protocol/src/lib.rs
@@ -61,6 +61,7 @@ pub mod client_msg {
     pub const SET_WINDOW_HAS_ALPHA_CONTENT: u32 = 28; // Set whether window content has alpha channel
     pub const SET_WINDOW_MENU_TITLES: u32 = 29; // Update menu titles for a window
     pub const ACTIVATE_MENU_ITEM: u32 = 30; // Request menu item activation for a window
+    pub const GET_OUTPUT_SCALE: u32 = 31; // Get output scale in milli-units (1000 = 1.0)
 }
 
 /// Message type IDs (server -> client).
@@ -84,6 +85,8 @@ pub mod server_msg {
     pub const MENU_ITEM_ACTIVATED: u32 = 20; // Menu item activation for a window
     pub const ACTIVE_APP_CHANGED: u32 = 21; // Broadcast when active application changes (normal windows only)
     pub const SCREEN_SIZE_CHANGED: u32 = 22; // Broadcast when the display size changes
+    pub const OUTPUT_SCALE: u32 = 23; // Response to GET_OUTPUT_SCALE
+    pub const OUTPUT_SCALE_CHANGED: u32 = 24; // Broadcast when output scale changes
 }
 
 /// Flags for transient (parent/child) window behavior.
@@ -320,6 +323,11 @@ pub enum ClientMessageRef<'a> {
     /// Get the screen size
     GetScreenSize {},
 
+    /// Get the output scale in milli-units.
+    ///
+    /// `1000` means 1.0, `2000` means 2.0.
+    GetOutputScale {},
+
     /// Get list of all windows
     GetWindowList {},
 
@@ -402,6 +410,18 @@ pub enum ServerMessage {
     ScreenSizeChanged {
         width: u32,
         height: u32,
+    },
+    /// Response to GET_OUTPUT_SCALE request.
+    ///
+    /// Scale is encoded in milli-units: `1000` means 1.0, `2000` means 2.0.
+    OutputScale {
+        scale_milli: u32,
+    },
+    /// Output scale changed asynchronously.
+    ///
+    /// Scale is encoded in milli-units: `1000` means 1.0, `2000` means 2.0.
+    OutputScaleChanged {
+        scale_milli: u32,
     },
     /// Response to GET_WINDOW_LIST request
     /// Contains a serialized list of windows
@@ -851,6 +871,12 @@ pub fn parse_client_message<'a>(
             }
             Ok(ClientMessageRef::GetScreenSize {})
         }
+        client_msg::GET_OUTPUT_SCALE => {
+            if !payload.is_empty() {
+                return Err(ProtocolError::MalformedPayload);
+            }
+            Ok(ClientMessageRef::GetOutputScale {})
+        }
         client_msg::GET_WINDOW_LIST => {
             if !payload.is_empty() {
                 return Err(ProtocolError::MalformedPayload);
@@ -1047,6 +1073,20 @@ pub fn parse_server_message(msg_type: u32, payload: &[u8]) -> Result<ServerMessa
             let width = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
             let height = u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
             Ok(ServerMessage::ScreenSizeChanged { width, height })
+        }
+        server_msg::OUTPUT_SCALE => {
+            if payload.len() != 4 {
+                return Err(ProtocolError::MalformedPayload);
+            }
+            let scale_milli = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+            Ok(ServerMessage::OutputScale { scale_milli })
+        }
+        server_msg::OUTPUT_SCALE_CHANGED => {
+            if payload.len() != 4 {
+                return Err(ProtocolError::MalformedPayload);
+            }
+            let scale_milli = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+            Ok(ServerMessage::OutputScaleChanged { scale_milli })
         }
         server_msg::WINDOW_LIST => {
             // Window list payload is variable length, just validate it's not empty
@@ -1774,6 +1814,13 @@ pub fn payload_screen_size(width: u32, height: u32) -> [u8; 8] {
     payload[0..4].copy_from_slice(&width.to_le_bytes());
     payload[4..8].copy_from_slice(&height.to_le_bytes());
     payload
+}
+
+/// Build payload for server->client `OUTPUT_SCALE`.
+///
+/// Scale is encoded in milli-units: `1000` means 1.0, `2000` means 2.0.
+pub fn payload_output_scale(scale_milli: u32) -> [u8; 4] {
+    scale_milli.to_le_bytes()
 }
 
 /// Window list entry for WINDOW_LIST message


### PR DESCRIPTION
This pull request introduces comprehensive support for display scaling throughout the desktop environment, including both the compositor and user interface components. The changes ensure that UI elements, pointer events, and work areas are correctly scaled according to a configurable output scale factor, and provide a user-facing option to adjust this scaling in the settings application. Additionally, the compositor now reads its configuration from a TOML file, enabling persistent scaling settings.

**Display scaling support and configuration:**

* Added utility functions (`scale_u32`, `scale_i32`, `unscale_u32`, `unscale_i32`, etc.) to handle scaling and unscaling of UI dimensions and pointer coordinates based on a `scale_milli` factor. Updated all relevant code paths in `scarlet_ui.rs` to apply these scaling functions when creating windows, handling pointer events, and managing work areas. (`user/bin/src/scarlet_desktop/taskbar/scarlet_ui.rs`) [[1]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L40-R85) [[2]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L666-R725) [[3]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L720-R773) [[4]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L762-R819) [[5]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L780-R837) [[6]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L845-R899) [[7]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L858-R909) [[8]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L880-R940) [[9]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07L985-R1054)
* The compositor now loads the output scale from `/etc/sws/config.toml`, parsing either a `scale` or `scale_milli` value in the `[output]` section, with robust TOML parsing and defaulting to a safe value if not present. (`user/bin/src/sws/compositor.rs`)

**User configuration and settings UI:**

* Added a "Display" page to the settings application, allowing users to select between 1.0x and 2.0x scaling. This writes the chosen scale to `/etc/sws/config.toml`, ensuring settings persist across reboots. (`user/bin/src/settings.rs`) [[1]](diffhunk://#diff-bcb5b41c7304df248855625011ec28c986ad8d9195ce8bf43cfd410a44f94aefR32-R33) [[2]](diffhunk://#diff-bcb5b41c7304df248855625011ec28c986ad8d9195ce8bf43cfd410a44f94aefR70-R91) [[3]](diffhunk://#diff-bcb5b41c7304df248855625011ec28c986ad8d9195ce8bf43cfd410a44f94aefR482-R503) [[4]](diffhunk://#diff-bcb5b41c7304df248855625011ec28c986ad8d9195ce8bf43cfd410a44f94aefR573)

**Popup menu and rendering improvements:**

* Updated `PopupMenuRenderer` and related popup menu code to respect the current scaling factor, ensuring menus are rendered at the correct size and position on high-DPI displays. (`user/bin/src/scarlet_desktop/taskbar/scarlet_ui.rs`) [[1]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07R532-R537) [[2]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07R550) [[3]](diffhunk://#diff-59a76a71e501af279479d4053291dd57eeb62760a9c48d4d7a2dda9af8e3fe07R575)

**Bug fixes and code quality:**

* Fixed work area calculation to account for scaling, preventing UI elements from overlapping or being misaligned when scaling is active. (`user/bin/src/scarlet_desktop/taskbar/scarlet_ui.rs`)

**Miscellaneous:**

* Added necessary imports and utility code for file I/O and string handling in the compositor to support configuration file reading. (`user/bin/src/sws/compositor.rs`)

These changes collectively enable high-DPI support and user-configurable scaling across the desktop environment.- Updated buffer resizing logic in various UI components (Button, Canvas, Divider, Menu, MenuItem, NavigationView, ProgressView, Rectangle, Slider, Text, TextGrid, Toggle, Window) to use logical dimensions instead of physical dimensions.
- Changed canvas creation to utilize a new method for better abstraction and clarity.
- Introduced handling for output scale changes in the event loop and connection handling for the SWS client.
- Added support for output scale retrieval and broadcasting in the SWS protocol.