### PR TITLE
interrupt: define shared IRQ source lifecycle

### DIFF
--- a/kernel/src/device/events.rs
+++ b/kernel/src/device/events.rs
@@ -130,6 +130,30 @@ impl DeviceEvent for ErrorEvent {
 ///
 /// Devices that can handle interrupts must implement this trait.
 pub trait InterruptCapableDevice: Send + Sync {
+    /// Handle an interrupt delivered to this device.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when interrupt processing completed successfully.
     fn handle_interrupt(&self) -> crate::interrupt::InterruptResult<()>;
+
+    /// Return the interrupt line associated with this device.
+    ///
+    /// # Returns
+    ///
+    /// The virtual IRQ number for this device, or `None` before registration.
     fn interrupt_id(&self) -> Option<crate::interrupt::InterruptId>;
+
+    /// Try to claim a shared interrupt line for this device.
+    ///
+    /// # Returns
+    ///
+    /// `Handled` when this device owned and cleared the interrupt, or `NotMine`
+    /// when another source asserted the shared line.
+    fn claim_interrupt(
+        &self,
+    ) -> crate::interrupt::InterruptResult<crate::interrupt::InterruptClaim> {
+        self.handle_interrupt()?;
+        Ok(crate::interrupt::InterruptClaim::Handled)
+    }
 }

--- a/kernel/src/device/pci/intx.rs
+++ b/kernel/src/device/pci/intx.rs
@@ -1,0 +1,105 @@
+//! PCI INTx interrupt source support.
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+
+use super::PciAddress;
+use super::config::{self, PciConfig};
+use super::device::PciDeviceInfo;
+use crate::device::events::InterruptCapableDevice;
+use crate::interrupt::{
+    InterruptClaim, InterruptId, InterruptResult, InterruptSource, MaskableInterruptSource,
+};
+
+/// Maskable interrupt source for a PCI legacy INTx function.
+pub struct PciIntxInterruptSource {
+    config: PciConfig,
+    address: PciAddress,
+    interrupt_id: InterruptId,
+    handler: Arc<dyn InterruptCapableDevice>,
+}
+
+impl PciIntxInterruptSource {
+    /// Create a PCI INTx interrupt source for a device.
+    ///
+    /// # Arguments
+    ///
+    /// * `device` - PCI function that provides the legacy INTx line.
+    /// * `handler` - Device interrupt handler for this function.
+    ///
+    /// # Returns
+    ///
+    /// A maskable INTx source, or `None` when the function has no usable legacy
+    /// interrupt routing.
+    pub fn new(device: &PciDeviceInfo, handler: Arc<dyn InterruptCapableDevice>) -> Option<Self> {
+        let interrupt_id = Self::interrupt_id_for_device(device)?;
+        Some(Self {
+            config: PciConfig::new(device.ecam_vaddr()),
+            address: device.address(),
+            interrupt_id,
+            handler,
+        })
+    }
+
+    /// Resolve the legacy INTx virtual IRQ for a PCI function.
+    ///
+    /// # Arguments
+    ///
+    /// * `device` - PCI function whose routing should be resolved.
+    ///
+    /// # Returns
+    ///
+    /// The routed virtual IRQ, or `None` when INTx is not usable.
+    pub fn interrupt_id_for_device(device: &PciDeviceInfo) -> Option<InterruptId> {
+        if device.interrupt_pin() == 0 {
+            return None;
+        }
+
+        device.routed_irq().or_else(|| {
+            let line = device.interrupt_line();
+            (line != 0 && line != 0xff).then_some(line as InterruptId)
+        })
+    }
+
+    fn set_masked(&self, masked: bool) {
+        let command = self.config.read_u16(&self.address, config::offset::COMMAND);
+        let next = if masked {
+            command | config::command::INTERRUPT_DISABLE
+        } else {
+            command & !config::command::INTERRUPT_DISABLE
+        };
+
+        if next != command {
+            self.config
+                .write_u16(&self.address, config::offset::COMMAND, next);
+        }
+    }
+}
+
+impl InterruptSource for PciIntxInterruptSource {
+    fn interrupt_id(&self) -> Option<InterruptId> {
+        Some(self.interrupt_id)
+    }
+
+    fn claim_interrupt(&self) -> InterruptResult<InterruptClaim> {
+        self.handler.claim_interrupt()
+    }
+}
+
+impl MaskableInterruptSource for PciIntxInterruptSource {
+    fn mask_source(&self) -> InterruptResult<()> {
+        self.set_masked(true);
+        Ok(())
+    }
+
+    fn unmask_source(&self) -> InterruptResult<()> {
+        self.set_masked(false);
+        Ok(())
+    }
+
+    fn clear_pending_source(&self) -> InterruptResult<()> {
+        let _ = self.handler.claim_interrupt()?;
+        Ok(())
+    }
+}

--- a/kernel/src/device/pci/mod.rs
+++ b/kernel/src/device/pci/mod.rs
@@ -49,6 +49,7 @@
 pub mod config;
 pub mod device;
 pub mod driver;
+pub mod intx;
 pub mod scan;
 
 extern crate alloc;

--- a/kernel/src/drivers/network/virtio_net.rs
+++ b/kernel/src/drivers/network/virtio_net.rs
@@ -35,7 +35,7 @@ use crate::device::{Device, DeviceType};
 use crate::drivers::virtio::features::VIRTIO_F_ANY_LAYOUT;
 use crate::drivers::virtio::features::VIRTIO_RING_F_INDIRECT_DESC;
 use crate::environment::PAGE_SIZE;
-use crate::interrupt::InterruptId;
+use crate::interrupt::{InterruptClaim, InterruptId};
 use crate::mem::page::ContiguousPages;
 use crate::network::config::apply_pending_ip_for_interface;
 use crate::network::ethernet_interface::EthernetNetworkInterface;
@@ -683,16 +683,25 @@ impl ControlOps for VirtioNetDevice {
 
 impl InterruptCapableDevice for VirtioNetDevice {
     fn handle_interrupt(&self) -> crate::interrupt::InterruptResult<()> {
+        let _ = self.claim_interrupt()?;
+        Ok(())
+    }
+
+    fn interrupt_id(&self) -> Option<InterruptId> {
+        self.interrupt_id.lock().clone()
+    }
+
+    fn claim_interrupt(&self) -> crate::interrupt::InterruptResult<InterruptClaim> {
         let isr = self.read32_register(Register::InterruptStatus);
         if isr == 0 {
-            return Ok(());
+            return Ok(InterruptClaim::NotMine);
         }
         // crate::println!("[virtio-net] Interrupt received, ISR=0x{:x}", isr);
         self.write32_register(Register::InterruptAck, isr & 0x03);
 
         let packets = self.process_received_packets().unwrap_or_default();
         if packets.is_empty() {
-            return Ok(());
+            return Ok(InterruptClaim::Handled);
         }
 
         if let Some(name) = self.interface_name.lock().clone() {
@@ -706,11 +715,7 @@ impl InterruptCapableDevice for VirtioNetDevice {
             crate::println!("[virtio-net] No interface name set!");
         }
 
-        Ok(())
-    }
-
-    fn interrupt_id(&self) -> Option<InterruptId> {
-        self.interrupt_id.lock().clone()
+        Ok(InterruptClaim::Handled)
     }
 }
 

--- a/kernel/src/drivers/uart/pl011.rs
+++ b/kernel/src/drivers/uart/pl011.rs
@@ -19,7 +19,7 @@ use crate::{
         },
     },
     driver_initcall,
-    interrupt::InterruptId,
+    interrupt::{InterruptClaim, InterruptId},
     object::capability::{ControlOps, MemoryMappingOps, Selectable},
 };
 
@@ -264,7 +264,19 @@ impl EventCapableDevice for Pl011Uart {
 
 impl InterruptCapableDevice for Pl011Uart {
     fn handle_interrupt(&self) -> crate::interrupt::InterruptResult<()> {
+        let _ = self.claim_interrupt()?;
+        Ok(())
+    }
+
+    fn interrupt_id(&self) -> Option<InterruptId> {
+        self.interrupt_id.read().clone()
+    }
+
+    fn claim_interrupt(&self) -> crate::interrupt::InterruptResult<InterruptClaim> {
         let ris = self.reg_read(UARTRIS);
+        if ris == 0 {
+            return Ok(InterruptClaim::NotMine);
+        }
 
         self.reg_write(UARTICR, 0x7FF);
 
@@ -275,11 +287,7 @@ impl InterruptCapableDevice for Pl011Uart {
             }
         }
 
-        Ok(())
-    }
-
-    fn interrupt_id(&self) -> Option<InterruptId> {
-        self.interrupt_id.read().clone()
+        Ok(InterruptClaim::Handled)
     }
 }
 

--- a/kernel/src/drivers/uart/virt.rs
+++ b/kernel/src/drivers/uart/virt.rs
@@ -18,7 +18,7 @@ use crate::{
         },
     },
     driver_initcall,
-    interrupt::InterruptId,
+    interrupt::{InterruptClaim, InterruptId},
     object::capability::{ControlOps, MemoryMappingOps, Selectable},
 };
 
@@ -271,18 +271,25 @@ impl EventCapableDevice for Uart {
 
 impl InterruptCapableDevice for Uart {
     fn handle_interrupt(&self) -> crate::interrupt::InterruptResult<()> {
-        let iir = self.reg_read(IIR_OFFSET);
-        if iir & IIR_PENDING == 0 {
-            let cause = iir & 0x0E;
-            if cause == IIR_RDA {
-                self.drain_rx();
-            }
-        }
+        let _ = self.claim_interrupt()?;
         Ok(())
     }
 
     fn interrupt_id(&self) -> Option<InterruptId> {
         self.interrupt_id.read().clone()
+    }
+
+    fn claim_interrupt(&self) -> crate::interrupt::InterruptResult<InterruptClaim> {
+        let iir = self.reg_read(IIR_OFFSET);
+        if iir & IIR_PENDING != 0 {
+            return Ok(InterruptClaim::NotMine);
+        }
+
+        let cause = iir & 0x0E;
+        if cause == IIR_RDA {
+            self.drain_rx();
+        }
+        Ok(InterruptClaim::Handled)
     }
 }
 

--- a/kernel/src/drivers/usb/xhci/mod.rs
+++ b/kernel/src/drivers/usb/xhci/mod.rs
@@ -26,6 +26,7 @@ use crate::device::manager::{DeviceManager, DriverPriority};
 use crate::device::pci::config::{self, PciConfig};
 use crate::device::pci::device::PciDeviceInfo;
 use crate::device::pci::driver::{PciDeviceDriver, PciDeviceId};
+use crate::device::pci::intx::PciIntxInterruptSource;
 use crate::device::usb::UsbHostController;
 use crate::driver_initcall;
 use crate::drivers::usb::core::descriptor::{
@@ -45,7 +46,7 @@ use crate::drivers::usb::xhci::registers::{RegisterSpace, capability, operationa
 use crate::drivers::usb::xhci::ring::{DmaTrbRing, EventRing};
 use crate::drivers::usb::xhci::trb::{Trb, TrbType};
 use crate::early_println;
-use crate::interrupt::InterruptId;
+use crate::interrupt::{InterruptClaim, InterruptId, InterruptManager};
 use crate::mem::page::ContiguousPages;
 use crate::timer::{TimerHandler, add_timer, get_tick, ms_to_ticks};
 use crate::vm;
@@ -547,9 +548,7 @@ impl XhciController {
             );
         }
 
-        crate::interrupt::InterruptManager::global()
-            .enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
-            .map_err(|_| "Failed to enable xHCI interrupt")
+        Ok(())
     }
 
     fn ring_command_doorbell(&self) {
@@ -1415,9 +1414,18 @@ impl TimerHandler for XhciPollHandler {
 
 impl InterruptCapableDevice for XhciController {
     fn handle_interrupt(&self) -> crate::interrupt::InterruptResult<()> {
+        let _ = self.claim_interrupt()?;
+        Ok(())
+    }
+
+    fn interrupt_id(&self) -> Option<InterruptId> {
+        *self.interrupt_id.lock()
+    }
+
+    fn claim_interrupt(&self) -> crate::interrupt::InterruptResult<InterruptClaim> {
         let status = self.operational.read_usbsts();
         if status & (USBSTS_EVENT_INTERRUPT | USBSTS_PORT_CHANGE_DETECT) == 0 {
-            return Ok(());
+            return Ok(InterruptClaim::NotMine);
         }
 
         self.operational
@@ -1431,19 +1439,11 @@ impl InterruptCapableDevice for XhciController {
         }
 
         self.process_interrupt_events();
-        Ok(())
-    }
-
-    fn interrupt_id(&self) -> Option<InterruptId> {
-        *self.interrupt_id.lock()
+        Ok(InterruptClaim::Handled)
     }
 }
 
-/// Probe function for xHCI PCI devices
-pub fn bind_xhci_mmio(
-    mmio_vaddr: usize,
-    interrupt: Option<InterruptId>,
-) -> Result<(), &'static str> {
+fn initialize_xhci_controller(mmio_vaddr: usize) -> Result<Arc<XhciController>, &'static str> {
     early_println!("[xHCI] Binding platform xHCI at {:#x}", mmio_vaddr);
 
     let controller = Arc::new(XhciController::new(mmio_vaddr)?);
@@ -1456,16 +1456,10 @@ pub fn bind_xhci_mmio(
         Err(error) => early_println!("[xHCI] Enumeration deferred: {}", error),
     }
 
-    if let Some(interrupt_id) = interrupt {
-        controller.enable_interrupts(interrupt_id)?;
-        crate::interrupt::InterruptManager::global()
-            .register_interrupt_device(interrupt_id, controller.clone())
-            .map_err(|_| "Failed to register xHCI interrupt device")?;
-        early_println!("[xHCI] Registered IRQ {}", interrupt_id);
-    } else {
-        early_println!("[xHCI] No interrupt provided for platform controller");
-    }
+    Ok(controller)
+}
 
+fn register_xhci_host(controller: Arc<XhciController>) {
     let host_id = NEXT_USB_HOST_ID.fetch_add(1, Ordering::SeqCst) as u32;
     let host: Arc<dyn UsbHostController> = controller.clone();
     DeviceManager::get_manager().register_usb_host(host_id, host);
@@ -1474,6 +1468,29 @@ pub fn bind_xhci_mmio(
     add_timer(get_tick() + ms_to_ticks(1000), &poll_handler, 0);
 
     early_println!("[xHCI] Platform controller registered successfully");
+}
+
+/// Probe function for xHCI PCI devices
+pub fn bind_xhci_mmio(
+    mmio_vaddr: usize,
+    interrupt: Option<InterruptId>,
+) -> Result<(), &'static str> {
+    let controller = initialize_xhci_controller(mmio_vaddr)?;
+
+    if let Some(interrupt_id) = interrupt {
+        InterruptManager::global()
+            .register_interrupt_device(interrupt_id, controller.clone())
+            .map_err(|_| "Failed to register xHCI interrupt device")?;
+        InterruptManager::global()
+            .enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
+            .map_err(|_| "Failed to enable xHCI interrupt")?;
+        controller.enable_interrupts(interrupt_id)?;
+        early_println!("[xHCI] Registered IRQ {}", interrupt_id);
+    } else {
+        early_println!("[xHCI] No interrupt provided for platform controller");
+    }
+
+    register_xhci_host(controller);
     Ok(())
 }
 
@@ -1492,7 +1509,7 @@ fn probe_xhci(device: &PciDeviceInfo) -> Result<(), &'static str> {
     config.write_u16(
         &addr,
         config::offset::COMMAND,
-        (command | config::command::BUS_MASTER) & !config::command::INTERRUPT_DISABLE,
+        command | config::command::BUS_MASTER | config::command::INTERRUPT_DISABLE,
     );
     early_println!("[xHCI] Bus mastering enabled");
 
@@ -1501,7 +1518,7 @@ fn probe_xhci(device: &PciDeviceInfo) -> Result<(), &'static str> {
     config.write_u16(
         &addr,
         config::offset::COMMAND,
-        (command | config::command::MEMORY_SPACE) & !config::command::INTERRUPT_DISABLE,
+        command | config::command::MEMORY_SPACE | config::command::INTERRUPT_DISABLE,
     );
     early_println!("[xHCI] Memory access enabled");
 
@@ -1552,7 +1569,23 @@ fn probe_xhci(device: &PciDeviceInfo) -> Result<(), &'static str> {
         None
     };
 
-    bind_xhci_mmio(mmio_vaddr, interrupt_id)
+    let controller = initialize_xhci_controller(mmio_vaddr)?;
+
+    if let Some(interrupt_id) = interrupt_id {
+        controller.enable_interrupts(interrupt_id)?;
+        let source = PciIntxInterruptSource::new(device, controller.clone())
+            .ok_or("Failed to create xHCI INTx source")?;
+        let source: Arc<dyn crate::interrupt::MaskableInterruptSource> = Arc::new(source);
+        InterruptManager::global()
+            .register_and_enable_interrupt_source(source, crate::arch::get_cpu().get_cpuid() as u32)
+            .map_err(|_| "Failed to register xHCI interrupt device")?;
+        early_println!("[xHCI] Registered IRQ {}", interrupt_id);
+    } else {
+        early_println!("[xHCI] No usable legacy IRQ routing for controller");
+    }
+
+    register_xhci_host(controller);
+    Ok(())
 }
 
 /// Remove function for xHCI PCI devices

--- a/kernel/src/drivers/virtio/pci.rs
+++ b/kernel/src/drivers/virtio/pci.rs
@@ -18,6 +18,7 @@ use crate::device::manager::{DeviceManager, DriverPriority};
 use crate::device::pci::config::{self, PciConfig, capability, command, status, vendor};
 use crate::device::pci::device::PciDeviceInfo;
 use crate::device::pci::driver::{PciDeviceDriver, PciDeviceId};
+use crate::device::pci::intx::PciIntxInterruptSource;
 use crate::driver_initcall;
 use crate::drivers::block::virtio_blk::VirtioBlockDevice;
 use crate::drivers::graphics::virtio_gpu::VirtioGpuDevice;
@@ -281,7 +282,7 @@ fn enable_pci_device(config: &PciConfig, device: &PciDeviceInfo) {
     config.write_u16(
         &addr,
         config::offset::COMMAND,
-        (command_bits | command::MEMORY_SPACE | command::BUS_MASTER) & !command::INTERRUPT_DISABLE,
+        command_bits | command::MEMORY_SPACE | command::BUS_MASTER | command::INTERRUPT_DISABLE,
     );
 }
 
@@ -289,33 +290,16 @@ fn register_legacy_intx(
     device: &PciDeviceInfo,
     handler: Arc<dyn crate::device::events::InterruptCapableDevice>,
 ) -> Option<InterruptId> {
-    let interrupt_pin = device.interrupt_pin();
-    let interrupt_id = device.routed_irq().or_else(|| {
-        let line = device.interrupt_line();
-        (line != 0 && line != 0xff).then_some(line as InterruptId)
-    })?;
-
-    if interrupt_pin == 0 {
-        return None;
-    }
+    let interrupt_id = PciIntxInterruptSource::interrupt_id_for_device(device)?;
+    let source = PciIntxInterruptSource::new(device, handler)?;
+    let source: Arc<dyn crate::interrupt::MaskableInterruptSource> = Arc::new(source);
 
     let manager = InterruptManager::global();
-    if let Err(e) = manager.register_interrupt_device(interrupt_id, handler) {
-        early_println!(
-            "[virtio-pci] Failed to register INTx IRQ {} for {:02x}:{:02x}.{}: {:?}",
-            interrupt_id,
-            device.address().bus,
-            device.address().device,
-            device.address().function,
-            e
-        );
-        return None;
-    }
-    if let Err(e) =
-        manager.enable_external_interrupt(interrupt_id, crate::arch::get_cpu().get_cpuid() as u32)
+    if let Err(e) = manager
+        .register_and_enable_interrupt_source(source, crate::arch::get_cpu().get_cpuid() as u32)
     {
         early_println!(
-            "[virtio-pci] Failed to enable INTx IRQ {} for {:02x}:{:02x}.{}: {:?}",
+            "[virtio-pci] Failed to register and enable INTx IRQ {} for {:02x}:{:02x}.{}: {:?}",
             interrupt_id,
             device.address().bus,
             device.address().device,
@@ -328,7 +312,7 @@ fn register_legacy_intx(
     early_println!(
         "[virtio-pci] Registered INTx IRQ {} pin {} for {:02x}:{:02x}.{}",
         interrupt_id,
-        interrupt_pin,
+        device.interrupt_pin(),
         device.address().bus,
         device.address().device,
         device.address().function

--- a/kernel/src/drivers/virtio_input.rs
+++ b/kernel/src/drivers/virtio_input.rs
@@ -23,6 +23,7 @@ use crate::drivers::virtio::device::{DeviceStatus, Register, VirtioDevice};
 use crate::drivers::virtio::queue::{DescriptorFlag, VirtQueue};
 use crate::early_println;
 use crate::environment::PAGE_SIZE;
+use crate::interrupt::InterruptClaim;
 use crate::mem::page::ContiguousPages;
 
 /// VirtIO Input event structure (matches Linux virtio_input_event)
@@ -550,10 +551,19 @@ mod tests {
 // Implement InterruptCapableDevice for VirtioInputDevice
 impl crate::device::events::InterruptCapableDevice for VirtioInputDevice {
     fn handle_interrupt(&self) -> crate::interrupt::InterruptResult<()> {
+        let _ = self.claim_interrupt()?;
+        Ok(())
+    }
+
+    fn interrupt_id(&self) -> Option<crate::interrupt::InterruptId> {
+        *self.interrupt_id.lock()
+    }
+
+    fn claim_interrupt(&self) -> crate::interrupt::InterruptResult<InterruptClaim> {
         // Read ISR status to acknowledge interrupt
         let isr_status = self.read32_register(Register::InterruptStatus);
         if isr_status == 0 {
-            return Ok(());
+            return Ok(InterruptClaim::NotMine);
         }
 
         // Acknowledge the interrupt
@@ -562,10 +572,6 @@ impl crate::device::events::InterruptCapableDevice for VirtioInputDevice {
         // Process pending events
         self.process_events();
 
-        Ok(())
-    }
-
-    fn interrupt_id(&self) -> Option<crate::interrupt::InterruptId> {
-        *self.interrupt_id.lock()
+        Ok(InterruptClaim::Handled)
     }
 }

--- a/kernel/src/drivers/virtio_video.rs
+++ b/kernel/src/drivers/virtio_video.rs
@@ -21,7 +21,7 @@ use crate::drivers::virtio::{
     queue::{DescriptorFlag, VirtQueue},
 };
 use crate::environment::PAGE_SIZE;
-use crate::interrupt::InterruptId;
+use crate::interrupt::{InterruptClaim, InterruptId};
 use crate::library::std::usercopy::{copy_from_user, copy_to_user};
 use crate::mem::page::ContiguousPages;
 use crate::object::capability::selectable::{ReadyInterest, SelectWaitOutcome, Selectable};
@@ -1777,20 +1777,25 @@ impl Selectable for VirtioVideoDevice {
 
 impl crate::device::events::InterruptCapableDevice for VirtioVideoDevice {
     fn handle_interrupt(&self) -> crate::interrupt::InterruptResult<()> {
+        let _ = self.claim_interrupt()?;
+        Ok(())
+    }
+
+    fn interrupt_id(&self) -> Option<InterruptId> {
+        *self.interrupt_id.lock()
+    }
+
+    fn claim_interrupt(&self) -> crate::interrupt::InterruptResult<InterruptClaim> {
         let isr_status = self.read32_register(Register::InterruptStatus);
         if isr_status == 0 {
-            return Ok(());
+            return Ok(InterruptClaim::NotMine);
         }
 
         self.write32_register(Register::InterruptAck, isr_status);
         if let Err(e) = self.try_complete_pending_decode() {
             self.decoded_frame.lock().last_error = Some(e);
         }
-        Ok(())
-    }
-
-    fn interrupt_id(&self) -> Option<InterruptId> {
-        *self.interrupt_id.lock()
+        Ok(InterruptClaim::Handled)
     }
 }
 

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -72,6 +72,23 @@ pub fn register_and_enable_platform_irq_device(
     InterruptManager::global().register_and_enable_platform_irq_device(resource, device, cpu_id)
 }
 
+/// Register and enable a maskable interrupt source in lifecycle-safe order.
+///
+/// # Arguments
+///
+/// * `source` - Maskable interrupt source to register.
+/// * `cpu_id` - CPU that should receive the interrupt.
+///
+/// # Returns
+///
+/// The virtual IRQ assigned to the source.
+pub fn register_and_enable_interrupt_source(
+    source: Arc<dyn MaskableInterruptSource>,
+    cpu_id: CpuId,
+) -> InterruptResult<InterruptId> {
+    InterruptManager::global().register_and_enable_interrupt_source(source, cpu_id)
+}
+
 /// Allocate MSI/MSI-X vectors from the active external interrupt controller.
 ///
 /// # Arguments
@@ -88,12 +105,95 @@ pub fn allocate_msi_vectors(
     InterruptManager::global().allocate_msi_vectors(request)
 }
 
-/// Handler function type for external interrupts
-pub type ExternalInterruptHandler = fn(&mut InterruptHandle) -> InterruptResult<()>;
+/// Handler function type for external interrupts.
+pub type ExternalInterruptHandler = fn(&mut InterruptHandle) -> InterruptResult<InterruptClaim>;
 
 /// Handler function type for local interrupts (timer, software)
 pub type LocalInterruptHandler =
     fn(cpu_id: CpuId, interrupt_type: controllers::LocalInterruptType) -> InterruptResult<()>;
+
+/// Result of asking an interrupt source to claim a shared interrupt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterruptClaim {
+    /// The source owned and cleared this interrupt.
+    Handled,
+    /// The source did not assert this shared interrupt line.
+    NotMine,
+}
+
+impl InterruptClaim {
+    /// Check whether this claim handled the interrupt.
+    ///
+    /// # Returns
+    ///
+    /// `true` when the interrupt source claimed and cleared the interrupt.
+    pub const fn is_handled(self) -> bool {
+        matches!(self, Self::Handled)
+    }
+}
+
+/// Interrupt source that can participate in shared IRQ dispatch.
+pub trait InterruptSource: Send + Sync {
+    /// Return the interrupt line this source is attached to.
+    ///
+    /// # Returns
+    ///
+    /// The virtual IRQ number for this source, or `None` when it has not been
+    /// attached yet.
+    fn interrupt_id(&self) -> Option<InterruptId>;
+
+    /// Try to claim and clear this source's interrupt cause.
+    ///
+    /// # Returns
+    ///
+    /// `Handled` when this source owned the interrupt and cleared its device-side
+    /// cause, or `NotMine` when another source on the shared line asserted it.
+    fn claim_interrupt(&self) -> InterruptResult<InterruptClaim>;
+}
+
+/// Interrupt source whose device-side assertion can be masked independently.
+pub trait MaskableInterruptSource: InterruptSource {
+    /// Mask this source before registering or reconfiguring it.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when the source can no longer assert its interrupt line.
+    fn mask_source(&self) -> InterruptResult<()>;
+
+    /// Unmask this source after its handler and controller line are ready.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when the source may assert its interrupt line again.
+    fn unmask_source(&self) -> InterruptResult<()>;
+
+    /// Clear stale pending device-side interrupt state while the source is masked.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when any pending cause that can be cleared has been drained.
+    fn clear_pending_source(&self) -> InterruptResult<()>;
+}
+
+struct InterruptDeviceSource {
+    device: Arc<dyn crate::device::events::InterruptCapableDevice>,
+}
+
+impl InterruptDeviceSource {
+    fn new(device: Arc<dyn crate::device::events::InterruptCapableDevice>) -> Self {
+        Self { device }
+    }
+}
+
+impl InterruptSource for InterruptDeviceSource {
+    fn interrupt_id(&self) -> Option<InterruptId> {
+        self.device.interrupt_id()
+    }
+
+    fn claim_interrupt(&self) -> InterruptResult<InterruptClaim> {
+        self.device.claim_interrupt()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct IrqDesc {
@@ -105,14 +205,9 @@ pub struct InterruptManager {
     irq_descs: spin::Lazy<spin::Mutex<HashMap<Virq, IrqDesc>>>,
     external_handlers: spin::Lazy<spin::Mutex<HashMap<InterruptId, ExternalInterruptHandler>>>,
     enabled_external_interrupts: spin::Lazy<spin::Mutex<HashMap<InterruptId, CpuId>>>,
-    interrupt_devices: spin::Lazy<
-        spin::Mutex<
-            HashMap<
-                InterruptId,
-                alloc::vec::Vec<Arc<dyn crate::device::events::InterruptCapableDevice>>,
-            >,
-        >,
-    >,
+    interrupt_sources:
+        spin::Lazy<spin::Mutex<HashMap<InterruptId, alloc::vec::Vec<Arc<dyn InterruptSource>>>>>,
+    unhandled_external_interrupts: spin::Lazy<spin::Mutex<HashMap<InterruptId, usize>>>,
 }
 
 impl InterruptManager {
@@ -122,7 +217,8 @@ impl InterruptManager {
             irq_descs: spin::Lazy::new(|| spin::Mutex::new(HashMap::new())),
             external_handlers: spin::Lazy::new(|| spin::Mutex::new(HashMap::new())),
             enabled_external_interrupts: spin::Lazy::new(|| spin::Mutex::new(HashMap::new())),
-            interrupt_devices: spin::Lazy::new(|| spin::Mutex::new(HashMap::new())),
+            interrupt_sources: spin::Lazy::new(|| spin::Mutex::new(HashMap::new())),
+            unhandled_external_interrupts: spin::Lazy::new(|| spin::Mutex::new(HashMap::new())),
         }
     }
 
@@ -254,6 +350,27 @@ impl InterruptManager {
         }
     }
 
+    fn record_unhandled_external_interrupt(&self, interrupt_id: InterruptId) -> usize {
+        let mut counts = self.unhandled_external_interrupts.lock();
+        let count = counts.entry(interrupt_id).or_insert(0);
+        *count += 1;
+        *count
+    }
+
+    fn clear_unhandled_external_interrupt_count(&self, interrupt_id: InterruptId) {
+        self.unhandled_external_interrupts
+            .lock()
+            .remove(&interrupt_id);
+    }
+
+    fn unhandled_external_interrupt_count(&self, interrupt_id: InterruptId) -> usize {
+        self.unhandled_external_interrupts
+            .lock()
+            .get(&interrupt_id)
+            .copied()
+            .unwrap_or(0)
+    }
+
     fn handle_pending_irq(&self, pending: controllers::PendingIrq) -> InterruptResult<()> {
         self.register_irq_mapping(pending.mapping);
         {
@@ -266,16 +383,45 @@ impl InterruptManager {
         }
 
         let interrupt_id = pending.mapping.virq;
-        let device = {
-            let devices = self.interrupt_devices.lock();
-            devices.get(&interrupt_id).cloned()
+        let sources = {
+            let sources = self.interrupt_sources.lock();
+            sources.get(&interrupt_id).cloned()
         };
 
-        if let Some(devices) = device {
-            for device in devices {
-                device.handle_interrupt()?;
+        if let Some(sources) = sources {
+            let mut handled = false;
+            let mut first_error = None;
+            for source in sources {
+                match source.claim_interrupt() {
+                    Ok(claim) => handled |= claim.is_handled(),
+                    Err(error) => {
+                        if first_error.is_none() {
+                            first_error = Some(error);
+                        }
+                    }
+                }
             }
-            self.finish_pending_irq(&pending)
+
+            if handled {
+                self.clear_unhandled_external_interrupt_count(interrupt_id);
+            } else {
+                let count = self.record_unhandled_external_interrupt(interrupt_id);
+                if count == 1 || count.is_power_of_two() {
+                    crate::early_println!(
+                        "[interrupt] IRQ {} was not claimed by any registered source (count={})",
+                        interrupt_id,
+                        count
+                    );
+                }
+            }
+
+            let finish_result = self.finish_pending_irq(&pending);
+            if let Some(error) = first_error {
+                finish_result?;
+                Err(error)
+            } else {
+                finish_result
+            }
         } else {
             let handler = {
                 let handlers = self.external_handlers.lock();
@@ -284,7 +430,20 @@ impl InterruptManager {
 
             if let Some(handler_fn) = handler {
                 let mut handle = InterruptHandle::new_pending(pending);
-                handler_fn(&mut handle)
+                let claim = handler_fn(&mut handle)?;
+                if claim.is_handled() {
+                    self.clear_unhandled_external_interrupt_count(interrupt_id);
+                } else {
+                    let count = self.record_unhandled_external_interrupt(interrupt_id);
+                    if count == 1 || count.is_power_of_two() {
+                        crate::early_println!(
+                            "[interrupt] IRQ {} was not claimed by its registered handler (count={})",
+                            interrupt_id,
+                            count
+                        );
+                    }
+                }
+                Ok(())
             } else {
                 self.finish_pending_irq(&pending)
             }
@@ -512,10 +671,73 @@ impl InterruptManager {
         interrupt_id: InterruptId,
         device: Arc<dyn crate::device::events::InterruptCapableDevice>,
     ) -> InterruptResult<()> {
+        self.register_interrupt_source(interrupt_id, Arc::new(InterruptDeviceSource::new(device)))
+    }
+
+    /// Register an interrupt source on a virtual IRQ.
+    ///
+    /// # Arguments
+    ///
+    /// * `interrupt_id` - Virtual IRQ to dispatch to this source.
+    /// * `source` - Source to call when the IRQ is delivered.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when the source is registered.
+    pub fn register_interrupt_source(
+        &self,
+        interrupt_id: InterruptId,
+        source: Arc<dyn InterruptSource>,
+    ) -> InterruptResult<()> {
+        if let Some(source_interrupt_id) = source.interrupt_id()
+            && source_interrupt_id != interrupt_id
+        {
+            return Err(InterruptError::InvalidInterruptId);
+        }
+
         self.irq_desc_or_legacy(interrupt_id);
-        let mut devices = self.interrupt_devices.lock();
-        devices.entry(interrupt_id).or_default().push(device);
+        let mut sources = self.interrupt_sources.lock();
+        sources.entry(interrupt_id).or_default().push(source);
         Ok(())
+    }
+
+    /// Register and enable a maskable interrupt source in lifecycle-safe order.
+    ///
+    /// The guaranteed order is:
+    ///
+    /// 1. mask the source;
+    /// 2. clear stale pending source state;
+    /// 3. register the source with the interrupt manager;
+    /// 4. enable the interrupt controller line;
+    /// 5. unmask the source.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - Maskable interrupt source to register.
+    /// * `cpu_id` - CPU that should receive the interrupt.
+    ///
+    /// # Returns
+    ///
+    /// The virtual IRQ assigned to the source.
+    pub fn register_and_enable_interrupt_source(
+        &self,
+        source: Arc<dyn MaskableInterruptSource>,
+        cpu_id: CpuId,
+    ) -> InterruptResult<InterruptId> {
+        source.mask_source()?;
+        source.clear_pending_source()?;
+        let interrupt_id = source
+            .interrupt_id()
+            .ok_or(InterruptError::InvalidInterruptId)?;
+        self.register_interrupt_source(interrupt_id, source.clone())?;
+        self.enable_external_interrupt(interrupt_id, cpu_id)?;
+
+        if let Err(error) = source.unmask_source() {
+            let _ = self.disable_external_interrupt(interrupt_id, cpu_id);
+            return Err(error);
+        }
+
+        Ok(interrupt_id)
     }
 
     pub fn register_platform_interrupt_device(
@@ -843,6 +1065,7 @@ pub fn enable_cpu_interrupts() {
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
     use alloc::vec;
     use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -854,6 +1077,141 @@ mod tests {
     struct FakeMsiController {
         result: Result<controllers::MsiAllocation, msi::MsiError>,
         calls: AtomicUsize,
+    }
+
+    struct FakeExternalController {
+        events: Arc<spin::Mutex<Vec<&'static str>>>,
+    }
+
+    impl FakeExternalController {
+        fn new(events: Arc<spin::Mutex<Vec<&'static str>>>) -> Self {
+            Self { events }
+        }
+    }
+
+    impl controllers::ExternalInterruptController for FakeExternalController {
+        fn init(&mut self) -> InterruptResult<()> {
+            Ok(())
+        }
+
+        fn enable_interrupt(
+            &self,
+            _interrupt_id: InterruptId,
+            _cpu_id: CpuId,
+        ) -> InterruptResult<()> {
+            self.events.lock().push("controller-enable");
+            Ok(())
+        }
+
+        fn disable_interrupt(
+            &self,
+            _interrupt_id: InterruptId,
+            _cpu_id: CpuId,
+        ) -> InterruptResult<()> {
+            self.events.lock().push("controller-disable");
+            Ok(())
+        }
+
+        fn set_priority(
+            &mut self,
+            _interrupt_id: InterruptId,
+            _priority: Priority,
+        ) -> InterruptResult<()> {
+            Ok(())
+        }
+
+        fn get_priority(&self, _interrupt_id: InterruptId) -> InterruptResult<Priority> {
+            Ok(0)
+        }
+
+        fn set_threshold(&mut self, _cpu_id: CpuId, _threshold: Priority) -> InterruptResult<()> {
+            Ok(())
+        }
+
+        fn get_threshold(&self, _cpu_id: CpuId) -> InterruptResult<Priority> {
+            Ok(0)
+        }
+
+        fn claim_interrupt(&self, _cpu_id: CpuId) -> InterruptResult<Option<InterruptId>> {
+            Ok(None)
+        }
+
+        fn complete_interrupt(
+            &self,
+            _cpu_id: CpuId,
+            _interrupt_id: InterruptId,
+        ) -> InterruptResult<()> {
+            self.events.lock().push("controller-eoi");
+            Ok(())
+        }
+
+        fn is_pending(&self, _interrupt_id: InterruptId) -> bool {
+            false
+        }
+
+        fn max_interrupts(&self) -> InterruptId {
+            256
+        }
+
+        fn max_cpus(&self) -> CpuId {
+            4
+        }
+
+        fn ack_irq(&self, _irq: &controllers::PendingIrq) -> InterruptResult<()> {
+            self.events.lock().push("controller-ack");
+            Ok(())
+        }
+    }
+
+    struct FakeInterruptSource {
+        interrupt_id: InterruptId,
+        claim: InterruptClaim,
+        event_name: &'static str,
+        events: Arc<spin::Mutex<Vec<&'static str>>>,
+    }
+
+    impl FakeInterruptSource {
+        fn new(
+            interrupt_id: InterruptId,
+            claim: InterruptClaim,
+            event_name: &'static str,
+            events: Arc<spin::Mutex<Vec<&'static str>>>,
+        ) -> Self {
+            Self {
+                interrupt_id,
+                claim,
+                event_name,
+                events,
+            }
+        }
+    }
+
+    impl InterruptSource for FakeInterruptSource {
+        fn interrupt_id(&self) -> Option<InterruptId> {
+            Some(self.interrupt_id)
+        }
+
+        fn claim_interrupt(&self) -> InterruptResult<InterruptClaim> {
+            self.events.lock().push(self.event_name);
+            Ok(self.claim)
+        }
+    }
+
+    impl MaskableInterruptSource for FakeInterruptSource {
+        fn mask_source(&self) -> InterruptResult<()> {
+            self.events.lock().push("source-mask");
+            Ok(())
+        }
+
+        fn unmask_source(&self) -> InterruptResult<()> {
+            self.events.lock().push("source-unmask");
+            Ok(())
+        }
+
+        fn clear_pending_source(&self) -> InterruptResult<()> {
+            self.events.lock().push("source-clear");
+            Ok(())
+        }
     }
 
     impl FakeMsiController {
@@ -957,5 +1315,106 @@ mod tests {
         assert_eq!(first.calls(), 1);
         assert_eq!(second.calls(), 1);
         assert_eq!(allocation.vectors[0].virq, 80);
+    }
+
+    #[test_case]
+    fn test_shared_interrupt_sources_all_claim_before_controller_eoi() {
+        let events = Arc::new(spin::Mutex::new(Vec::new()));
+        let manager = InterruptManager::new();
+        manager
+            .register_external_controller(Box::new(FakeExternalController::new(events.clone())))
+            .expect("fake external controller should register");
+        manager
+            .register_interrupt_source(
+                42,
+                Arc::new(FakeInterruptSource::new(
+                    42,
+                    InterruptClaim::NotMine,
+                    "source-a",
+                    events.clone(),
+                )),
+            )
+            .expect("first source should register");
+        manager
+            .register_interrupt_source(
+                42,
+                Arc::new(FakeInterruptSource::new(
+                    42,
+                    InterruptClaim::Handled,
+                    "source-b",
+                    events.clone(),
+                )),
+            )
+            .expect("second source should register");
+
+        manager
+            .handle_external_interrupt(42, 0)
+            .expect("shared IRQ should dispatch");
+
+        assert_eq!(
+            events.lock().as_slice(),
+            ["controller-ack", "source-a", "source-b", "controller-eoi"]
+        );
+        assert_eq!(manager.unhandled_external_interrupt_count(42), 0);
+    }
+
+    #[test_case]
+    fn test_unclaimed_shared_interrupt_is_counted_and_eoi_still_runs() {
+        let events = Arc::new(spin::Mutex::new(Vec::new()));
+        let manager = InterruptManager::new();
+        manager
+            .register_external_controller(Box::new(FakeExternalController::new(events.clone())))
+            .expect("fake external controller should register");
+        manager
+            .register_interrupt_source(
+                43,
+                Arc::new(FakeInterruptSource::new(
+                    43,
+                    InterruptClaim::NotMine,
+                    "source-a",
+                    events.clone(),
+                )),
+            )
+            .expect("source should register");
+
+        manager
+            .handle_external_interrupt(43, 0)
+            .expect("unclaimed IRQ should still finish at controller");
+
+        assert_eq!(
+            events.lock().as_slice(),
+            ["controller-ack", "source-a", "controller-eoi"]
+        );
+        assert_eq!(manager.unhandled_external_interrupt_count(43), 1);
+    }
+
+    #[test_case]
+    fn test_register_and_enable_interrupt_source_orders_mask_clear_enable_unmask() {
+        let events = Arc::new(spin::Mutex::new(Vec::new()));
+        let manager = InterruptManager::new();
+        manager
+            .register_external_controller(Box::new(FakeExternalController::new(events.clone())))
+            .expect("fake external controller should register");
+
+        let source = Arc::new(FakeInterruptSource::new(
+            44,
+            InterruptClaim::Handled,
+            "source-claim",
+            events.clone(),
+        ));
+        let interrupt_id = manager
+            .register_and_enable_interrupt_source(source, 0)
+            .expect("source lifecycle should complete");
+
+        assert_eq!(interrupt_id, 44);
+        assert_eq!(
+            events.lock().as_slice(),
+            [
+                "source-mask",
+                "source-clear",
+                "controller-enable",
+                "source-unmask"
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add shared interrupt source claims with `Handled` / `NotMine`
- add lifecycle-safe registration for maskable interrupt sources
- route PCI INTx through a maskable source wrapper and keep INTx masked until registration is complete
- update virtio, xHCI, and UART interrupt handlers to report `NotMine` on shared lines

Closes #489

## Validation

- `cargo make test-riscv64`
- `cargo make test-aarch64`
- `git diff --check`