### PR TITLE
Refactor display buffer update & sws

### DIFF
--- a/docs/display_present.md
+++ b/docs/display_present.md
@@ -1,0 +1,44 @@
+# Display Present Paths
+
+Scarlet uses two CPU-composited display presentation paths.
+
+## Display Surface Path
+
+Display-system clients open `/dev/display0` through `DisplaySurface`, not the
+legacy framebuffer node. Clients that track damage in screen coordinates call
+`DisplaySurface::present_region` for each bounded damage rectangle after CPU
+composition into the display backing store.
+
+That call maps to `DISPLAY_PRESENT_REGION`, and the kernel forwards the region
+to the graphics device as
+`present_current_framebuffer_region(region)`. For virtio-gpu this becomes:
+
+```text
+TRANSFER_TO_HOST_2D(region)
+RESOURCE_FLUSH(region)
+```
+
+The virtio-gpu driver is passive in this path. It does not schedule a periodic
+full-screen flush; it only transfers and flushes regions requested by the
+display stack.
+
+## Legacy /dev/fb0 Path
+
+`/dev/fb0` is a legacy compatibility alias for the display backing store. It is
+not the primary display API and does not own a separate scanout buffer.
+
+The mmap path keeps the VM mapping writable at the object level, but installs
+read-only PTEs for non-store faults and after every compatibility present. A
+store fault marks the framebuffer dirty, temporarily installs a writable PTE for
+that page, and arms a 16 ms one-shot timer. When the timer expires, the compat
+path performs a full-frame present, clears the dirty flag, and write-protects the
+tracked framebuffer mappings again.
+
+`write_at` follows the same compatibility model: it writes into the display
+backing store, marks the legacy framebuffer dirty, and lets the one-shot timer
+perform the full-frame present. `FBIO_FLUSH` remains the explicit synchronization
+command for legacy programs; it performs an immediate full-frame present and
+write-protects the tracked mappings.
+
+Region presents intentionally belong to `/dev/displayX`, not the framebuffer
+compatibility node.

--- a/docs/display_present.md
+++ b/docs/display_present.md
@@ -9,6 +9,11 @@ legacy framebuffer node. Clients that track damage in screen coordinates call
 `DisplaySurface::present_region` for each bounded damage rectangle after CPU
 composition into the display backing store.
 
+`DISPLAY_GET_INFO` reports both `buffer_len` and a `backing_id`. Display
+clients reuse an mmap only while both values match. This matters for resize and
+mode-change paths where the graphics device may allocate a new backing store
+whose page-aligned size is identical to the previous one.
+
 That call maps to `DISPLAY_PRESENT_REGION`, and the kernel forwards the region
 to the graphics device as
 `present_current_framebuffer_region(region)`. For virtio-gpu this becomes:

--- a/kernel/src/device/graphics/display_device.rs
+++ b/kernel/src/device/graphics/display_device.rs
@@ -1,0 +1,493 @@
+//! Modern display character device.
+//!
+//! This endpoint represents a scanout/display surface for display-system
+//! clients that explicitly present damage regions. Legacy framebuffer
+//! compatibility remains available through `/dev/fbX`.
+
+extern crate alloc;
+
+use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use core::any::Any;
+use spin::RwLock;
+
+use super::{FramebufferConfig, PixelFormat, manager::FramebufferResource, output::DisplayRegion};
+use crate::device::{Device, DeviceType, char::CharDevice, manager::DeviceManager};
+use crate::object::capability::selectable::{ReadyInterest, SelectWaitOutcome, Selectable};
+use crate::object::capability::{ControlOps, MemoryMappingOps};
+use crate::vm::addr::phys_to_virt;
+
+/// Display character device control commands.
+///
+/// These are Scarlet display controls, not Linux framebuffer compatibility
+/// ioctls. `/dev/fbX` owns the `FBIO_*` namespace.
+pub mod display_commands {
+    /// Get display surface information.
+    pub const DISPLAY_GET_INFO: u32 = 0x5000;
+    /// Present the whole display surface.
+    pub const DISPLAY_PRESENT: u32 = 0x5001;
+    /// Present a display surface region.
+    pub const DISPLAY_PRESENT_REGION: u32 = 0x5002;
+}
+
+/// 32-bit RGBA pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_RGBA8888: u32 = 1;
+/// 32-bit BGRA pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_BGRA8888: u32 = 2;
+/// 32-bit XRGB pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_XRGB8888: u32 = 3;
+/// 32-bit XBGR pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_XBGR8888: u32 = 4;
+/// 32-bit XRGB2101010 pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_XRGB2101010: u32 = 5;
+/// 24-bit RGB pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_RGB888: u32 = 6;
+/// 16-bit RGB565 pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_RGB565: u32 = 7;
+/// 16-bit ARGB1555 pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_ARGB1555: u32 = 8;
+/// 16-bit XRGB1555 pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_XRGB1555: u32 = 9;
+
+/// Display surface information.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DisplayInfo {
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+    /// Bytes per row.
+    pub stride: u32,
+    /// Pixel format, one of `DISPLAY_PIXEL_FORMAT_*`.
+    pub format: u32,
+    /// Page-aligned size of the mappable display backing store.
+    pub buffer_len: u32,
+}
+
+/// Region argument for DISPLAY_PRESENT_REGION.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DisplayPresentRegion {
+    /// Left edge in pixels.
+    pub x: u32,
+    /// Top edge in pixels.
+    pub y: u32,
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+}
+
+#[derive(Debug, Clone)]
+struct DisplayBackingInfo {
+    config: FramebufferConfig,
+    physical_addr: usize,
+    size: usize,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+struct DisplayMapping {
+    vaddr: usize,
+    length: usize,
+}
+
+/// Modern display device backed by a graphics scanout resource.
+///
+/// The device deliberately has a separate `/dev/displayX` namespace from
+/// `/dev/fbX`, even though the current CPU-composited backing store is still a
+/// mappable framebuffer. Presentation is expected to happen through explicit
+/// display controls rather than framebuffer compatibility ioctls.
+pub struct DisplayCharDevice {
+    /// The graphics resource this display surface presents.
+    fb_resource: Arc<FramebufferResource>,
+    /// Track mappings for testing and diagnostics.
+    mappings: RwLock<BTreeMap<usize, DisplayMapping>>,
+    #[cfg(test)]
+    device_manager_addr: Option<usize>,
+}
+
+impl DisplayCharDevice {
+    /// Create a new display character device.
+    ///
+    /// # Arguments
+    ///
+    /// * `fb_resource` - The graphics resource backing this display surface.
+    ///
+    /// # Returns
+    ///
+    /// A new DisplayCharDevice instance.
+    pub fn new(fb_resource: Arc<FramebufferResource>) -> Self {
+        Self {
+            fb_resource,
+            mappings: RwLock::new(BTreeMap::new()),
+            #[cfg(test)]
+            device_manager_addr: None,
+        }
+    }
+
+    /// Create a new display character device with an explicit DeviceManager.
+    ///
+    /// # Arguments
+    ///
+    /// * `fb_resource` - The graphics resource backing this display surface.
+    /// * `device_manager` - Device manager used for tests.
+    ///
+    /// # Returns
+    ///
+    /// A new DisplayCharDevice instance.
+    #[cfg(test)]
+    pub fn new_with_device_manager(
+        fb_resource: Arc<FramebufferResource>,
+        device_manager: &DeviceManager,
+    ) -> Self {
+        Self {
+            fb_resource,
+            mappings: RwLock::new(BTreeMap::new()),
+            device_manager_addr: Some(device_manager as *const DeviceManager as usize),
+        }
+    }
+
+    #[cfg(test)]
+    fn device_manager(&self) -> &DeviceManager {
+        match self.device_manager_addr {
+            Some(device_manager_addr) => unsafe { &*(device_manager_addr as *const DeviceManager) },
+            None => DeviceManager::get_manager(),
+        }
+    }
+
+    #[cfg(not(test))]
+    fn device_manager(&self) -> &DeviceManager {
+        DeviceManager::get_manager()
+    }
+
+    fn page_aligned_size(size: usize) -> usize {
+        (size + crate::environment::PAGE_SIZE - 1) & !(crate::environment::PAGE_SIZE - 1)
+    }
+
+    fn current_backing_info(&self) -> Result<DisplayBackingInfo, &'static str> {
+        if let Some(device) = self
+            .device_manager()
+            .get_device(self.fb_resource.source_device_id)
+        {
+            if let Some(graphics_device) = device.as_graphics_device() {
+                let (config, physical_addr) = graphics_device.get_framebuffer_info()?;
+                let size = Self::page_aligned_size(config.size());
+                return Ok(DisplayBackingInfo {
+                    config,
+                    physical_addr,
+                    size,
+                });
+            }
+        }
+
+        Ok(DisplayBackingInfo {
+            config: self.fb_resource.config.clone(),
+            physical_addr: self.fb_resource.physical_addr,
+            size: self.fb_resource.size,
+        })
+    }
+
+    fn display_format(format: PixelFormat) -> u32 {
+        match format {
+            PixelFormat::RGBA8888 => DISPLAY_PIXEL_FORMAT_RGBA8888,
+            PixelFormat::BGRA8888 => DISPLAY_PIXEL_FORMAT_BGRA8888,
+            PixelFormat::XRGB8888 => DISPLAY_PIXEL_FORMAT_XRGB8888,
+            PixelFormat::XBGR8888 => DISPLAY_PIXEL_FORMAT_XBGR8888,
+            PixelFormat::XRGB2101010 => DISPLAY_PIXEL_FORMAT_XRGB2101010,
+            PixelFormat::RGB888 => DISPLAY_PIXEL_FORMAT_RGB888,
+            PixelFormat::RGB565 => DISPLAY_PIXEL_FORMAT_RGB565,
+            PixelFormat::ARGB1555 => DISPLAY_PIXEL_FORMAT_ARGB1555,
+            PixelFormat::XRGB1555 => DISPLAY_PIXEL_FORMAT_XRGB1555,
+        }
+    }
+
+    fn current_display_info(&self) -> Result<DisplayInfo, &'static str> {
+        let backing = self.current_backing_info()?;
+        Ok(DisplayInfo {
+            width: backing.config.width,
+            height: backing.config.height,
+            stride: backing.config.stride,
+            format: Self::display_format(backing.config.format),
+            buffer_len: backing.size as u32,
+        })
+    }
+
+    fn translated_ptr(arg: usize) -> Result<usize, &'static str> {
+        if arg == 0 {
+            return Err("Invalid argument pointer");
+        }
+
+        if let Some(current_task) = crate::task::mytask() {
+            current_task
+                .vm_manager
+                .translate_to_kva(arg)
+                .ok_or("Invalid user pointer - not mapped")
+        } else {
+            Ok(arg)
+        }
+    }
+
+    fn handle_get_info(&self, arg: usize) -> Result<i32, &'static str> {
+        let target_ptr = Self::translated_ptr(arg)?;
+        let info = self.current_display_info()?;
+
+        // SAFETY: target_ptr is either a translated user pointer or a kernel
+        // pointer supplied by in-kernel tests.
+        unsafe {
+            core::ptr::write(target_ptr as *mut DisplayInfo, info);
+        }
+
+        Ok(0)
+    }
+
+    fn handle_present(&self) -> Result<i32, &'static str> {
+        let backing = self.current_backing_info()?;
+        if backing.physical_addr == 0 {
+            return Err("Invalid display backing address");
+        }
+
+        self.present_region(DisplayRegion::full(&backing.config))?;
+        Ok(0)
+    }
+
+    fn handle_present_region(&self, arg: usize) -> Result<i32, &'static str> {
+        let target_ptr = Self::translated_ptr(arg)?;
+
+        // SAFETY: target_ptr is either a translated user pointer or a kernel
+        // pointer supplied by in-kernel tests.
+        let region = unsafe { core::ptr::read(target_ptr as *const DisplayPresentRegion) };
+
+        self.present_region(DisplayRegion::new(
+            region.x,
+            region.y,
+            region.width,
+            region.height,
+        ))?;
+        Ok(0)
+    }
+
+    fn present_region(&self, region: DisplayRegion) -> Result<(), &'static str> {
+        let device = self
+            .device_manager()
+            .get_device(self.fb_resource.source_device_id)
+            .ok_or("Display source device not found")?;
+        let graphics_device = device
+            .as_graphics_device()
+            .ok_or("Display source device is not graphics-capable")?;
+        let (config, physical_addr) = graphics_device.get_framebuffer_info()?;
+        if physical_addr == 0 {
+            return Err("Invalid display backing address");
+        }
+
+        let region = DisplayRegion::new(
+            region.x.min(config.width),
+            region.y.min(config.height),
+            region.width.min(config.width.saturating_sub(region.x)),
+            region.height.min(config.height.saturating_sub(region.y)),
+        );
+        graphics_device.present_current_framebuffer_region(region)
+    }
+}
+
+impl Device for DisplayCharDevice {
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Char
+    }
+
+    fn name(&self) -> &'static str {
+        "display"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn as_char_device(&self) -> Option<&dyn CharDevice> {
+        Some(self)
+    }
+}
+
+impl CharDevice for DisplayCharDevice {
+    fn read_byte(&self) -> Option<u8> {
+        None
+    }
+
+    fn write_byte(&self, _byte: u8) -> Result<(), &'static str> {
+        Err("write_byte is not supported - use write_at through DevFileObject instead")
+    }
+
+    fn write(&self, _buffer: &[u8]) -> Result<usize, &'static str> {
+        Err("write is not supported - use write_at through DevFileObject instead")
+    }
+
+    fn can_read(&self) -> bool {
+        match self.current_backing_info() {
+            Ok(info) => info.physical_addr != 0 && info.size > 0,
+            Err(_) => false,
+        }
+    }
+
+    fn can_write(&self) -> bool {
+        match self.current_backing_info() {
+            Ok(info) => info.physical_addr != 0 && info.size > 0,
+            Err(_) => false,
+        }
+    }
+
+    fn read_at(&self, position: u64, buffer: &mut [u8]) -> Result<usize, &'static str> {
+        let info = self.current_backing_info()?;
+        if info.physical_addr == 0 {
+            return Err("Invalid display backing address");
+        }
+
+        let logical_size = info.config.size();
+        let start_pos = position as usize;
+        if start_pos >= logical_size {
+            return Ok(0);
+        }
+
+        let to_read = buffer.len().min(logical_size - start_pos);
+        unsafe {
+            let src_ptr = (phys_to_virt(info.physical_addr) as *const u8).add(start_pos);
+            for i in 0..to_read {
+                buffer[i] = core::ptr::read_volatile(src_ptr.add(i));
+            }
+        }
+
+        Ok(to_read)
+    }
+
+    fn write_at(&self, position: u64, buffer: &[u8]) -> Result<usize, &'static str> {
+        let info = self.current_backing_info()?;
+        if info.physical_addr == 0 {
+            return Err("Invalid display backing address");
+        }
+
+        let logical_size = info.config.size();
+        let start_pos = position as usize;
+        if start_pos >= logical_size {
+            return Err("Position beyond display backing size");
+        }
+
+        let to_write = buffer.len().min(logical_size - start_pos);
+        unsafe {
+            let dst_ptr = (phys_to_virt(info.physical_addr) as *mut u8).add(start_pos);
+            for i in 0..to_write {
+                core::ptr::write_volatile(dst_ptr.add(i), buffer[i]);
+            }
+        }
+
+        Ok(to_write)
+    }
+
+    fn can_seek(&self) -> bool {
+        true
+    }
+}
+
+impl ControlOps for DisplayCharDevice {
+    fn control(&self, command: u32, arg: usize) -> Result<i32, &'static str> {
+        use display_commands::*;
+
+        match command {
+            DISPLAY_GET_INFO => self.handle_get_info(arg),
+            DISPLAY_PRESENT => self.handle_present(),
+            DISPLAY_PRESENT_REGION => self.handle_present_region(arg),
+            _ => Err("Unsupported display control command"),
+        }
+    }
+
+    fn supported_control_commands(&self) -> Vec<(u32, &'static str)> {
+        use display_commands::*;
+        vec![
+            (DISPLAY_GET_INFO, "Get display surface information"),
+            (DISPLAY_PRESENT, "Present whole display surface"),
+            (DISPLAY_PRESENT_REGION, "Present display surface region"),
+        ]
+    }
+}
+
+impl MemoryMappingOps for DisplayCharDevice {
+    fn get_mapping_info(
+        &self,
+        offset: usize,
+        length: usize,
+    ) -> Result<(usize, usize, bool), &'static str> {
+        let info = self.current_backing_info()?;
+
+        if offset % crate::environment::PAGE_SIZE != 0 {
+            return Err("Display mmap offset must be page-aligned");
+        }
+        if length % crate::environment::PAGE_SIZE != 0 {
+            return Err("Display mmap length must be page-aligned");
+        }
+        if info.physical_addr == 0 || info.size == 0 {
+            return Err("Invalid display backing configuration");
+        }
+        if info.physical_addr % crate::environment::PAGE_SIZE != 0 {
+            return Err("Display backing physical address must be page-aligned");
+        }
+        if offset >= info.size {
+            return Err("Offset exceeds display backing size");
+        }
+
+        let available_size = info.size - offset;
+        if length > available_size {
+            return Err("Requested length exceeds available display backing size");
+        }
+
+        Ok((info.physical_addr + offset, 0x3, true))
+    }
+
+    fn on_mapped(&self, vaddr: usize, _paddr: usize, length: usize, _offset: usize) {
+        self.mappings
+            .write()
+            .insert(vaddr, DisplayMapping { vaddr, length });
+    }
+
+    fn on_unmapped(&self, vaddr: usize, _length: usize) {
+        self.mappings.write().remove(&vaddr);
+    }
+
+    fn supports_mmap(&self) -> bool {
+        match self.current_backing_info() {
+            Ok(info) => info.physical_addr != 0 && info.size > 0,
+            Err(_) => false,
+        }
+    }
+
+    fn mmap_owner_name(&self) -> alloc::string::String {
+        alloc::string::String::from("display")
+    }
+}
+
+impl Selectable for DisplayCharDevice {
+    fn current_ready(
+        &self,
+        interest: ReadyInterest,
+    ) -> crate::object::capability::selectable::ReadySet {
+        let mut set = crate::object::capability::selectable::ReadySet::none();
+        if interest.read {
+            set.read = self.can_read();
+        }
+        if interest.write {
+            set.write = self.can_write();
+        }
+        set
+    }
+
+    fn wait_until_ready(
+        &self,
+        _interest: ReadyInterest,
+        _trapframe: &mut crate::arch::Trapframe,
+        _timeout_ticks: Option<u64>,
+        _min_wait_ticks: u64,
+    ) -> SelectWaitOutcome {
+        SelectWaitOutcome::Ready
+    }
+}

--- a/kernel/src/device/graphics/display_device.rs
+++ b/kernel/src/device/graphics/display_device.rs
@@ -62,6 +62,11 @@ pub struct DisplayInfo {
     pub format: u32,
     /// Page-aligned size of the mappable display backing store.
     pub buffer_len: u32,
+    /// Opaque identifier for the current mappable backing store.
+    ///
+    /// This value changes when the display surface's mapped backing changes,
+    /// even if `buffer_len` remains the same.
+    pub backing_id: usize,
 }
 
 /// Region argument for DISPLAY_PRESENT_REGION.
@@ -210,6 +215,7 @@ impl DisplayCharDevice {
             stride: backing.config.stride,
             format: Self::display_format(backing.config.format),
             buffer_len: backing.size as u32,
+            backing_id: backing.physical_addr,
         })
     }
 

--- a/kernel/src/device/graphics/framebuffer_device.rs
+++ b/kernel/src/device/graphics/framebuffer_device.rs
@@ -17,7 +17,7 @@ extern crate alloc;
 
 use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
 use core::any::Any;
-use spin::RwLock;
+use spin::{Mutex, RwLock};
 
 use crate::device::{
     Device, DeviceType,
@@ -25,8 +25,14 @@ use crate::device::{
     graphics::{FramebufferConfig, manager::FramebufferResource, output::DisplayRegion},
     manager::DeviceManager,
 };
+use crate::environment::PAGE_SIZE;
+use crate::object::capability::memory_mapping::{
+    AccessKind, AccessOp, ResolveFaultError, ResolveFaultResult,
+};
 use crate::object::capability::selectable::Selectable;
 use crate::object::capability::{ControlOps, MemoryMappingOps};
+use crate::sched::scheduler::get_task_by_id;
+use crate::timer::{TimerHandler, add_timer, get_tick, ms_to_ticks};
 use crate::vm::addr::phys_to_virt;
 
 /// Linux framebuffer ioctl command constants
@@ -222,12 +228,29 @@ impl Default for FbBitfield {
     }
 }
 
-/// Mock mapping for testing purposes
-#[allow(dead_code)]
+/// Active legacy framebuffer mmap alias.
 #[derive(Debug, Clone)]
-struct MockMapping {
+struct FramebufferMapping {
+    task_id: usize,
     vaddr: usize,
     length: usize,
+    offset: usize,
+    write_protect: bool,
+}
+
+#[derive(Debug)]
+struct FbCompatDirtyState {
+    dirty: bool,
+    timer_armed: bool,
+    generation: usize,
+}
+
+struct FbCompatFlushHandler {
+    fb_resource: Arc<FramebufferResource>,
+    mappings: Arc<RwLock<BTreeMap<(usize, usize), FramebufferMapping>>>,
+    dirty_state: Arc<Mutex<FbCompatDirtyState>>,
+    #[cfg(test)]
+    device_manager_addr: Option<usize>,
 }
 
 /// Framebuffer character device implementation
@@ -241,8 +264,12 @@ struct MockMapping {
 pub struct FramebufferCharDevice {
     /// The framebuffer resource this device represents
     fb_resource: Arc<FramebufferResource>,
-    /// Track mappings for testing purposes  
-    mappings: RwLock<BTreeMap<usize, MockMapping>>, // virtual_start -> MockMapping
+    /// Track legacy framebuffer mmap aliases by (task_id, virtual_start).
+    mappings: Arc<RwLock<BTreeMap<(usize, usize), FramebufferMapping>>>,
+    /// Dirty state for legacy fb compat one-shot flushing.
+    dirty_state: Arc<Mutex<FbCompatDirtyState>>,
+    /// Timer handler kept alive for the legacy fb compat one-shot flush.
+    flush_handler: Arc<FbCompatFlushHandler>,
     #[cfg(test)]
     device_manager_addr: Option<usize>,
 }
@@ -264,9 +291,25 @@ impl FramebufferCharDevice {
     ///
     /// A new FramebufferCharDevice instance
     pub fn new(fb_resource: Arc<FramebufferResource>) -> Self {
+        let mappings = Arc::new(RwLock::new(BTreeMap::new()));
+        let dirty_state = Arc::new(Mutex::new(FbCompatDirtyState {
+            dirty: false,
+            timer_armed: false,
+            generation: 0,
+        }));
+        let flush_handler = Arc::new(FbCompatFlushHandler {
+            fb_resource: Arc::clone(&fb_resource),
+            mappings: Arc::clone(&mappings),
+            dirty_state: Arc::clone(&dirty_state),
+            #[cfg(test)]
+            device_manager_addr: None,
+        });
+
         Self {
             fb_resource,
-            mappings: RwLock::new(BTreeMap::new()),
+            mappings,
+            dirty_state,
+            flush_handler,
             #[cfg(test)]
             device_manager_addr: None,
         }
@@ -277,10 +320,26 @@ impl FramebufferCharDevice {
         fb_resource: Arc<FramebufferResource>,
         device_manager: &DeviceManager,
     ) -> Self {
+        let mappings = Arc::new(RwLock::new(BTreeMap::new()));
+        let dirty_state = Arc::new(Mutex::new(FbCompatDirtyState {
+            dirty: false,
+            timer_armed: false,
+            generation: 0,
+        }));
+        let device_manager_addr = device_manager as *const DeviceManager as usize;
+        let flush_handler = Arc::new(FbCompatFlushHandler {
+            fb_resource: Arc::clone(&fb_resource),
+            mappings: Arc::clone(&mappings),
+            dirty_state: Arc::clone(&dirty_state),
+            device_manager_addr: Some(device_manager_addr),
+        });
+
         Self {
             fb_resource,
-            mappings: RwLock::new(BTreeMap::new()),
-            device_manager_addr: Some(device_manager as *const DeviceManager as usize),
+            mappings,
+            dirty_state,
+            flush_handler,
+            device_manager_addr: Some(device_manager_addr),
         }
     }
 
@@ -327,6 +386,217 @@ impl FramebufferCharDevice {
             physical_addr: self.fb_resource.physical_addr,
             size: self.fb_resource.size,
         })
+    }
+
+    fn current_task_id() -> usize {
+        crate::task::mytask().map(|task| task.get_id()).unwrap_or(0)
+    }
+
+    fn record_mapping_for_current_task(
+        &self,
+        vaddr: usize,
+        length: usize,
+        offset: usize,
+        write_protect: bool,
+    ) {
+        let task_id = Self::current_task_id();
+        let mapping = FramebufferMapping {
+            task_id,
+            vaddr,
+            length,
+            offset,
+            write_protect,
+        };
+        self.mappings.write().insert((task_id, vaddr), mapping);
+    }
+
+    fn mark_legacy_dirty(&self) {
+        let arm_context = {
+            let mut state = self.dirty_state.lock();
+            state.dirty = true;
+            if state.timer_armed {
+                None
+            } else {
+                state.timer_armed = true;
+                state.generation = state.generation.wrapping_add(1);
+                Some(state.generation)
+            }
+        };
+
+        if let Some(context) = arm_context {
+            let handler: Arc<dyn TimerHandler> = self.flush_handler.clone();
+            add_timer(
+                get_tick().saturating_add(ms_to_ticks(16)),
+                &handler,
+                context,
+            );
+        }
+    }
+
+    fn disarm_legacy_dirty_timer(&self) {
+        let mut state = self.dirty_state.lock();
+        state.dirty = false;
+        state.timer_armed = false;
+        state.generation = state.generation.wrapping_add(1);
+    }
+
+    fn mapping_for_fault(
+        &self,
+        access: &AccessKind,
+        vm_start: usize,
+        info: &CurrentFramebufferInfo,
+    ) -> Option<FramebufferMapping> {
+        let task_id = Self::current_task_id();
+        if let Some(mapping) = self.mappings.read().get(&(task_id, vm_start)).cloned() {
+            return Some(mapping);
+        }
+
+        let task = crate::task::mytask()?;
+        let memory_map = task.vm_manager.search_memory_map(access.vaddr)?;
+        let map_object_offset = memory_map.pmarea.start.saturating_sub(info.physical_addr);
+        let map_vm_offset = memory_map.vmarea.start.saturating_sub(memory_map.vm_start);
+        let base_offset = map_object_offset.saturating_sub(map_vm_offset);
+        let mapping = FramebufferMapping {
+            task_id,
+            vaddr: memory_map.vm_start,
+            length: memory_map
+                .vmarea
+                .end
+                .saturating_sub(memory_map.vm_start)
+                .saturating_add(1),
+            offset: base_offset,
+            write_protect: memory_map.is_shared,
+        };
+        self.mappings
+            .write()
+            .insert((task_id, memory_map.vm_start), mapping.clone());
+        Some(mapping)
+    }
+
+    fn write_protect_mappings(
+        mappings: &RwLock<BTreeMap<(usize, usize), FramebufferMapping>>,
+        info: &CurrentFramebufferInfo,
+    ) {
+        let snapshot: Vec<FramebufferMapping> = mappings.read().values().cloned().collect();
+        for mapping in snapshot {
+            if !mapping.write_protect {
+                continue;
+            }
+            let Some(task) = get_task_by_id(mapping.task_id) else {
+                continue;
+            };
+            let Some(root_pagetable) = task.vm_manager.get_root_page_table() else {
+                continue;
+            };
+
+            let asid = task.vm_manager.get_asid();
+            let mut page_offset = 0usize;
+            while page_offset < mapping.length {
+                let object_offset = mapping.offset.saturating_add(page_offset);
+                if object_offset >= info.size {
+                    break;
+                }
+
+                root_pagetable.map(
+                    asid,
+                    mapping.vaddr.saturating_add(page_offset),
+                    info.physical_addr.saturating_add(object_offset),
+                    0x1 | 0x08,
+                    true,
+                    false,
+                );
+                page_offset = page_offset.saturating_add(PAGE_SIZE);
+            }
+        }
+    }
+}
+
+impl FbCompatFlushHandler {
+    #[cfg(test)]
+    fn device_manager(&self) -> &DeviceManager {
+        match self.device_manager_addr {
+            Some(device_manager_addr) => unsafe { &*(device_manager_addr as *const DeviceManager) },
+            None => DeviceManager::get_manager(),
+        }
+    }
+
+    #[cfg(not(test))]
+    fn device_manager(&self) -> &DeviceManager {
+        DeviceManager::get_manager()
+    }
+
+    fn current_framebuffer_info(&self) -> Result<CurrentFramebufferInfo, &'static str> {
+        if let Some(device) = self
+            .device_manager()
+            .get_device(self.fb_resource.source_device_id)
+        {
+            if let Some(graphics_device) = device.as_graphics_device() {
+                let (config, physical_addr) = graphics_device.get_framebuffer_info()?;
+                let size = FramebufferCharDevice::page_aligned_size(config.size());
+                return Ok(CurrentFramebufferInfo {
+                    config,
+                    physical_addr,
+                    size,
+                });
+            }
+        }
+
+        Ok(CurrentFramebufferInfo {
+            config: self.fb_resource.config.clone(),
+            physical_addr: self.fb_resource.physical_addr,
+            size: self.fb_resource.size,
+        })
+    }
+
+    fn trigger_display_update(&self, region: DisplayRegion) -> Result<(), &'static str> {
+        let device_manager = self.device_manager();
+        if let Some(device) = device_manager.get_device(self.fb_resource.source_device_id) {
+            if let Some(graphics_device) = device.as_graphics_device() {
+                let (config, physical_addr) = graphics_device.get_framebuffer_info()?;
+                let region = DisplayRegion::new(
+                    region.x.min(config.width),
+                    region.y.min(config.height),
+                    region.width.min(config.width.saturating_sub(region.x)),
+                    region.height.min(config.height.saturating_sub(region.y)),
+                );
+                graphics_device.present_current_framebuffer_region(region)?;
+                if physical_addr == 0 {
+                    return Err("Graphics device framebuffer address is null");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl TimerHandler for FbCompatFlushHandler {
+    fn on_timer_expired(self: Arc<Self>, context: usize) {
+        let should_flush = {
+            let mut state = self.dirty_state.lock();
+            if !state.timer_armed || state.generation != context {
+                false
+            } else {
+                state.timer_armed = false;
+                if state.dirty {
+                    state.dirty = false;
+                    true
+                } else {
+                    false
+                }
+            }
+        };
+
+        if !should_flush {
+            return;
+        }
+
+        if let Ok(info) = self.current_framebuffer_info() {
+            if info.physical_addr != 0 {
+                let _ = self.trigger_display_update(DisplayRegion::full(&info.config));
+                FramebufferCharDevice::write_protect_mappings(&self.mappings, &info);
+            }
+        }
     }
 }
 
@@ -503,6 +773,10 @@ impl CharDevice for FramebufferCharDevice {
             }
         }
 
+        if to_write > 0 {
+            self.mark_legacy_dirty();
+        }
+
         Ok(to_write)
     }
 }
@@ -573,15 +847,20 @@ impl MemoryMappingOps for FramebufferCharDevice {
         Ok((paddr, permissions, is_shared))
     }
 
-    fn on_mapped(&self, vaddr: usize, _paddr: usize, length: usize, _offset: usize) {
-        // Record this mapping in our tracking structure
-        let mapping = MockMapping { vaddr, length };
-        self.mappings.write().insert(vaddr, mapping);
+    fn on_mapped(&self, vaddr: usize, paddr: usize, length: usize, offset: usize) {
+        self.record_mapping_for_current_task(vaddr, length, offset, paddr != 0);
     }
 
-    fn on_unmapped(&self, vaddr: usize, _length: usize) {
-        // Remove the mapping from our tracking
-        self.mappings.write().remove(&vaddr);
+    fn on_unmapped(&self, vaddr: usize, length: usize) {
+        let task_id = Self::current_task_id();
+        let unmap_end = vaddr.saturating_add(length);
+        self.mappings.write().retain(|_, mapping| {
+            if task_id != 0 && mapping.task_id != task_id {
+                return true;
+            }
+            let mapping_end = mapping.vaddr.saturating_add(mapping.length);
+            mapping_end <= vaddr || mapping.vaddr >= unmap_end
+        });
     }
 
     fn supports_mmap(&self) -> bool {
@@ -589,6 +868,51 @@ impl MemoryMappingOps for FramebufferCharDevice {
             Ok(info) => info.physical_addr != 0 && info.size > 0,
             Err(_) => false,
         }
+    }
+
+    fn resolve_fault(
+        &self,
+        access: &AccessKind,
+        _page_idx: usize,
+        vm_start: usize,
+    ) -> Result<ResolveFaultResult, ResolveFaultError> {
+        let info = self
+            .current_framebuffer_info()
+            .map_err(|_| ResolveFaultError::Invalid)?;
+        let mapping = self
+            .mapping_for_fault(access, vm_start, &info)
+            .ok_or(ResolveFaultError::Invalid)?;
+
+        if access.vaddr < mapping.vaddr {
+            return Err(ResolveFaultError::Invalid);
+        }
+
+        let page_offset = (access.vaddr - mapping.vaddr) & !(PAGE_SIZE - 1);
+        let object_offset = mapping.offset.saturating_add(page_offset);
+        if object_offset >= info.size {
+            return Err(ResolveFaultError::Unmapped);
+        }
+
+        if matches!(access.op, AccessOp::Store) {
+            self.mark_legacy_dirty();
+        }
+
+        Ok(ResolveFaultResult {
+            paddr_page_base: info.physical_addr.saturating_add(object_offset),
+            is_tail: false,
+        })
+    }
+
+    fn fault_page_permissions(&self, access: &AccessKind, default_permissions: usize) -> usize {
+        if matches!(access.op, AccessOp::Store) {
+            default_permissions
+        } else {
+            default_permissions & !0x2
+        }
+    }
+
+    fn mmap_owner_name(&self) -> alloc::string::String {
+        alloc::string::String::from("framebuffer")
     }
 }
 
@@ -922,7 +1246,9 @@ impl FramebufferCharDevice {
 
         // Trigger display controller update if needed
         // For some hardware, writing to framebuffer memory doesn't immediately update the display
-        self.trigger_display_update()?;
+        self.trigger_display_update(DisplayRegion::full(&info.config))?;
+        self.disarm_legacy_dirty_timer();
+        Self::write_protect_mappings(&self.mappings, &info);
 
         Ok(0) // Success
     }
@@ -931,7 +1257,7 @@ impl FramebufferCharDevice {
     ///
     /// Some display controllers require explicit commands to update the display
     /// from framebuffer contents. This method handles such updates.
-    fn trigger_display_update(&self) -> Result<(), &'static str> {
+    fn trigger_display_update(&self, region: DisplayRegion) -> Result<(), &'static str> {
         // Try to get the source graphics device to trigger a display update
         let device_manager = self.device_manager();
         if let Some(device) = device_manager.get_device(self.fb_resource.source_device_id) {
@@ -939,7 +1265,13 @@ impl FramebufferCharDevice {
             if let Some(graphics_device) = device.as_graphics_device() {
                 let (config, physical_addr) = graphics_device.get_framebuffer_info()?;
 
-                graphics_device.present_current_framebuffer_region(DisplayRegion::full(&config))?;
+                let region = DisplayRegion::new(
+                    region.x.min(config.width),
+                    region.y.min(config.height),
+                    region.width.min(config.width.saturating_sub(region.x)),
+                    region.height.min(config.height.saturating_sub(region.y)),
+                );
+                graphics_device.present_current_framebuffer_region(region)?;
 
                 // Verify that the framebuffer address is still valid
                 if physical_addr == 0 {
@@ -1307,6 +1639,7 @@ mod tests {
             physical_addr: 0, // Invalid address
             size: 300,
             created_char_device_id: RwLock::new(None),
+            created_display_device_id: RwLock::new(None),
         });
         let invalid_device = FramebufferCharDevice::new(invalid_resource);
 
@@ -1579,7 +1912,7 @@ mod tests {
         {
             let mappings = fb_device.mappings.read();
             assert_eq!(mappings.len(), 1);
-            assert!(mappings.contains_key(&0x1000));
+            assert!(mappings.contains_key(&(0, 0x1000)));
         }
 
         // Test on_unmapped callback

--- a/kernel/src/device/graphics/framebuffer_device.rs
+++ b/kernel/src/device/graphics/framebuffer_device.rs
@@ -371,7 +371,8 @@ impl FramebufferCharDevice {
             .get_device(self.fb_resource.source_device_id)
         {
             if let Some(graphics_device) = device.as_graphics_device() {
-                let (config, physical_addr) = graphics_device.get_framebuffer_info()?;
+                let config = graphics_device.get_framebuffer_config()?;
+                let physical_addr = graphics_device.get_framebuffer_address()?;
                 let size = Self::page_aligned_size(config.size());
                 return Ok(CurrentFramebufferInfo {
                     config,
@@ -531,7 +532,8 @@ impl FbCompatFlushHandler {
             .get_device(self.fb_resource.source_device_id)
         {
             if let Some(graphics_device) = device.as_graphics_device() {
-                let (config, physical_addr) = graphics_device.get_framebuffer_info()?;
+                let config = graphics_device.get_framebuffer_config()?;
+                let physical_addr = graphics_device.get_framebuffer_address()?;
                 let size = FramebufferCharDevice::page_aligned_size(config.size());
                 return Ok(CurrentFramebufferInfo {
                     config,

--- a/kernel/src/device/graphics/manager.rs
+++ b/kernel/src/device/graphics/manager.rs
@@ -55,6 +55,8 @@ pub struct FramebufferResource {
     pub size: usize,
     /// ID of the created /dev/fbX character device (if any)
     pub created_char_device_id: RwLock<Option<usize>>,
+    /// ID of the created /dev/displayX character device (if any)
+    pub created_display_device_id: RwLock<Option<usize>>,
 }
 
 impl FramebufferResource {
@@ -73,6 +75,7 @@ impl FramebufferResource {
             physical_addr,
             size,
             created_char_device_id: RwLock::new(None),
+            created_display_device_id: RwLock::new(None),
         }
     }
 }
@@ -289,6 +292,19 @@ impl GraphicsManager {
             );
         }
 
+        crate::early_println!(
+            "[GraphicsManager] Creating display char device for {}",
+            logical_name
+        );
+        if let Err(e) = self.create_display_char_device_with_manager(&logical_name, device_manager)
+        {
+            crate::early_println!(
+                "[GraphicsManager] Warning: Failed to create display device for {}: {}",
+                logical_name,
+                e
+            );
+        }
+
         Ok(())
     }
 
@@ -424,6 +440,96 @@ impl GraphicsManager {
         if let Some(map) = framebuffers.as_mut() {
             if let Some(resource) = map.get_mut(fb_name) {
                 *resource.created_char_device_id.write() = Some(char_device_id);
+                Ok(())
+            } else {
+                Err("Framebuffer not found")
+            }
+        } else {
+            Err("Framebuffer not found")
+        }
+    }
+
+    /// Create a DisplayCharDevice and register it with DeviceManager.
+    ///
+    /// # Arguments
+    ///
+    /// * `fb_name` - The logical framebuffer name backing the display.
+    ///
+    /// # Returns
+    ///
+    /// Result indicating success or failure.
+    pub fn create_display_char_device(&self, fb_name: &str) -> Result<(), &'static str> {
+        self.create_display_char_device_with_manager(fb_name, DeviceManager::get_manager())
+    }
+
+    fn create_display_char_device_with_manager(
+        &self,
+        fb_name: &str,
+        device_manager: &DeviceManager,
+    ) -> Result<(), &'static str> {
+        use crate::device::graphics::display_device::DisplayCharDevice;
+        use alloc::sync::Arc;
+
+        let fb_resource = {
+            let framebuffers = self.framebuffers.lock();
+            framebuffers
+                .as_ref()
+                .and_then(|map| map.get(fb_name))
+                .cloned()
+                .ok_or("Framebuffer not found")?
+        };
+
+        let display_index = fb_name
+            .strip_prefix("fb")
+            .ok_or("Invalid framebuffer name")?;
+        let display_name = format!("display{}", display_index);
+
+        #[cfg(test)]
+        let display_device =
+            DisplayCharDevice::new_with_device_manager(fb_resource, device_manager);
+        #[cfg(not(test))]
+        let display_device = DisplayCharDevice::new(fb_resource);
+
+        let device_id = device_manager
+            .register_device_with_name(display_name.clone(), Arc::new(display_device));
+
+        self.set_display_device_id(fb_name, device_id)?;
+
+        crate::early_println!(
+            "[GraphicsManager] Created display character device: /dev/{}",
+            display_name
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn create_display_char_device_with_device_manager(
+        &self,
+        fb_name: &str,
+        device_manager: &DeviceManager,
+    ) -> Result<(), &'static str> {
+        self.create_display_char_device_with_manager(fb_name, device_manager)
+    }
+
+    /// Update the display character device ID for a framebuffer resource.
+    ///
+    /// # Arguments
+    ///
+    /// * `fb_name` - The logical framebuffer name.
+    /// * `display_device_id` - The character device ID from DeviceManager.
+    ///
+    /// # Returns
+    ///
+    /// Result indicating success or failure.
+    pub fn set_display_device_id(
+        &self,
+        fb_name: &str,
+        display_device_id: usize,
+    ) -> Result<(), &'static str> {
+        let mut framebuffers = self.framebuffers.lock();
+        if let Some(map) = framebuffers.as_mut() {
+            if let Some(resource) = map.get_mut(fb_name) {
+                *resource.created_display_device_id.write() = Some(display_device_id);
                 Ok(())
             } else {
                 Err("Framebuffer not found")

--- a/kernel/src/device/graphics/mod.rs
+++ b/kernel/src/device/graphics/mod.rs
@@ -13,6 +13,7 @@ use super::{Device, DeviceType, manager::DeviceManager};
 use crate::object::capability::selectable::Selectable;
 use crate::object::capability::{ControlOps, MemoryMappingOps};
 
+pub mod display_device;
 pub mod framebuffer_device;
 pub mod manager;
 pub mod output;

--- a/kernel/src/device/graphics/tests/integration_tests.rs
+++ b/kernel/src/device/graphics/tests/integration_tests.rs
@@ -276,6 +276,7 @@ mod integration_tests {
             physical_addr: 0, // Invalid address
             size: invalid_config.size(),
             created_char_device_id: RwLock::new(None),
+            created_display_device_id: RwLock::new(None),
         });
 
         let char_device = FramebufferCharDevice::new(invalid_resource);
@@ -299,6 +300,7 @@ mod integration_tests {
             physical_addr: 0x1003,
             size: crate::environment::PAGE_SIZE,
             created_char_device_id: RwLock::new(None),
+            created_display_device_id: RwLock::new(None),
         });
         let char_device = FramebufferCharDevice::new(resource);
 

--- a/kernel/src/drivers/graphics/virtio_gpu.rs
+++ b/kernel/src/drivers/graphics/virtio_gpu.rs
@@ -28,7 +28,6 @@ use crate::{
     },
     mem::page::ContiguousPages,
     object::capability::{ControlOps, MemoryMappingOps, Selectable},
-    timer::{TimerHandler, add_timer, get_tick, ms_to_ticks},
     vm::addr::virt_to_phys,
 };
 use core::ptr;
@@ -1268,7 +1267,6 @@ impl VirtioDevice for VirtioGpuDeviceCore {
 
 pub struct VirtioGpuDevice {
     core: Arc<Mutex<VirtioGpuDeviceCore>>,
-    handler: RwLock<Option<Arc<dyn TimerHandler>>>,
 }
 
 impl VirtioGpuDevice {
@@ -1284,7 +1282,6 @@ impl VirtioGpuDevice {
     pub fn new(base_addr: usize) -> Self {
         Self {
             core: Arc::new(Mutex::new(VirtioGpuDeviceCore::new(base_addr))),
-            handler: RwLock::new(None),
         }
     }
 
@@ -1300,7 +1297,6 @@ impl VirtioGpuDevice {
     pub fn new_pci(transport: VirtioPciTransport) -> Self {
         Self {
             core: Arc::new(Mutex::new(VirtioGpuDeviceCore::new_pci(transport))),
-            handler: RwLock::new(None),
         }
     }
 }
@@ -1458,6 +1454,7 @@ impl GraphicsDevice for VirtioGpuDevice {
 
     fn get_framebuffer_info(&self) -> Result<(FramebufferConfig, usize), &'static str> {
         let core = self.core.lock();
+        let _ = core.poll_display_resize();
         let config = core.get_framebuffer_config()?;
         let physical_addr = core.get_framebuffer_address()?;
         Ok((config, physical_addr))
@@ -1519,70 +1516,8 @@ impl GraphicsDevice for VirtioGpuDevice {
         // Set up framebuffer
         self.core.lock().setup_framebuffer()?;
 
-        crate::early_println!("[virtio-gpu] init_graphics: add timer handler");
-
-        let handler: Arc<dyn TimerHandler> = Arc::new(FramebufferUpdateHandler {
-            device: self.core.clone(),
-            last_resize_poll_tick: Mutex::new(0),
-        });
-
-        add_timer(get_tick() + ms_to_ticks(16), &handler, 0);
-
-        // Store handler via interior mutability
-        *self.handler.write() = Some(handler);
-
         crate::early_println!("[virtio-gpu] init_graphics: done");
         Ok(())
-    }
-}
-
-struct FramebufferUpdateHandler {
-    device: Arc<Mutex<VirtioGpuDeviceCore>>,
-    last_resize_poll_tick: Mutex<u64>,
-}
-
-impl FramebufferUpdateHandler {
-    fn present_framebuffer(&self) {
-        let now = get_tick();
-        let should_poll_resize = {
-            let mut last_poll = self.last_resize_poll_tick.lock();
-            if now.saturating_sub(*last_poll) >= ms_to_ticks(250) {
-                *last_poll = now;
-                true
-            } else {
-                false
-            }
-        };
-        if should_poll_resize {
-            let _ = self.device.lock().poll_display_resize();
-        }
-
-        let (width, height) = {
-            let core = self.device.lock();
-            if core.framebuffer_addr.read().is_none() {
-                return;
-            }
-            let display_info_guard = core.display_info.read();
-            let display_info = match display_info_guard.as_ref() {
-                Some(info) => info,
-                None => return,
-            };
-            let width = display_info.pmodes[0].r.width;
-            let height = display_info.pmodes[0].r.height;
-            (width, height)
-        };
-        let _ = self
-            .device
-            .lock()
-            .present_framebuffer_region(DisplayRegion::new(0, 0, width, height));
-    }
-}
-
-impl TimerHandler for FramebufferUpdateHandler {
-    fn on_timer_expired(self: Arc<Self>, context: usize) {
-        self.present_framebuffer();
-        let handler = self as Arc<dyn TimerHandler>;
-        add_timer(get_tick() + ms_to_ticks(16), &handler, context);
     }
 }
 

--- a/kernel/src/object/capability/memory_mapping/mod.rs
+++ b/kernel/src/object/capability/memory_mapping/mod.rs
@@ -101,6 +101,29 @@ pub trait MemoryMappingOps: Send + Sync {
         Err(crate::object::capability::memory_mapping::ResolveFaultError::Unmapped)
     }
 
+    /// Choose the actual page-table permissions for a resolved fault.
+    ///
+    /// The virtual memory map keeps the maximum permissions requested by mmap,
+    /// while some owners need to install a stricter PTE temporarily. A
+    /// framebuffer compatibility mapping, for example, keeps the VM map
+    /// writable but resolves read faults as read-only so a later store still
+    /// traps and can mark the legacy framebuffer dirty.
+    ///
+    /// # Arguments
+    /// * `access` - Access that caused the fault
+    /// * `default_permissions` - Permissions from the virtual memory map
+    ///
+    /// # Returns
+    /// The permissions to install in the page table for this fault.
+    fn fault_page_permissions(
+        &self,
+        access: &crate::object::capability::memory_mapping::AccessKind,
+        default_permissions: usize,
+    ) -> usize {
+        let _ = access;
+        default_permissions
+    }
+
     fn release_pages(&self, _start_page_idx: usize, _page_count: usize) {}
 
     fn fork_clone(&self) -> Option<alloc::sync::Arc<dyn MemoryMappingOps>> {

--- a/kernel/src/vm/manager.rs
+++ b/kernel/src/vm/manager.rs
@@ -542,6 +542,7 @@ impl VirtualMemoryManager {
             };
             match owner.resolve_fault(&owner_access, page_idx, memory_map.vm_start) {
                 Ok(res) => {
+                    perms = owner.fault_page_permissions(&owner_access, perms);
                     if res.is_tail {
                         perms &= !0x1;
                         perms &= !0x2;
@@ -677,6 +678,8 @@ impl VirtualMemoryManager {
                         let page_idx = (page_vaddr - map.vm_start) / PAGE_SIZE;
                         match owner.resolve_fault(&test_access, page_idx, map.vm_start) {
                             Ok(res) => {
+                                let permissions =
+                                    owner.fault_page_permissions(&test_access, map.permissions);
                                 // Owner says this offset is valid - extend vmarea.end
                                 let new_end = page_vaddr + PAGE_SIZE - 1;
                                 crate::println!(
@@ -687,7 +690,7 @@ impl VirtualMemoryManager {
                                 );
                                 map.vmarea.end = new_end;
 
-                                found = Some((res.paddr_page_base, map.permissions));
+                                found = Some((res.paddr_page_base, permissions));
                                 break;
                             }
                             Err(_) => {

--- a/user/bin/src/stemd/main.rs
+++ b/user/bin/src/stemd/main.rs
@@ -1032,6 +1032,26 @@ fn handle_shutdown() {
     shutdown(ShutdownType::PowerOff);
 }
 
+fn read_until(
+    stream: &std::handle::capability::StreamOps<'_>,
+    buffer: &mut [u8],
+    filled: &mut usize,
+    target: usize,
+) -> bool {
+    if target > buffer.len() {
+        return false;
+    }
+
+    while *filled < target {
+        match stream.read(&mut buffer[*filled..target]) {
+            Ok(0) | Err(_) => return false,
+            Ok(bytes) => *filled += bytes,
+        }
+    }
+
+    true
+}
+
 /// IPC thread: accept commands via socket
 fn ipc_thread() {
     println!("stemd: IPC thread started");
@@ -1073,18 +1093,18 @@ fn ipc_thread() {
                 // Read command (larger buffer for binary commands)
                 let mut buffer = [0u8; 1024];
                 match stream.read(&mut buffer) {
-                    Ok(n) if n > 0 => {
+                    Ok(mut n) if n > 0 => {
                         // Check if this is a binary launch command.
                         if buffer[0] == cmd::LAUNCH_OR_FOCUS || buffer[0] == cmd::LAUNCH {
                             // Parse launch command.
                             // Format: cmd(1) + app_id_len(4) + app_id + exec_path_len(4) + exec_path
-                            if n >= 9 {
+                            if read_until(&stream, &mut buffer, &mut n, 9) {
                                 let app_id_len = u32::from_le_bytes([
                                     buffer[1], buffer[2], buffer[3], buffer[4],
                                 ]) as usize;
 
                                 let exec_path_offset = 5 + app_id_len;
-                                if n >= exec_path_offset + 4 {
+                                if read_until(&stream, &mut buffer, &mut n, exec_path_offset + 4) {
                                     let exec_path_len = u32::from_le_bytes([
                                         buffer[exec_path_offset],
                                         buffer[exec_path_offset + 1],
@@ -1094,7 +1114,7 @@ fn ipc_thread() {
                                         as usize;
 
                                     let total_len = exec_path_offset + 4 + exec_path_len;
-                                    if n >= total_len {
+                                    if read_until(&stream, &mut buffer, &mut n, total_len) {
                                         let app_id =
                                             core::str::from_utf8(&buffer[5..5 + app_id_len]);
                                         let exec_path = core::str::from_utf8(
@@ -1177,12 +1197,12 @@ fn ipc_thread() {
                                 let _ = stream.write(error_msg.as_bytes());
                             }
                         } else if buffer[0] == cmd::SERVICE_READY {
-                            if n >= 5 {
+                            if read_until(&stream, &mut buffer, &mut n, 5) {
                                 let service_name_len = u32::from_le_bytes([
                                     buffer[1], buffer[2], buffer[3], buffer[4],
                                 ]) as usize;
                                 let end = 5 + service_name_len;
-                                if n >= end {
+                                if read_until(&stream, &mut buffer, &mut n, end) {
                                     match core::str::from_utf8(&buffer[5..end]) {
                                         Ok(service_name) => {
                                             println!(

--- a/user/bin/src/sws/compositor.rs
+++ b/user/bin/src/sws/compositor.rs
@@ -5,12 +5,15 @@ use super::input::{CompositorInputEvent, InputManager, key_codes};
 use super::ipc::{IpcEvent, IpcServer, send_message_to_client, send_message_to_window};
 use super::window::WindowManager;
 use core::sync::atomic::{AtomicU8, Ordering};
-use framebuffer::Framebuffer;
+use core::time::Duration;
+use framebuffer::DisplaySurface;
 use std::env;
 use std::fs::File;
 use std::handle::Handle;
+use std::poll::{POLLIN, PollHandle, poll};
 use std::println;
 use std::string::String;
+use std::thread;
 use std::vec::Vec;
 use sws_protocol;
 
@@ -28,8 +31,8 @@ fn is_sws_debug_enabled() -> bool {
     enabled
 }
 
-// NOTE: The compositor intentionally does NOT manage a manual VRAM mmap mapping.
-// Rendering goes through the framebuffer library (which may internally use mmap).
+// NOTE: The compositor intentionally opens the modern display surface endpoint,
+// not the legacy framebuffer node. The endpoint may internally use mmap.
 
 // Debug: dump VRAM mmap range and window buffer ranges.
 // This helps confirm whether corruption is caused by virtual-address overlap.
@@ -44,8 +47,12 @@ const LOG_RENDER_VALIDATION: bool = false;
 const ENABLE_DIRTY_RECT: bool = true;
 const MAX_PENDING_DAMAGE_RECTS: usize = 8;
 const DAMAGE_MERGE_AREA_FACTOR: u64 = 2;
+const FRAME_BATCH_INTERVAL: Duration = Duration::from_nanos(16_666_667);
 const DEFAULT_OUTPUT_SCALE_MILLI: u32 = 2000;
 const SWS_CONFIG_PATH: &str = "/etc/sws/config.toml";
+
+type DamageRect = (i32, i32, u32, u32);
+type PresentDamage = Option<Vec<DamageRect>>;
 
 fn load_output_scale_milli() -> u32 {
     match read_sws_config(SWS_CONFIG_PATH) {
@@ -174,7 +181,7 @@ fn normalize_scale_milli(scale_milli: u32) -> u32 {
 
 /// Compositor - the main window server with proper layer compositing
 pub struct Compositor {
-    framebuffer: Framebuffer,
+    display: DisplaySurface,
     window_manager: WindowManager,
     ipc_server: IpcServer,
     wake_read: Handle,
@@ -231,16 +238,16 @@ impl Compositor {
     pub fn new() -> Result<Self, &'static str> {
         println!("[Compositor] Starting initialization...");
 
-        // Open framebuffer
-        let framebuffer =
-            Framebuffer::open("/dev/fb0").map_err(|_| "Failed to open framebuffer")?;
+        // Open the modern display endpoint. The legacy framebuffer node remains
+        // a compatibility path for direct framebuffer clients.
+        let display = DisplaySurface::open_primary().map_err(|_| "Failed to open display")?;
 
         // Get screen dimensions
-        let var_info = framebuffer
+        let var_info = display
             .get_var_screen_info()
             .map_err(|_| "Failed to get screen info")?;
 
-        let fix_info = framebuffer
+        let fix_info = display
             .get_fix_screen_info()
             .map_err(|_| "Failed to get fixed screen info")?;
 
@@ -290,7 +297,7 @@ impl Compositor {
         backbuffer.resize(buffer_size, 0);
 
         Ok(Self {
-            framebuffer,
+            display,
             window_manager,
             ipc_server,
             wake_read,
@@ -460,7 +467,7 @@ impl Compositor {
 
     fn check_display_resize(&mut self) -> Result<bool, &'static str> {
         let var_info = self
-            .framebuffer
+            .display
             .get_var_screen_info()
             .map_err(|_| "Failed to get screen info")?;
         let new_width = var_info.xres;
@@ -478,9 +485,9 @@ impl Compositor {
             self.screen_width, self.screen_height, new_width, new_height
         );
 
-        self.framebuffer
+        self.display
             .refresh_mapping()
-            .map_err(|_| "Failed to refresh framebuffer mapping")?;
+            .map_err(|_| "Failed to refresh display mapping")?;
 
         self.screen_width = new_width;
         self.screen_height = new_height;
@@ -581,24 +588,24 @@ impl Compositor {
         let sp_hint = (&stack_marker as *const u8) as usize;
         println!("[Compositor] stack marker addr: 0x{:x}", sp_hint);
 
-        if let Some((addr, size)) = self.framebuffer.get_mapping_info() {
+        if let Some((addr, size)) = self.display.get_mapping_info() {
             let vram_start = addr;
             let vram_end = addr.saturating_add(size);
             println!(
-                "[Compositor] VRAM mmap (framebuffer lib): 0x{:x}..0x{:x} ({} bytes)",
+                "[Compositor] display mmap: 0x{:x}..0x{:x} ({} bytes)",
                 vram_start, vram_end, size
             );
 
             let bb_overlap = bb_start < vram_end && vram_start < bb_end;
             if bb_overlap {
-                println!("[Compositor] WARNING: backbuffer overlaps framebuffer mapping!");
+                println!("[Compositor] WARNING: backbuffer overlaps display mapping!");
             }
 
             if sp_hint >= vram_start && sp_hint < vram_end {
-                println!("[Compositor] WARNING: stack marker is inside framebuffer mapping!");
+                println!("[Compositor] WARNING: stack marker is inside display mapping!");
             }
         } else {
-            println!("[Compositor] VRAM mmap (framebuffer lib): (unavailable)");
+            println!("[Compositor] display mmap: (unavailable)");
         }
 
         let mut ranges: Vec<(u32, usize, usize, usize)> = Vec::new();
@@ -616,12 +623,12 @@ impl Compositor {
                     w.id, shm_addr, end, buffer_size
                 );
 
-                if let Some((vram_start, vram_size)) = self.framebuffer.get_mapping_info() {
+                if let Some((vram_start, vram_size)) = self.display.get_mapping_info() {
                     let vram_end = vram_start.saturating_add(vram_size);
                     let overlap = shm_addr < vram_end && vram_start < end;
                     if overlap {
                         println!(
-                            "[Compositor] WARNING: window #{} SHM overlaps framebuffer mapping!",
+                            "[Compositor] WARNING: window #{} SHM overlaps display mapping!",
                             w.id
                         );
                     }
@@ -647,12 +654,12 @@ impl Compositor {
                     w.id, start, end, len, fp
                 );
 
-                if let Some((vram_start, vram_size)) = self.framebuffer.get_mapping_info() {
+                if let Some((vram_start, vram_size)) = self.display.get_mapping_info() {
                     let vram_end = vram_start.saturating_add(vram_size);
                     let overlap = start < vram_end && vram_start < end;
                     if overlap {
                         println!(
-                            "[Compositor] WARNING: window #{} buffer overlaps framebuffer mapping!",
+                            "[Compositor] WARNING: window #{} buffer overlaps display mapping!",
                             w.id
                         );
                     }
@@ -792,7 +799,7 @@ impl Compositor {
         union_area <= separate_area.saturating_mul(DAMAGE_MERGE_AREA_FACTOR)
     }
 
-    fn push_damage_rect(rects: &mut Vec<(i32, i32, u32, u32)>, rect: (i32, i32, u32, u32)) {
+    fn push_damage_rect(rects: &mut Vec<DamageRect>, rect: DamageRect) {
         for existing in rects.iter_mut() {
             if Self::should_merge_damage(*existing, rect) {
                 *existing = Self::union_damage_rect(*existing, rect);
@@ -816,6 +823,20 @@ impl Compositor {
             }
         }
         rects[best_index] = Self::union_damage_rect(rects[best_index], rect);
+    }
+
+    fn merge_present_damage(accumulated: &mut PresentDamage, next: PresentDamage) {
+        match (accumulated, next) {
+            (accum @ Some(_), None) => {
+                *accum = None;
+            }
+            (Some(accumulated_rects), Some(next_rects)) => {
+                for rect in next_rects {
+                    Self::push_damage_rect(accumulated_rects, rect);
+                }
+            }
+            (None, _) => {}
+        }
     }
 
     fn add_pending_damage(&mut self, rect: (i32, i32, u32, u32)) {
@@ -842,9 +863,8 @@ impl Compositor {
         }
     }
 
-    /// Composite all layers directly to VRAM (or framebuffer as fallback)
-    fn composite_and_present(&mut self) -> Result<(), &'static str> {
-        let dirty_rects = if !ENABLE_DIRTY_RECT {
+    fn pending_present_damage(&self) -> PresentDamage {
+        if !ENABLE_DIRTY_RECT {
             // Force full redraw when dirty rect optimization is disabled
             None
         } else if self.full_redraw_needed {
@@ -860,27 +880,65 @@ impl Compositor {
                 Self::push_damage_rect(&mut rects, rect);
             }
             Some(rects)
-        };
+        }
+    }
 
+    fn composite_damage_to_display(
+        &mut self,
+        dirty_rects: &PresentDamage,
+    ) -> Result<(), &'static str> {
         match dirty_rects {
             None => {
-                self.composite_via_framebuffer(None)?;
+                self.composite_via_display(None)?;
             }
             Some(rects) => {
-                for rect in rects {
-                    self.composite_via_framebuffer(Some(rect))?;
+                for rect in rects.iter().copied() {
+                    self.composite_via_display(Some(rect))?;
                 }
             }
         }
 
-        // Flush to display
-        self.framebuffer
-            .flush()
-            .map_err(|_| "Failed to flush framebuffer")?;
-
+        self.cursor.mark_drawn();
         self.full_redraw_needed = false;
         self.pending_damage.clear();
         Ok(())
+    }
+
+    fn present_damage(&self, dirty_rects: PresentDamage) -> Result<(), &'static str> {
+        // Present only the damage SWS actually composed. Legacy framebuffer
+        // clients keep their own full-frame compatibility path.
+        match dirty_rects {
+            None => self
+                .display
+                .present()
+                .map_err(|_| "Failed to present display")?,
+            Some(rects) => {
+                for (x, y, width, height) in rects {
+                    let Some((x, y, width, height)) =
+                        self.clamp_rect_to_screen((x, y, width, height))
+                    else {
+                        continue;
+                    };
+                    self.display
+                        .present_region(x as u32, y as u32, width, height)
+                        .map_err(|_| "Failed to present display region")?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn composite_pending_to_display(&mut self) -> Result<PresentDamage, &'static str> {
+        let dirty_rects = self.pending_present_damage();
+        self.composite_damage_to_display(&dirty_rects)?;
+        Ok(dirty_rects)
+    }
+
+    /// Composite all layers directly to the display backing store.
+    fn composite_and_present(&mut self) -> Result<(), &'static str> {
+        let dirty_rects = self.composite_pending_to_display()?;
+        self.present_damage(dirty_rects)
     }
 
     fn validate_vram_samples(
@@ -1367,7 +1425,7 @@ impl Compositor {
     }
 
     /// Composite into the persistent backbuffer, then present the affected region.
-    fn composite_via_framebuffer(
+    fn composite_via_display(
         &mut self,
         dirty: Option<(i32, i32, u32, u32)>,
     ) -> Result<(), &'static str> {
@@ -1394,7 +1452,6 @@ impl Compositor {
 
         if w == 0 || h == 0 {
             // Nothing to redraw.
-            self.cursor.mark_drawn();
             return Ok(());
         }
 
@@ -1464,22 +1521,18 @@ impl Compositor {
 
             // Layer 3: Draw cursor
             let cursor = &self.cursor;
-            cursor.draw_to_buffer_direct(
+            cursor.draw_to_buffer_direct_clipped(
                 backbuffer,
                 screen_width,
                 screen_height,
                 bytes_per_pixel,
                 stride,
+                clip,
             );
         }
 
         // Validate composition against expected pixels before presenting.
-        self.validate_vram_samples(
-            &self.backbuffer,
-            stride,
-            dirty,
-            "after framebuffer composite",
-        );
+        self.validate_vram_samples(&self.backbuffer, stride, dirty, "after display composite");
 
         // Present only the dirty region when available.
         let src_off = (y0 as usize)
@@ -1490,11 +1543,10 @@ impl Compositor {
         }
         let src = &self.backbuffer[src_off..];
 
-        self.framebuffer
-            .write_block_bgra_strided(x0 as u32, y0 as u32, w, h, src, stride as usize)
+        self.display
+            .write_bgra_strided(x0 as u32, y0 as u32, w, h, src, stride as usize)
             .map_err(|_| "Failed to write backbuffer")?;
 
-        self.cursor.mark_drawn();
         Ok(())
     }
 
@@ -1739,11 +1791,78 @@ impl Compositor {
         self.send_mouse_position_to_window_coords(window_id, window, window_x, window_y);
     }
 
-    fn wait_for_wake(&mut self) {
+    fn wait_for_event_signal(&mut self) {
+        let Ok(stream) = self.wake_read.as_stream() else {
+            return;
+        };
+
         let mut buf = [0u8; 1];
-        if let Ok(stream) = self.wake_read.as_stream() {
-            let _ = stream.read(&mut buf);
+        if stream.read(&mut buf).is_ok() {
+            super::ipc::consume_compositor_wake();
         }
+    }
+
+    fn consume_event_signal_if_ready(&mut self) {
+        let mut handles = [PollHandle::new(self.wake_read.as_raw() as u32, POLLIN)];
+        let Ok(ready) = poll(&mut handles, 0) else {
+            return;
+        };
+        if ready == 0 || (handles[0].revents & POLLIN) == 0 {
+            return;
+        }
+
+        let Ok(stream) = self.wake_read.as_stream() else {
+            return;
+        };
+
+        let mut buf = [0u8; 1];
+        if stream.read(&mut buf).is_ok() {
+            super::ipc::consume_compositor_wake();
+        }
+    }
+
+    fn process_pending_events(&mut self) -> Result<bool, &'static str> {
+        let mut needs_redraw = false;
+
+        if self.check_display_resize()? {
+            needs_redraw = true;
+        }
+
+        // Process IPC events from global queue (non-blocking)
+        let ipc_events = self.ipc_server.process_messages()?;
+        // if !ipc_events.is_empty() {
+        //     println!("[Compositor] Processing {} IPC events", ipc_events.len());
+        // }
+        for event in ipc_events {
+            if self.handle_ipc_event(event)? {
+                needs_redraw = true;
+            }
+        }
+
+        // Process input events from global queue (non-blocking)
+        let input_events = super::input::pop_all_input_events();
+        if !input_events.is_empty() {
+            for event in input_events {
+                if self.handle_input_event(event)? {
+                    needs_redraw = true;
+                }
+            }
+        }
+
+        Ok(needs_redraw)
+    }
+
+    fn has_pending_redraw(&self, needs_redraw: bool) -> bool {
+        needs_redraw
+            || self.full_redraw_needed
+            || !self.pending_damage.is_empty()
+            || self.cursor.needs_redraw()
+    }
+
+    fn wait_for_frame_batch(&mut self) -> Result<bool, &'static str> {
+        thread::sleep(FRAME_BATCH_INTERVAL);
+        self.consume_event_signal_if_ready();
+        self.process_pending_events()
     }
 
     /// Main event loop
@@ -1751,48 +1870,27 @@ impl Compositor {
         println!("[Compositor] Starting main loop (multithreaded)");
 
         loop {
-            let mut needs_redraw = false;
-
-            if self.check_display_resize()? {
-                needs_redraw = true;
-            }
-
-            // Process IPC events from global queue (non-blocking)
-            let ipc_events = self.ipc_server.process_messages()?;
-            // if !ipc_events.is_empty() {
-            //     println!("[Compositor] Processing {} IPC events", ipc_events.len());
-            // }
-            for event in ipc_events {
-                if self.handle_ipc_event(event)? {
-                    needs_redraw = true;
-                }
-            }
-
-            // Process input events from global queue (non-blocking)
-            let input_events = super::input::pop_all_input_events();
-            if !input_events.is_empty() {
-                for event in input_events {
-                    if self.handle_input_event(event)? {
-                        needs_redraw = true;
-                    }
-                }
-            }
+            let mut needs_redraw = self.process_pending_events()?;
 
             // Re-composite and present if needed
-            if needs_redraw
-                || self.full_redraw_needed
-                || !self.pending_damage.is_empty()
-                || self.cursor.needs_redraw()
-            {
+            if self.has_pending_redraw(needs_redraw) {
+                let mut present_damage = self.composite_pending_to_display()?;
+                needs_redraw |= self.wait_for_frame_batch()?;
                 if self.full_redraw_needed && is_sws_debug_enabled() {
                     println!("[Compositor] Full redraw triggered");
                 }
-                self.composite_and_present()?;
+                if self.has_pending_redraw(needs_redraw) {
+                    let next_damage = self.composite_pending_to_display()?;
+                    Self::merge_present_damage(&mut present_damage, next_damage);
+                }
+                self.present_damage(present_damage)?;
                 self.event_counter += 1;
             }
 
-            // Sleep until IPC/input explicitly wakes the compositor.
-            self.wait_for_wake();
+            // Sleep until IPC/input explicitly signals that new work is queued.
+            // Signal writes are coalesced so producers cannot fill the pipe
+            // while the compositor is busy processing a batch.
+            self.wait_for_event_signal();
 
             // Periodically print Z-order (every 100 redraws)
             // if self.event_counter % 100 == 0 && self.event_counter > 0 {

--- a/user/bin/src/sws/cursor.rs
+++ b/user/bin/src/sws/cursor.rs
@@ -5,6 +5,7 @@ use framebuffer::Framebuffer;
 /// Cursor bitmap - simple 0/1/2 format
 const CURSOR_WIDTH: usize = 16;
 const CURSOR_HEIGHT: usize = 24;
+const CURSOR_DAMAGE_PADDING: i32 = 2;
 
 /// Cursor color (white)
 const CURSOR_COLOR: [u8; 4] = [255, 255, 255, 255]; // BGRA
@@ -180,8 +181,30 @@ impl Cursor {
         bytes_per_pixel: u32,
         stride: u32,
     ) {
+        self.draw_to_buffer_direct_clipped(
+            buffer,
+            screen_width,
+            screen_height,
+            bytes_per_pixel,
+            stride,
+            None,
+        );
+    }
+
+    /// Draw cursor directly to a buffer with custom stride and optional clip.
+    pub fn draw_to_buffer_direct_clipped(
+        &self,
+        buffer: &mut [u8],
+        screen_width: u32,
+        screen_height: u32,
+        bytes_per_pixel: u32,
+        stride: u32,
+        clip_rect: Option<(i32, i32, u32, u32)>,
+    ) {
         let cx = self.x;
         let cy = self.y;
+        let clip = clip_rect
+            .map(|(x, y, w, h)| (x, y, x.saturating_add(w as i32), y.saturating_add(h as i32)));
 
         for y in 0..CURSOR_HEIGHT {
             for x in 0..CURSOR_WIDTH {
@@ -212,6 +235,15 @@ impl Cursor {
                         {
                             continue;
                         }
+                        if let Some((clip_x0, clip_y0, clip_x1, clip_y1)) = clip {
+                            if screen_x < clip_x0
+                                || screen_x >= clip_x1
+                                || screen_y < clip_y0
+                                || screen_y >= clip_y1
+                            {
+                                continue;
+                            }
+                        }
 
                         let offset = ((screen_y as u32 * stride)
                             + (screen_x as u32 * bytes_per_pixel))
@@ -236,10 +268,20 @@ impl Cursor {
 
     /// Get the dirty region that needs redrawing (union of prev and current cursor)
     pub fn get_dirty_region(&self) -> (i32, i32, u32, u32) {
-        let min_x = self.prev_x.min(self.x);
-        let min_y = self.prev_y.min(self.y);
-        let max_x = (self.prev_x + self.width as i32).max(self.x + self.width as i32);
-        let max_y = (self.prev_y + self.height as i32).max(self.y + self.height as i32);
+        let min_x = self
+            .prev_x
+            .min(self.x)
+            .saturating_sub(CURSOR_DAMAGE_PADDING);
+        let min_y = self
+            .prev_y
+            .min(self.y)
+            .saturating_sub(CURSOR_DAMAGE_PADDING);
+        let max_x = (self.prev_x + self.width as i32)
+            .max(self.x + self.width as i32)
+            .saturating_add(CURSOR_DAMAGE_PADDING);
+        let max_y = (self.prev_y + self.height as i32)
+            .max(self.y + self.height as i32)
+            .saturating_add(CURSOR_DAMAGE_PADDING);
         (min_x, min_y, (max_x - min_x) as u32, (max_y - min_y) as u32)
     }
 

--- a/user/bin/src/sws/ipc.rs
+++ b/user/bin/src/sws/ipc.rs
@@ -1,6 +1,6 @@
 //! IPC Server module - handles client connections and messages
 
-use core::sync::atomic::{AtomicU8, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::collections::BTreeMap;
 use std::env;
 use std::handle::Handle;
@@ -285,6 +285,7 @@ fn push_input_event_coalesced(events: &mut Vec<PendingInputEvent>, event: Pendin
 
 /// Wake pipe used by worker threads to interrupt the compositor event loop.
 static COMPOSITOR_WAKE_WRITE: Mutex<Option<Handle>> = Mutex::new(None);
+static COMPOSITOR_WAKE_PENDING: AtomicBool = AtomicBool::new(false);
 
 /// Install the compositor wake pipe write handle.
 ///
@@ -298,16 +299,32 @@ pub fn set_compositor_wake_handle(write_handle: Handle) {
 
 /// Wake the compositor if it is sleeping on the wake pipe.
 pub fn wake_compositor() {
+    if COMPOSITOR_WAKE_PENDING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+
     let wake = COMPOSITOR_WAKE_WRITE.lock();
     let Some(handle) = wake.as_ref() else {
+        COMPOSITOR_WAKE_PENDING.store(false, Ordering::Release);
         return;
     };
 
     let Ok(stream) = handle.as_stream() else {
+        COMPOSITOR_WAKE_PENDING.store(false, Ordering::Release);
         return;
     };
 
-    let _ = stream.write(&[1]);
+    if stream.write(&[1]).is_err() {
+        COMPOSITOR_WAKE_PENDING.store(false, Ordering::Release);
+    }
+}
+
+/// Mark the currently pending compositor wake as consumed.
+pub fn consume_compositor_wake() {
+    COMPOSITOR_WAKE_PENDING.store(false, Ordering::Release);
 }
 
 /// Global event queue for IPC events
@@ -450,18 +467,16 @@ fn cleanup_window_state(window_id: u32) {
 /// Queue an input event for a specific window (O(log n) lookup)
 pub fn send_input_to_window(window_id: u32, time: u64, type_: u16, code: u16, value: i32) {
     let mut pending = PENDING_INPUT_EVENTS.lock();
-
-    if let Some(events) = pending.get_mut(&window_id) {
-        push_input_event_coalesced(
-            events,
-            PendingInputEvent {
-                time,
-                type_,
-                code,
-                value,
-            },
-        );
-    }
+    let events = pending.entry(window_id).or_insert_with(Vec::new);
+    push_input_event_coalesced(
+        events,
+        PendingInputEvent {
+            time,
+            type_,
+            code,
+            value,
+        },
+    );
 }
 
 /// Pending extension input events: BTreeMap from (extension_id, external_client_id) to events

--- a/user/lib/framebuffer/src/lib.rs
+++ b/user/lib/framebuffer/src/lib.rs
@@ -74,6 +74,11 @@ pub struct DisplayInfo {
     pub format: u32,
     /// Page-aligned size of the mappable display backing store.
     pub buffer_len: u32,
+    /// Opaque identifier for the current mappable backing store.
+    ///
+    /// This value changes when the display surface's mapped backing changes,
+    /// even if `buffer_len` remains the same.
+    pub backing_id: usize,
 }
 
 /// Region argument for DISPLAY_PRESENT_REGION.
@@ -273,6 +278,7 @@ pub struct Framebuffer {
 pub struct DisplaySurface {
     file: File,
     mapped_buffer: Option<(usize, usize)>,
+    mapped_backing_id: usize,
 }
 
 impl DisplaySurface {
@@ -299,6 +305,7 @@ impl DisplaySurface {
         let mut display = Self {
             file,
             mapped_buffer: None,
+            mapped_backing_id: 0,
         };
         let _ = display.setup_mmap();
         Ok(display)
@@ -322,6 +329,7 @@ impl DisplaySurface {
             )
             .map_err(|_| HandleError::SystemError(-1))?;
         self.mapped_buffer = Some((mapped_addr, info.buffer_len as usize));
+        self.mapped_backing_id = info.backing_id;
         Ok(())
     }
 
@@ -535,13 +543,16 @@ impl DisplaySurface {
     pub fn refresh_mapping(&mut self) -> HandleResult<()> {
         let info = self.get_info()?;
         let new_size = info.buffer_len as usize;
-        if matches!(self.mapped_buffer, Some((_, mapped_size)) if mapped_size == new_size) {
+        if matches!(self.mapped_buffer, Some((_, mapped_size)) if mapped_size == new_size)
+            && self.mapped_backing_id == info.backing_id
+        {
             return Ok(());
         }
 
         if let Some((mapped_addr, mapped_size)) = self.mapped_buffer.take() {
             let _ = munmap(mapped_addr, mapped_size);
         }
+        self.mapped_backing_id = 0;
 
         match self.setup_mmap() {
             Ok(()) => Ok(()),

--- a/user/lib/framebuffer/src/lib.rs
+++ b/user/lib/framebuffer/src/lib.rs
@@ -31,6 +31,65 @@ pub mod commands {
     pub const FBIO_FLUSH: u32 = 0x4620;
 }
 
+/// Scarlet display surface control command constants.
+pub mod display_commands {
+    /// Get display surface information.
+    pub const DISPLAY_GET_INFO: u32 = 0x5000;
+    /// Present the whole display surface.
+    pub const DISPLAY_PRESENT: u32 = 0x5001;
+    /// Present a display surface region.
+    pub const DISPLAY_PRESENT_REGION: u32 = 0x5002;
+}
+
+/// 32-bit RGBA pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_RGBA8888: u32 = 1;
+/// 32-bit BGRA pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_BGRA8888: u32 = 2;
+/// 32-bit XRGB pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_XRGB8888: u32 = 3;
+/// 32-bit XBGR pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_XBGR8888: u32 = 4;
+/// 32-bit XRGB2101010 pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_XRGB2101010: u32 = 5;
+/// 24-bit RGB pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_RGB888: u32 = 6;
+/// 16-bit RGB565 pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_RGB565: u32 = 7;
+/// 16-bit ARGB1555 pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_ARGB1555: u32 = 8;
+/// 16-bit XRGB1555 pixel layout.
+pub const DISPLAY_PIXEL_FORMAT_XRGB1555: u32 = 9;
+
+/// Display surface information.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DisplayInfo {
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+    /// Bytes per row.
+    pub stride: u32,
+    /// Pixel format, one of `DISPLAY_PIXEL_FORMAT_*`.
+    pub format: u32,
+    /// Page-aligned size of the mappable display backing store.
+    pub buffer_len: u32,
+}
+
+/// Region argument for DISPLAY_PRESENT_REGION.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DisplayPresentRegion {
+    /// Left edge in pixels.
+    pub x: u32,
+    /// Top edge in pixels.
+    pub y: u32,
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+}
+
 /// Color bit field information
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
@@ -204,6 +263,428 @@ pub struct Framebuffer {
     /// Memory-mapped framebuffer buffer (address, size)
     mapped_buffer: Option<(usize, usize)>,
     mapped_physical_addr: Option<usize>,
+}
+
+/// Modern display surface wrapper.
+///
+/// This type opens `/dev/displayX` scanout endpoints. The current
+/// implementation is CPU-composited and mappable, but presentation is explicit
+/// and region-based instead of relying on legacy `/dev/fbX` semantics.
+pub struct DisplaySurface {
+    file: File,
+    mapped_buffer: Option<(usize, usize)>,
+}
+
+impl DisplaySurface {
+    /// Open the primary display surface.
+    ///
+    /// # Returns
+    ///
+    /// Display surface instance or HandleError on failure.
+    pub fn open_primary() -> HandleResult<Self> {
+        Self::open("/dev/display0")
+    }
+
+    /// Open a display surface.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the display device (e.g., "/dev/display0").
+    ///
+    /// # Returns
+    ///
+    /// Display surface instance or HandleError on failure.
+    pub fn open(path: &str) -> HandleResult<Self> {
+        let file = File::open(path).map_err(|_| HandleError::NotFound)?;
+        let mut display = Self {
+            file,
+            mapped_buffer: None,
+        };
+        let _ = display.setup_mmap();
+        Ok(display)
+    }
+
+    fn setup_mmap(&mut self) -> HandleResult<()> {
+        let info = self.get_info()?;
+        if info.buffer_len == 0 {
+            return Err(HandleError::InvalidParameter);
+        }
+
+        let handle = self.file.as_handle();
+        let mapper = handle.as_memory_mapping()?;
+        let mapped_addr = mapper
+            .mmap(
+                0,
+                info.buffer_len as usize,
+                prot::READ | prot::WRITE,
+                flags::SHARED,
+                0,
+            )
+            .map_err(|_| HandleError::SystemError(-1))?;
+        self.mapped_buffer = Some((mapped_addr, info.buffer_len as usize));
+        Ok(())
+    }
+
+    fn display_bytes_per_pixel(format: u32) -> usize {
+        match format {
+            DISPLAY_PIXEL_FORMAT_RGBA8888
+            | DISPLAY_PIXEL_FORMAT_BGRA8888
+            | DISPLAY_PIXEL_FORMAT_XRGB8888
+            | DISPLAY_PIXEL_FORMAT_XBGR8888
+            | DISPLAY_PIXEL_FORMAT_XRGB2101010 => 4,
+            DISPLAY_PIXEL_FORMAT_RGB888 => 3,
+            DISPLAY_PIXEL_FORMAT_RGB565
+            | DISPLAY_PIXEL_FORMAT_ARGB1555
+            | DISPLAY_PIXEL_FORMAT_XRGB1555 => 2,
+            _ => 0,
+        }
+    }
+
+    fn display_info_to_var_info(info: DisplayInfo) -> FbVarScreenInfo {
+        let mut var_info = FbVarScreenInfo {
+            xres: info.width,
+            yres: info.height,
+            xres_virtual: info.width,
+            yres_virtual: info.height,
+            bits_per_pixel: (Self::display_bytes_per_pixel(info.format) * 8) as u32,
+            ..FbVarScreenInfo::default()
+        };
+
+        match info.format {
+            DISPLAY_PIXEL_FORMAT_RGBA8888 => {
+                var_info.red = FbBitfield {
+                    offset: 0,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 8,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 16,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 24,
+                    length: 8,
+                    msb_right: 0,
+                };
+            }
+            DISPLAY_PIXEL_FORMAT_BGRA8888 | DISPLAY_PIXEL_FORMAT_XBGR8888 => {
+                var_info.blue = FbBitfield {
+                    offset: 0,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 8,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.red = FbBitfield {
+                    offset: 16,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 24,
+                    length: if info.format == DISPLAY_PIXEL_FORMAT_BGRA8888 {
+                        8
+                    } else {
+                        0
+                    },
+                    msb_right: 0,
+                };
+            }
+            DISPLAY_PIXEL_FORMAT_XRGB8888 => {
+                var_info.red = FbBitfield {
+                    offset: 0,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 8,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 16,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 24,
+                    length: 0,
+                    msb_right: 0,
+                };
+            }
+            DISPLAY_PIXEL_FORMAT_RGB888 => {
+                var_info.red = FbBitfield {
+                    offset: 0,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 8,
+                    length: 8,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 16,
+                    length: 8,
+                    msb_right: 0,
+                };
+            }
+            DISPLAY_PIXEL_FORMAT_RGB565 => {
+                var_info.red = FbBitfield {
+                    offset: 11,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 5,
+                    length: 6,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 0,
+                    length: 5,
+                    msb_right: 0,
+                };
+            }
+            DISPLAY_PIXEL_FORMAT_ARGB1555 | DISPLAY_PIXEL_FORMAT_XRGB1555 => {
+                var_info.red = FbBitfield {
+                    offset: 10,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.green = FbBitfield {
+                    offset: 5,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.blue = FbBitfield {
+                    offset: 0,
+                    length: 5,
+                    msb_right: 0,
+                };
+                var_info.transp = FbBitfield {
+                    offset: 15,
+                    length: if info.format == DISPLAY_PIXEL_FORMAT_ARGB1555 {
+                        1
+                    } else {
+                        0
+                    },
+                    msb_right: 0,
+                };
+            }
+            _ => {}
+        }
+
+        var_info
+    }
+
+    /// Get display surface information.
+    ///
+    /// # Returns
+    ///
+    /// Display surface information or HandleError on failure.
+    pub fn get_info(&self) -> HandleResult<DisplayInfo> {
+        let mut info = DisplayInfo::default();
+        self.file.as_handle().control(
+            display_commands::DISPLAY_GET_INFO,
+            &mut info as *mut DisplayInfo as usize,
+        )?;
+        Ok(info)
+    }
+
+    /// Get variable screen information from the display surface.
+    ///
+    /// # Returns
+    ///
+    /// Variable screen information or HandleError on failure.
+    pub fn get_var_screen_info(&self) -> HandleResult<FbVarScreenInfo> {
+        Ok(Self::display_info_to_var_info(self.get_info()?))
+    }
+
+    /// Get fixed screen information from the display surface.
+    ///
+    /// # Returns
+    ///
+    /// Fixed screen information or HandleError on failure.
+    pub fn get_fix_screen_info(&self) -> HandleResult<FbFixScreenInfo> {
+        let info = self.get_info()?;
+        let mut fix_info = FbFixScreenInfo::default();
+        let id = b"display";
+        fix_info.id[..id.len()].copy_from_slice(id);
+        fix_info.smem_len = info.buffer_len;
+        fix_info.line_length = info.stride;
+        fix_info.type_ = 0;
+        fix_info.visual = 2;
+        Ok(fix_info)
+    }
+
+    /// Refresh the display memory mapping if the kernel reports a new backing store.
+    ///
+    /// # Returns
+    ///
+    /// Success or HandleError on failure.
+    pub fn refresh_mapping(&mut self) -> HandleResult<()> {
+        let info = self.get_info()?;
+        let new_size = info.buffer_len as usize;
+        if matches!(self.mapped_buffer, Some((_, mapped_size)) if mapped_size == new_size) {
+            return Ok(());
+        }
+
+        if let Some((mapped_addr, mapped_size)) = self.mapped_buffer.take() {
+            let _ = munmap(mapped_addr, mapped_size);
+        }
+
+        match self.setup_mmap() {
+            Ok(()) => Ok(()),
+            Err(_) => Ok(()),
+        }
+    }
+
+    /// Get memory mapping information if available.
+    ///
+    /// # Returns
+    ///
+    /// Mapping address and size if memory mapping is active.
+    pub fn get_mapping_info(&self) -> Option<(usize, usize)> {
+        self.mapped_buffer
+    }
+
+    /// Present the whole display surface.
+    ///
+    /// # Returns
+    ///
+    /// Success or HandleError on failure.
+    pub fn present(&self) -> HandleResult<()> {
+        self.file
+            .as_handle()
+            .control(display_commands::DISPLAY_PRESENT, 0)?;
+        Ok(())
+    }
+
+    /// Present a display surface region.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - Left edge in pixels.
+    /// * `y` - Top edge in pixels.
+    /// * `width` - Width in pixels.
+    /// * `height` - Height in pixels.
+    ///
+    /// # Returns
+    ///
+    /// Success or HandleError on failure.
+    pub fn present_region(&self, x: u32, y: u32, width: u32, height: u32) -> HandleResult<()> {
+        if width == 0 || height == 0 {
+            return Ok(());
+        }
+
+        let region = DisplayPresentRegion {
+            x,
+            y,
+            width,
+            height,
+        };
+        self.file.as_handle().control(
+            display_commands::DISPLAY_PRESENT_REGION,
+            &region as *const DisplayPresentRegion as usize,
+        )?;
+        Ok(())
+    }
+
+    /// Write BGRA source data into a display surface region.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - Destination left edge in pixels.
+    /// * `y` - Destination top edge in pixels.
+    /// * `width` - Region width in pixels.
+    /// * `height` - Region height in pixels.
+    /// * `data` - Source BGRA pixel bytes.
+    /// * `src_stride_bytes` - Source row stride in bytes.
+    ///
+    /// # Returns
+    ///
+    /// Success or HandleError on failure.
+    pub fn write_bgra_strided(
+        &mut self,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+        data: &[u8],
+        src_stride_bytes: usize,
+    ) -> HandleResult<()> {
+        if width == 0 || height == 0 {
+            return Ok(());
+        }
+
+        let info = self.get_info()?;
+        if info.format != DISPLAY_PIXEL_FORMAT_BGRA8888 {
+            return Err(HandleError::InvalidParameter);
+        }
+        if x >= info.width || y >= info.height {
+            return Err(HandleError::InvalidParameter);
+        }
+        if x.saturating_add(width) > info.width || y.saturating_add(height) > info.height {
+            return Err(HandleError::InvalidParameter);
+        }
+
+        let line_length = info.stride as usize;
+        let dst_bytes_per_pixel = 4usize;
+        let src_line_bytes = width as usize * 4;
+        if src_stride_bytes < src_line_bytes {
+            return Err(HandleError::InvalidParameter);
+        }
+        let required = (height as usize - 1)
+            .saturating_mul(src_stride_bytes)
+            .saturating_add(src_line_bytes);
+        if required > data.len() {
+            return Err(HandleError::InvalidParameter);
+        }
+
+        if let Some((mapped_addr, mapped_size)) = self.mapped_buffer {
+            for row in 0..height as usize {
+                let dst_off = (y as usize + row)
+                    .saturating_mul(line_length)
+                    .saturating_add(x as usize * dst_bytes_per_pixel);
+                let src_off = row.saturating_mul(src_stride_bytes);
+                if dst_off.saturating_add(src_line_bytes) > mapped_size {
+                    return Err(HandleError::InvalidParameter);
+                }
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        data[src_off..src_off + src_line_bytes].as_ptr(),
+                        (mapped_addr + dst_off) as *mut u8,
+                        src_line_bytes,
+                    );
+                }
+            }
+        } else {
+            for row in 0..height as usize {
+                let dst_off = (y as usize + row)
+                    .saturating_mul(line_length)
+                    .saturating_add(x as usize * dst_bytes_per_pixel);
+                let src_off = row.saturating_mul(src_stride_bytes);
+                self.file
+                    .seek(SeekFrom::Start(dst_off as u64))
+                    .map_err(|_| HandleError::SystemError(-1))?;
+                self.file
+                    .write(&data[src_off..src_off + src_line_bytes])
+                    .map_err(|_| HandleError::SystemError(-1))?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Framebuffer {
@@ -1061,5 +1542,13 @@ impl Drop for Framebuffer {
             let _ = munmap(mapped_addr, mapped_size);
         }
         self.mapped_physical_addr = None;
+    }
+}
+
+impl Drop for DisplaySurface {
+    fn drop(&mut self) {
+        if let Some((mapped_addr, mapped_size)) = self.mapped_buffer {
+            let _ = munmap(mapped_addr, mapped_size);
+        }
     }
 }

--- a/user/lib/scarlet-ui/src/platform/sws.rs
+++ b/user/lib/scarlet-ui/src/platform/sws.rs
@@ -496,8 +496,6 @@ impl PlatformWindow for SWSPlatformWindow {
                 let dst_data =
                     unsafe { core::slice::from_raw_parts_mut(shm_buf.as_mut_ptr(), shm_len) };
 
-                dst_data.fill(0);
-
                 let src_width = buffer.width() as usize;
                 let src_height = buffer.height() as usize;
                 let dst_width = width as usize;
@@ -517,6 +515,25 @@ impl PlatformWindow for SWSPlatformWindow {
                     let len = (src_end - src_offset).min(dst_end - dst_offset);
                     dst_data[dst_offset..dst_offset + len]
                         .copy_from_slice(&src_data[src_offset..src_offset + len]);
+                }
+
+                if copy_width < dst_width {
+                    for y in 0..copy_height {
+                        let row_start = y
+                            .saturating_mul(dst_width)
+                            .saturating_add(copy_width)
+                            .saturating_mul(4);
+                        let row_end = y.saturating_add(1).saturating_mul(dst_width).saturating_mul(4);
+                        if row_start < row_end && row_end <= dst_data.len() {
+                            dst_data[row_start..row_end].fill(0);
+                        }
+                    }
+                }
+                if copy_height < dst_height {
+                    let clear_start = copy_height.saturating_mul(dst_width).saturating_mul(4);
+                    if clear_start < dst_data.len() {
+                        dst_data[clear_start..].fill(0);
+                    }
                 }
             });
         }


### PR DESCRIPTION
This pull request significantly refactors the legacy framebuffer (`/dev/fb0`) compatibility path in the kernel's graphics subsystem. The changes introduce robust tracking of framebuffer mappings, implement one-shot dirty tracking and flushing for legacy framebuffer writes, and ensure proper synchronization and protection of framebuffer memory. Additionally, the documentation is updated to clarify the distinction between the modern display surface API and the legacy framebuffer path.

The most important changes are:

**Legacy Framebuffer Compatibility Path Overhaul:**

* Introduced `FramebufferMapping` and `FbCompatDirtyState` structs to accurately track per-task framebuffer mappings and dirty state for `/dev/fb0` compatibility. Added a `FbCompatFlushHandler` to manage one-shot timer-based flushing of dirty regions, replacing the previous mock/test mapping logic. [[1]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417L225-R253) [[2]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417L244-R272) [[3]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417R294-R312) [[4]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417R323-R342)
* Implemented logic to mark the framebuffer as dirty on writes or store faults, arm a 16ms one-shot timer, and trigger a full-frame flush with write protection when the timer expires. This matches the intended legacy behavior and ensures efficient updates. [[1]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417R390-R600) [[2]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417R776-R779) [[3]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417L576-R863) [[4]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417R872-R916) [[5]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417L925-R1251)
* Enhanced the memory mapping and page fault handling for `/dev/fb0` to ensure correct permissions and synchronization, including write-protecting mappings after flushes and handling explicit `FBIO_FLUSH` commands. [[1]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417L576-R863) [[2]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417R872-R916) [[3]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417L925-R1251)

**API and Documentation Improvements:**

* Added comprehensive documentation (`docs/display_present.md`) explaining the two display presentation paths: the modern `DisplaySurface` API and the legacy `/dev/fb0` compatibility path, including their synchronization and memory protection semantics.

**Graphics Device and Resource Management:**

* Updated `FramebufferResource` to track both the created `/dev/fbX` and `/dev/displayX` device IDs, and modified the graphics manager to create and log both device types. [[1]](diffhunk://#diff-7c998f6a66aadf3de1bd2d6e9007c119ecd9ac13c1e2d03fa149f21c6cb5b413R58-R59) [[2]](diffhunk://#diff-7c998f6a66aadf3de1bd2d6e9007c119ecd9ac13c1e2d03fa149f21c6cb5b413R78) [[3]](diffhunk://#diff-7c998f6a66aadf3de1bd2d6e9007c119ecd9ac13c1e2d03fa149f21c6cb5b413R295-R307)

**Testing and Internal Consistency:**

* Adjusted tests and internal data structures to use the new mapping keys and tracking logic, ensuring correctness for multi-task scenarios and robust unmapping behavior. [[1]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417R1642) [[2]](diffhunk://#diff-7ac4329fe6dfe6d9f0ec74028fe8d7bdcb62c5c69097659df3145e80bba71417L1582-R1915)

These changes modernize the legacy framebuffer compatibility layer, making it safer, more efficient, and better integrated with the rest of the display stack.