### PR TITLE
vm: add declarative memory attributes

### DIFF
--- a/kernel/src/abi/linux/device/kvm/mod.rs
+++ b/kernel/src/abi/linux/device/kvm/mod.rs
@@ -256,7 +256,7 @@ impl MemoryMappingOps for KvmCreatedDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("KVM device does not support mmap")
     }
 
@@ -1410,7 +1410,7 @@ impl MemoryMappingOps for KvmSystemDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by KVM system device")
     }
 

--- a/kernel/src/abi/linux/generic/mm.rs
+++ b/kernel/src/abi/linux/generic/mm.rs
@@ -175,6 +175,7 @@ pub fn sys_mmap(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
             vm_start: final_vaddr,
             permissions: final_permissions,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: Some(owner),
         };
 
@@ -207,11 +208,11 @@ pub fn sys_mmap(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
         return final_vaddr;
     }
 
-    // Shared path: need get_mapping_info_with for pmarea and permissions
+    // Shared path: need get_mapping_info_with for pmarea, permissions, and memory attribute.
     let mut ok_len = aligned_length;
-    let (mapping_base, obj_permissions, _obj_is_shared) = loop {
+    let mapping_info = loop {
         match memory_mappable.get_mapping_info_with(offset, ok_len, is_shared) {
-            Ok(info) => break info,
+            Ok(info) => break Some(info),
             Err(_e) => {
                 if ok_len >= PAGE_SIZE {
                     ok_len -= PAGE_SIZE;
@@ -219,24 +220,23 @@ pub fn sys_mmap(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
                     ok_len = 0;
                 }
                 if ok_len == 0 {
-                    break (0, 0, false);
+                    break None;
                 }
             }
         }
     };
-    let paddr = if mapping_base != 0 && is_direct_mapped(mapping_base) {
-        virt_to_phys(mapping_base)
+    let Some(mapping_info) = mapping_info else {
+        return to_result(errno::EINVAL);
+    };
+    let paddr = if mapping_info.paddr != 0 && is_direct_mapped(mapping_info.paddr) {
+        virt_to_phys(mapping_info.paddr)
     } else {
-        mapping_base
+        mapping_info.paddr
     };
 
-    final_permissions = obj_permissions & prot_mask;
+    final_permissions = mapping_info.permissions & prot_mask;
     if prot != 0 {
         final_permissions |= 0x08;
-    }
-
-    if paddr == 0 && ok_len == 0 {
-        return to_result(errno::EINVAL);
     }
 
     let ok_len_aligned = (ok_len / PAGE_SIZE) * PAGE_SIZE;
@@ -251,7 +251,8 @@ pub fn sys_mmap(abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
         .handle_table
         .get_arc_clone(handle)
         .and_then(|obj| obj.as_memory_mappable_arc());
-    let vm_map = VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner);
+    let vm_map = VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner)
+        .with_memory_attribute(mapping_info.memory_attribute);
 
     let map_result = if is_fixed {
         task.vm_manager
@@ -367,6 +368,7 @@ fn handle_anonymous_mapping(
         vm_start: final_vaddr,
         permissions,
         is_shared,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: Some(owner),
     };
 
@@ -446,8 +448,8 @@ pub fn sys_mprotect(_abi: &mut LinuxAbi, trapframe: &mut Trapframe) -> usize {
 
         if let Some(owner) = &original_mapping.owner {
             let offset = page_addr - original_mapping.vmarea.start;
-            if let Ok((_, obj_permissions, _)) = owner.get_mapping_info(offset, PAGE_SIZE) {
-                if (new_permissions & obj_permissions) != (new_permissions & 0x7) {
+            if let Ok(info) = owner.get_mapping_info(offset, PAGE_SIZE) {
+                if (new_permissions & info.permissions) != (new_permissions & 0x7) {
                     return usize::MAX;
                 }
             }

--- a/kernel/src/abi/xv6/drivers/console.rs
+++ b/kernel/src/abi/xv6/drivers/console.rs
@@ -112,7 +112,7 @@ impl MemoryMappingOps for ConsoleDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by console device")
     }
 

--- a/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
+++ b/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
@@ -11,8 +11,9 @@ use core::arch::asm;
 use core::result::Result;
 
 use crate::arch::vm::new_raw_pagetable;
-use crate::environment::{IOREMAP_END, IOREMAP_START, PAGE_SIZE};
+use crate::environment::PAGE_SIZE;
 use crate::vm::addr::{phys_to_virt, virt_to_phys};
+use crate::vm::vmem::MemoryAttribute;
 use crate::vm::vmem::VirtualMemoryMap;
 use crate::vm::vmem::VirtualMemoryPermission;
 
@@ -37,11 +38,11 @@ const MAX_BLOCK_LEVEL: usize = 2;
 
 /// Attributes carried while installing a mapping.
 ///
-/// Currently this only stores Scarlet virtual-memory permissions, but keeping
-/// the attributes bundled makes the level-specific mapping path explicit.
+/// Keeping the attributes bundled makes the level-specific mapping path explicit.
 #[derive(Clone, Copy)]
 struct MapAttrs {
     permissions: usize,
+    memory_attribute: MemoryAttribute,
 }
 
 /// Returns the page size represented by a logical page-table level.
@@ -287,14 +288,6 @@ pub enum Shareability {
     InnerShareable = 0b11,
 }
 
-/// Memory attribute indices for MAIR_EL1
-#[repr(u8)]
-pub enum MemoryAttribute {
-    Device = 0,
-    Normal = 1,
-    NonCacheable = 2,
-}
-
 /// Page table structure aligned to 4KB
 #[repr(align(4096))]
 #[derive(Debug)]
@@ -423,6 +416,7 @@ impl PageTable {
 
         let attrs = MapAttrs {
             permissions: mmap.permissions,
+            memory_attribute: mmap.memory_attribute,
         };
         let mut vaddr = mmap.vmarea.start;
         let mut paddr = mmap.pmarea.start;
@@ -481,8 +475,17 @@ impl PageTable {
         let vaddr = vaddr & !0xfff;
         let paddr = paddr & !0xfff;
 
-        self.try_map_at_level(asid, vaddr, paddr, MapAttrs { permissions }, 0)
-            .expect("map: couldn't install a 4 KiB leaf mapping");
+        self.try_map_at_level(
+            asid,
+            vaddr,
+            paddr,
+            MapAttrs {
+                permissions,
+                memory_attribute: MemoryAttribute::Normal,
+            },
+            0,
+        )
+        .expect("map: couldn't install a 4 KiB leaf mapping");
 
         // Publish new mappings to all PEs that may run this address space.
         unsafe { asm!("dsb ishst", "tlbi vmalle1is", "dsb ish", "isb") };
@@ -515,7 +518,13 @@ impl PageTable {
             return Err("Cannot replace existing page table with a leaf");
         }
 
-        let entry = Self::make_leaf_entry(vaddr, paddr, attrs.permissions, level);
+        let entry = Self::make_leaf_entry(
+            vaddr,
+            paddr,
+            attrs.permissions,
+            level,
+            attrs.memory_attribute,
+        );
         pte.set_entry(entry);
 
         // Ensure the updated PTE is visible to the hardware table walker.
@@ -533,18 +542,24 @@ impl PageTable {
     /// Level 0 uses a page descriptor (`0b11`); levels 1 and 2 use block
     /// descriptors (`0b01`). Permission, memory type, shareability, and execute
     /// attributes are encoded from the mapping request.
-    fn make_leaf_entry(vaddr: usize, paddr: usize, permissions: usize, level: usize) -> u64 {
+    fn make_leaf_entry(
+        vaddr: usize,
+        paddr: usize,
+        permissions: usize,
+        level: usize,
+        memory_attribute: MemoryAttribute,
+    ) -> u64 {
         let is_user = VirtualMemoryPermission::User.contained_in(permissions);
-        let is_device = !is_user && (IOREMAP_START..=IOREMAP_END).contains(&vaddr);
-        let memory_attr = if is_device {
-            MemoryAttribute::Device as u64
-        } else {
-            MemoryAttribute::Normal as u64
+        let memory_attr = match memory_attribute {
+            MemoryAttribute::Normal => 1,
+            MemoryAttribute::NonCacheable => 2,
+            MemoryAttribute::Device => 0,
         };
-        let shareability = if is_device {
-            Shareability::OuterShareable as u64
-        } else {
-            Shareability::InnerShareable as u64
+        let shareability = match memory_attribute {
+            MemoryAttribute::Device => Shareability::OuterShareable as u64,
+            MemoryAttribute::Normal | MemoryAttribute::NonCacheable => {
+                Shareability::InnerShareable as u64
+            }
         };
 
         let mut entry = 0u64;
@@ -582,7 +597,7 @@ impl PageTable {
                 paddr,
                 permissions,
                 is_user,
-                is_device,
+                memory_attribute == MemoryAttribute::Device,
                 entry,
             );
         }
@@ -952,6 +967,55 @@ mod tests {
         );
         let pte = page_table.walk(0xffff_ffff_8000_0000, false, 1).unwrap();
         assert_eq!(pte.entry & 0xfff, 0x707);
+    }
+
+    #[test_case]
+    fn test_leaf_encoding_uses_declared_memory_attribute() {
+        let asid = alloc_virtual_address_space();
+        let root = crate::arch::vm::get_root_pagetable(asid).expect("root page table not found");
+        let vaddr = 0x4100_0000;
+        let paddr = 0x8100_0000;
+        let mmap = VirtualMemoryMap::new(
+            MemoryArea::new(paddr, paddr + PAGE_SIZE - 1),
+            MemoryArea::new(vaddr, vaddr + PAGE_SIZE - 1),
+            VirtualMemoryPermission::Read as usize
+                | VirtualMemoryPermission::Write as usize
+                | VirtualMemoryPermission::User as usize,
+            true,
+            None,
+        )
+        .with_memory_attribute(crate::vm::vmem::MemoryAttribute::NonCacheable);
+
+        root.map_memory_area(asid, mmap, true, true)
+            .expect("non-cacheable mapping failed");
+
+        let pte = root
+            .walk_to_level(vaddr, 0, false, asid)
+            .expect("leaf PTE not found");
+        assert_eq!((pte.entry >> 2) & 0b111, 2);
+
+        free_virtual_address_space(asid);
+    }
+
+    #[test_case]
+    fn test_leaf_encoding_does_not_infer_device_from_ioremap_va() {
+        let normal_entry = PageTable::make_leaf_entry(
+            crate::environment::IOREMAP_START,
+            0x8100_0000,
+            VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+            0,
+            MemoryAttribute::Normal,
+        );
+        assert_eq!((normal_entry >> 2) & 0b111, 1);
+
+        let device_entry = PageTable::make_leaf_entry(
+            0x4200_0000,
+            0x8200_0000,
+            VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+            0,
+            MemoryAttribute::Device,
+        );
+        assert_eq!((device_entry >> 2) & 0b111, 0);
     }
 
     #[test_case]

--- a/kernel/src/arch/aarch64/vm/mod.rs
+++ b/kernel/src/arch/aarch64/vm/mod.rs
@@ -274,6 +274,7 @@ fn setup_trampoline_at_end(manager: &VirtualMemoryManager, trampoline_vaddr_end:
             | VirtualMemoryPermission::Write as usize
             | VirtualMemoryPermission::Execute as usize,
         is_shared: true,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
 

--- a/kernel/src/arch/riscv64/vm/mod.rs
+++ b/kernel/src/arch/riscv64/vm/mod.rs
@@ -273,6 +273,7 @@ fn setup_trampoline_at_end(manager: &VirtualMemoryManager, trampoline_vaddr_end:
             | VirtualMemoryPermission::Write as usize
             | VirtualMemoryPermission::Execute as usize,
         is_shared: true,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
 

--- a/kernel/src/device/audio/mod.rs
+++ b/kernel/src/device/audio/mod.rs
@@ -1091,7 +1091,7 @@ impl MemoryMappingOps for AudioCharDevice {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         let _irq_guard = IrqGuard::new();
         let guard = self.ring.lock();
         let ring = guard.as_ref().ok_or("PCM ring is not configured")?;
@@ -1104,7 +1104,11 @@ impl MemoryMappingOps for AudioCharDevice {
         if length > ring.mapped_bytes - offset {
             return Err("PCM mmap length exceeds ring size");
         }
-        Ok((ring.paddr() + offset, 0x3, true))
+        Ok(crate::object::capability::MemoryMappingInfo::new(
+            ring.paddr() + offset,
+            0x3,
+            true,
+        ))
     }
 
     fn on_mapped(&self, _vaddr: usize, _paddr: usize, _length: usize, _offset: usize) {}

--- a/kernel/src/device/block/mockblk.rs
+++ b/kernel/src/device/block/mockblk.rs
@@ -147,7 +147,7 @@ impl MemoryMappingOps for MockBlockDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported")
     }
 

--- a/kernel/src/device/block/mod.rs
+++ b/kernel/src/device/block/mod.rs
@@ -91,7 +91,7 @@ impl MemoryMappingOps for GenericBlockDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by this block device")
     }
 

--- a/kernel/src/device/char/mockchar.rs
+++ b/kernel/src/device/char/mockchar.rs
@@ -116,7 +116,7 @@ impl MemoryMappingOps for MockCharDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by mock character device")
     }
 

--- a/kernel/src/device/char/mod.rs
+++ b/kernel/src/device/char/mod.rs
@@ -261,7 +261,7 @@ impl MemoryMappingOps for GenericCharDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by this character device")
     }
 

--- a/kernel/src/device/char/pty/mod.rs
+++ b/kernel/src/device/char/pty/mod.rs
@@ -389,7 +389,7 @@ impl MemoryMappingOps for PtyMasterDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by PTY master")
     }
 

--- a/kernel/src/device/char/tty.rs
+++ b/kernel/src/device/char/tty.rs
@@ -1388,7 +1388,7 @@ impl MemoryMappingOps for TtyDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by TTY device")
     }
 

--- a/kernel/src/device/gpu.rs
+++ b/kernel/src/device/gpu.rs
@@ -975,7 +975,7 @@ impl crate::object::capability::MemoryMappingOps for GpuCharDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("GPU device memory mapping is not implemented")
     }
 

--- a/kernel/src/device/graphics/display_device.rs
+++ b/kernel/src/device/graphics/display_device.rs
@@ -423,7 +423,7 @@ impl MemoryMappingOps for DisplayCharDevice {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         let info = self.current_backing_info()?;
 
         if offset % crate::environment::PAGE_SIZE != 0 {
@@ -447,7 +447,12 @@ impl MemoryMappingOps for DisplayCharDevice {
             return Err("Requested length exceeds available display backing size");
         }
 
-        Ok((info.physical_addr + offset, 0x3, true))
+        Ok(crate::object::capability::MemoryMappingInfo::new(
+            info.physical_addr + offset,
+            0x3,
+            true,
+        )
+        .with_memory_attribute(crate::vm::vmem::MemoryAttribute::NonCacheable))
     }
 
     fn on_mapped(&self, vaddr: usize, _paddr: usize, length: usize, _offset: usize) {

--- a/kernel/src/device/graphics/framebuffer_device.rs
+++ b/kernel/src/device/graphics/framebuffer_device.rs
@@ -812,7 +812,7 @@ impl MemoryMappingOps for FramebufferCharDevice {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         let info = self.current_framebuffer_info()?;
 
         // VMM requires page-aligned physical mappings.
@@ -846,7 +846,10 @@ impl MemoryMappingOps for FramebufferCharDevice {
         let permissions = 0x3; // Read and Write
         let is_shared = true; // Framebuffer mappings are shared
 
-        Ok((paddr, permissions, is_shared))
+        Ok(
+            crate::object::capability::MemoryMappingInfo::new(paddr, permissions, is_shared)
+                .with_memory_attribute(crate::vm::vmem::MemoryAttribute::NonCacheable),
+        )
     }
 
     fn on_mapped(&self, vaddr: usize, paddr: usize, length: usize, offset: usize) {
@@ -1896,10 +1899,14 @@ mod tests {
         // Test get_mapping_info
         let result = fb_device.get_mapping_info(0, fb_pages * 4096);
         assert!(result.is_ok());
-        let (paddr, permissions, is_shared) = result.unwrap();
-        assert_eq!(paddr, crate::vm::addr::virt_to_phys(fb_addr));
-        assert_eq!(permissions, 0x3); // Read and Write
-        assert!(is_shared);
+        let info = result.unwrap();
+        assert_eq!(info.paddr, crate::vm::addr::virt_to_phys(fb_addr));
+        assert_eq!(info.permissions, 0x3); // Read and Write
+        assert!(info.is_shared);
+        assert_eq!(
+            info.memory_attribute,
+            crate::vm::vmem::MemoryAttribute::NonCacheable
+        );
 
         // Test invalid offset
         let result = fb_device.get_mapping_info(fb_size + 1, 32);
@@ -1910,7 +1917,7 @@ mod tests {
         assert!(result.is_err());
 
         // Test on_mapped callback
-        fb_device.on_mapped(0x1000, paddr, fb_pages * 4096, 0);
+        fb_device.on_mapped(0x1000, info.paddr, fb_pages * 4096, 0);
         {
             let mappings = fb_device.mappings.read();
             assert_eq!(mappings.len(), 1);
@@ -1982,9 +1989,13 @@ mod tests {
         // Test get_mapping_info with valid parameters
         let result = char_device.get_mapping_info(0, fb_pages * 4096);
         assert!(result.is_ok());
-        let (paddr, permissions, is_shared) = result.unwrap();
-        assert_eq!(paddr, crate::vm::addr::virt_to_phys(fb_addr));
-        assert_eq!(permissions, 0x3);
-        assert!(is_shared);
+        let info = result.unwrap();
+        assert_eq!(info.paddr, crate::vm::addr::virt_to_phys(fb_addr));
+        assert_eq!(info.permissions, 0x3);
+        assert!(info.is_shared);
+        assert_eq!(
+            info.memory_attribute,
+            crate::vm::vmem::MemoryAttribute::NonCacheable
+        );
     }
 }

--- a/kernel/src/device/graphics/mod.rs
+++ b/kernel/src/device/graphics/mod.rs
@@ -309,7 +309,7 @@ impl MemoryMappingOps for GenericGraphicsDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by this graphics device")
     }
 

--- a/kernel/src/device/input/event_device.rs
+++ b/kernel/src/device/input/event_device.rs
@@ -319,7 +319,7 @@ impl MemoryMappingOps for EventDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for input event devices")
     }
 }

--- a/kernel/src/device/mod.rs
+++ b/kernel/src/device/mod.rs
@@ -250,7 +250,7 @@ impl MemoryMappingOps for GenericDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by this generic device")
     }
 

--- a/kernel/src/device/network/mod.rs
+++ b/kernel/src/device/network/mod.rs
@@ -324,7 +324,7 @@ impl MemoryMappingOps for GenericNetworkDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by this network device")
     }
 

--- a/kernel/src/drivers/block/virtio_blk.rs
+++ b/kernel/src/drivers/block/virtio_blk.rs
@@ -696,7 +696,7 @@ impl MemoryMappingOps for VirtioBlockDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by VirtIO block device")
     }
 

--- a/kernel/src/drivers/graphics/simple_framebuffer.rs
+++ b/kernel/src/drivers/graphics/simple_framebuffer.rs
@@ -69,7 +69,7 @@ impl MemoryMappingOps for SimpleFramebufferDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by simple framebuffer device")
     }
 

--- a/kernel/src/drivers/graphics/virtio_gpu.rs
+++ b/kernel/src/drivers/graphics/virtio_gpu.rs
@@ -1339,7 +1339,7 @@ impl MemoryMappingOps for VirtioGpuDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by VirtIO GPU device")
     }
 

--- a/kernel/src/drivers/network/virtio_net.rs
+++ b/kernel/src/drivers/network/virtio_net.rs
@@ -635,7 +635,7 @@ impl MemoryMappingOps for VirtioNetDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by VirtIO network device")
     }
 

--- a/kernel/src/drivers/special/kmsg.rs
+++ b/kernel/src/drivers/special/kmsg.rs
@@ -119,7 +119,7 @@ impl MemoryMappingOps for KmsgDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by kmsg device")
     }
 

--- a/kernel/src/drivers/special/null.rs
+++ b/kernel/src/drivers/special/null.rs
@@ -91,7 +91,7 @@ impl MemoryMappingOps for NullDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported by null device")
     }
 

--- a/kernel/src/drivers/uart/pl011.rs
+++ b/kernel/src/drivers/uart/pl011.rs
@@ -157,7 +157,7 @@ impl MemoryMappingOps for Pl011Uart {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for UART")
     }
 

--- a/kernel/src/drivers/uart/virt.rs
+++ b/kernel/src/drivers/uart/virt.rs
@@ -155,7 +155,7 @@ impl MemoryMappingOps for Uart {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for UART")
     }
 

--- a/kernel/src/drivers/virtio_input.rs
+++ b/kernel/src/drivers/virtio_input.rs
@@ -434,7 +434,7 @@ impl crate::object::capability::memory_mapping::MemoryMappingOps for VirtioInput
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported")
     }
 }

--- a/kernel/src/drivers/virtio_snd.rs
+++ b/kernel/src/drivers/virtio_snd.rs
@@ -683,7 +683,7 @@ impl MemoryMappingOps for VirtioSndDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("VirtIO sound backend does not support direct mmap")
     }
 

--- a/kernel/src/drivers/virtio_video.rs
+++ b/kernel/src/drivers/virtio_video.rs
@@ -1731,7 +1731,7 @@ impl MemoryMappingOps for VirtioVideoDevice {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         if offset % PAGE_SIZE != 0 || length % PAGE_SIZE != 0 {
             return Err("VirtIO video mmap offset and length must be page-aligned");
         }
@@ -1749,7 +1749,11 @@ impl MemoryMappingOps for VirtioVideoDevice {
         let buffer = mapped_buffer
             .as_ref()
             .ok_or("VirtIO video mmap buffer is not available")?;
-        Ok((buffer.as_paddr() + session_offset, 0x3, true))
+        Ok(crate::object::capability::MemoryMappingInfo::new(
+            buffer.as_paddr() + session_offset,
+            0x3,
+            true,
+        ))
     }
 
     fn supports_mmap(&self) -> bool {

--- a/kernel/src/fs/vfs_v2/core.rs
+++ b/kernel/src/fs/vfs_v2/core.rs
@@ -467,7 +467,7 @@ impl MemoryMappingOps for VfsFileObject {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         self.inner.get_mapping_info(offset, length)
     }
 
@@ -476,7 +476,7 @@ impl MemoryMappingOps for VfsFileObject {
         offset: usize,
         length: usize,
         is_shared: bool,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         self.inner.get_mapping_info_with(offset, length, is_shared)
     }
 

--- a/kernel/src/fs/vfs_v2/drivers/cpiofs.rs
+++ b/kernel/src/fs/vfs_v2/drivers/cpiofs.rs
@@ -544,7 +544,7 @@ impl MemoryMappingOps for CpioFileObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for CPIO files")
     }
 
@@ -753,7 +753,7 @@ impl MemoryMappingOps for CpioDirectoryObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for directories")
     }
 
@@ -883,7 +883,7 @@ impl MemoryMappingOps for CpioSymlinkObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for symbolic links")
     }
 

--- a/kernel/src/fs/vfs_v2/drivers/devfs.rs
+++ b/kernel/src/fs/vfs_v2/drivers/devfs.rs
@@ -782,7 +782,7 @@ impl MemoryMappingOps for DevFileObject {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         // For device files, delegate to the underlying device if it supports memory mapping
         if let Some(ref device_guard) = self.device_guard {
             let device_guard_ref = device_guard.as_ref();
@@ -996,7 +996,7 @@ impl MemoryMappingOps for DevDirectoryObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for directories")
     }
 

--- a/kernel/src/fs/vfs_v2/drivers/devpts.rs
+++ b/kernel/src/fs/vfs_v2/drivers/devpts.rs
@@ -623,7 +623,7 @@ impl MemoryMappingOps for DevPtsFileObject {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         match &self.endpoint {
             DevPtsEndpoint::Master(master) => master.get_mapping_info(offset, length),
             DevPtsEndpoint::Slave(slave) => slave.get_mapping_info(offset, length),
@@ -782,7 +782,7 @@ impl MemoryMappingOps for DevPtsDirectoryObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for DevPTS directories")
     }
 

--- a/kernel/src/fs/vfs_v2/drivers/ext2/char_device_tests.rs
+++ b/kernel/src/fs/vfs_v2/drivers/ext2/char_device_tests.rs
@@ -125,7 +125,7 @@ mod tests {
             &self,
             _offset: usize,
             _length: usize,
-        ) -> Result<(usize, usize, bool), &'static str> {
+        ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
             Err("Memory mapping not supported")
         }
     }

--- a/kernel/src/fs/vfs_v2/drivers/ext2/node.rs
+++ b/kernel/src/fs/vfs_v2/drivers/ext2/node.rs
@@ -554,7 +554,7 @@ impl MemoryMappingOps for Ext2FileObject {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         if offset % PAGE_SIZE != 0 {
             return Err("Offset not page aligned");
         }
@@ -590,7 +590,9 @@ impl MemoryMappingOps for Ext2FileObject {
             return Err("Backing address not aligned");
         }
 
-        Ok((paddr, 0x3, true))
+        Ok(crate::object::capability::MemoryMappingInfo::new(
+            paddr, 0x3, true,
+        ))
     }
 
     fn get_mapping_info_with(
@@ -598,7 +600,7 @@ impl MemoryMappingOps for Ext2FileObject {
         offset: usize,
         length: usize,
         is_shared: bool,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         if is_shared {
             if offset % PAGE_SIZE != 0 {
                 return Err("Offset not page aligned");
@@ -624,7 +626,9 @@ impl MemoryMappingOps for Ext2FileObject {
             }
 
             let _ = length;
-            return Ok((0, 0x3, true));
+            return Ok(crate::object::capability::MemoryMappingInfo::new(
+                0, 0x3, true,
+            ));
         }
 
         self.get_mapping_info(offset, length)
@@ -1373,7 +1377,7 @@ impl MemoryMappingOps for Ext2DirectoryObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for directories")
     }
 }
@@ -1597,7 +1601,7 @@ impl MemoryMappingOps for Ext2CharDeviceFileObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         // Most character devices don't support memory mapping
         Err("Memory mapping not supported")
     }

--- a/kernel/src/fs/vfs_v2/drivers/fat32/node.rs
+++ b/kernel/src/fs/vfs_v2/drivers/fat32/node.rs
@@ -588,7 +588,7 @@ impl MemoryMappingOps for Fat32FileObject {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         if offset % PAGE_SIZE != 0 {
             return Err("Offset not page aligned");
         }
@@ -610,7 +610,9 @@ impl MemoryMappingOps for Fat32FileObject {
             return Err("Backing address not aligned");
         }
 
-        Ok((paddr, 0x3, true))
+        Ok(crate::object::capability::MemoryMappingInfo::new(
+            paddr, 0x3, true,
+        ))
     }
 
     fn get_mapping_info_with(
@@ -618,7 +620,7 @@ impl MemoryMappingOps for Fat32FileObject {
         offset: usize,
         length: usize,
         is_shared: bool,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         if is_shared {
             if offset % PAGE_SIZE != 0 {
                 return Err("Offset not page aligned");
@@ -630,7 +632,9 @@ impl MemoryMappingOps for Fat32FileObject {
             }
 
             let _ = length;
-            return Ok((0, 0x3, true));
+            return Ok(crate::object::capability::MemoryMappingInfo::new(
+                0, 0x3, true,
+            ));
         }
 
         self.get_mapping_info(offset, length)
@@ -1137,7 +1141,7 @@ impl MemoryMappingOps for Fat32DirectoryObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for FAT32 directories")
     }
 

--- a/kernel/src/fs/vfs_v2/drivers/overlayfs/mod.rs
+++ b/kernel/src/fs/vfs_v2/drivers/overlayfs/mod.rs
@@ -1404,7 +1404,7 @@ impl MemoryMappingOps for OverlayDirectoryObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for directories")
     }
 

--- a/kernel/src/fs/vfs_v2/drivers/tmpfs/mod.rs
+++ b/kernel/src/fs/vfs_v2/drivers/tmpfs/mod.rs
@@ -1497,7 +1497,7 @@ impl MemoryMappingOps for TmpFileObject {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         if offset % PAGE_SIZE != 0 {
             return Err("Offset not page aligned");
         }
@@ -1522,7 +1522,9 @@ impl MemoryMappingOps for TmpFileObject {
             return Err("Backing address not aligned");
         }
 
-        Ok((paddr, 0x3, false))
+        Ok(crate::object::capability::MemoryMappingInfo::new(
+            paddr, 0x3, false,
+        ))
     }
 
     fn get_mapping_info_with(
@@ -1530,7 +1532,7 @@ impl MemoryMappingOps for TmpFileObject {
         offset: usize,
         length: usize,
         is_shared: bool,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         if is_shared {
             if offset % PAGE_SIZE != 0 {
                 return Err("Offset not page aligned");
@@ -1542,7 +1544,9 @@ impl MemoryMappingOps for TmpFileObject {
             }
 
             let _ = length;
-            return Ok((0, 0x3, true));
+            return Ok(crate::object::capability::MemoryMappingInfo::new(
+                0, 0x3, true,
+            ));
         }
 
         self.get_mapping_info(offset, length)

--- a/kernel/src/ipc/shared_memory.rs
+++ b/kernel/src/ipc/shared_memory.rs
@@ -247,7 +247,7 @@ impl MemoryMappingOps for SharedMemory {
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         let state = self.state.read();
 
         if !state.valid {
@@ -265,13 +265,17 @@ impl MemoryMappingOps for SharedMemory {
             return Err("Mapping request exceeds shared memory size");
         }
 
-        // Return physical address (base + offset), permissions, and shared flag
+        // Return physical address (base + offset), permissions, and shared flag.
         let paddr = state
             .paddr
             .checked_add(offset)
             .ok_or("Physical address overflow in shared memory mapping")?;
 
-        Ok((paddr, state.permissions, true))
+        Ok(crate::object::capability::MemoryMappingInfo::new(
+            paddr,
+            state.permissions,
+            true,
+        ))
     }
 
     fn on_mapped(&self, _vaddr: usize, _paddr: usize, _length: usize, _offset: usize) {
@@ -426,20 +430,20 @@ mod tests {
 
         // Test valid mapping request
         match shmem.get_mapping_info(0, 4096) {
-            Ok((mapped_paddr, mapped_perms, is_shared)) => {
-                assert_eq!(mapped_paddr, paddr);
-                assert_eq!(mapped_perms, permissions);
-                assert!(is_shared); // Shared memory should always be shared
+            Ok(info) => {
+                assert_eq!(info.paddr, paddr);
+                assert_eq!(info.permissions, permissions);
+                assert!(info.is_shared); // Shared memory should always be shared
             }
             Err(e) => panic!("Mapping info failed: {}", e),
         }
 
         // Test mapping with offset
         match shmem.get_mapping_info(1024, 2048) {
-            Ok((mapped_paddr, mapped_perms, is_shared)) => {
-                assert_eq!(mapped_paddr, paddr + 1024);
-                assert_eq!(mapped_perms, permissions);
-                assert!(is_shared);
+            Ok(info) => {
+                assert_eq!(info.paddr, paddr + 1024);
+                assert_eq!(info.permissions, permissions);
+                assert!(info.is_shared);
             }
             Err(e) => panic!("Mapping info with offset failed: {}", e),
         }

--- a/kernel/src/lsm/loader.rs
+++ b/kernel/src/lsm/loader.rs
@@ -403,6 +403,7 @@ pub fn load_module(data: &[u8]) -> Result<u64, LsmError> {
             vm_start: base_vaddr,
             permissions,
             is_shared: true,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
 

--- a/kernel/src/object/capability/memory_mapping/anon_owner.rs
+++ b/kernel/src/object/capability/memory_mapping/anon_owner.rs
@@ -43,7 +43,7 @@ impl MemoryMappingOps for AnonymousPageOwner {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("AnonymousPageOwner does not support get_mapping_info")
     }
 
@@ -140,7 +140,7 @@ impl MemoryMappingOps for ForkCowPageOwner {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("ForkCowPageOwner does not support get_mapping_info")
     }
 

--- a/kernel/src/object/capability/memory_mapping/mod.rs
+++ b/kernel/src/object/capability/memory_mapping/mod.rs
@@ -6,7 +6,56 @@
 pub mod anon_owner;
 pub mod syscall;
 
+use crate::vm::vmem::MemoryAttribute;
+
 pub use syscall::{sys_memory_map, sys_memory_unmap};
+
+/// Information needed to map a region of an object into virtual memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryMappingInfo {
+    /// Physical address backing the mapping.
+    pub paddr: usize,
+    /// Scarlet virtual-memory permission bits allowed by the object.
+    pub permissions: usize,
+    /// Whether the mapping is shared with other tasks.
+    pub is_shared: bool,
+    /// Cacheability/device attribute requested for the mapping.
+    pub memory_attribute: MemoryAttribute,
+}
+
+impl MemoryMappingInfo {
+    /// Creates mapping information for normal cacheable memory.
+    ///
+    /// # Arguments
+    /// * `paddr` - Physical address backing the mapping
+    /// * `permissions` - Scarlet virtual-memory permission bits allowed by the object
+    /// * `is_shared` - Whether the mapping is shared with other tasks
+    ///
+    /// # Returns
+    /// Mapping information with [`MemoryAttribute::Normal`].
+    pub const fn new(paddr: usize, permissions: usize, is_shared: bool) -> Self {
+        Self {
+            paddr,
+            permissions,
+            is_shared,
+            memory_attribute: MemoryAttribute::Normal,
+        }
+    }
+
+    /// Returns this mapping information with an explicit memory attribute.
+    ///
+    /// # Arguments
+    /// * `memory_attribute` - Cacheability/device attribute requested for the mapping
+    ///
+    /// # Returns
+    /// The mapping information with the supplied memory attribute.
+    pub const fn with_memory_attribute(self, memory_attribute: MemoryAttribute) -> Self {
+        Self {
+            memory_attribute,
+            ..self
+        }
+    }
+}
 
 /// Memory mapping operations capability
 ///
@@ -17,31 +66,39 @@ pub use syscall::{sys_memory_map, sys_memory_unmap};
 pub trait MemoryMappingOps: Send + Sync {
     /// Get mapping information for a region of the object
     ///
-    /// Returns the physical address, permissions, and sharing information
-    /// for mapping a region of this object into virtual memory.
+    /// Returns the physical address, permissions, sharing information, and
+    /// memory attribute for mapping a region of this object into virtual memory.
     ///
     /// # Arguments
     /// * `offset` - Offset within the object to start mapping from
     /// * `length` - Length of the mapping in bytes
     ///
     /// # Returns
-    /// * `Result<(usize, usize, bool), &'static str>` - (paddr, permissions, is_shared) on success
+    /// * `Result<MemoryMappingInfo, &'static str>` - Mapping information on success
     fn get_mapping_info(
         &self,
         offset: usize,
         length: usize,
-    ) -> Result<(usize, usize, bool), &'static str>;
+    ) -> Result<MemoryMappingInfo, &'static str>;
 
     /// Get mapping information with sharing intent.
     ///
     /// Default implementation ignores `is_shared` and delegates to
     /// `get_mapping_info` for backward compatibility.
+    ///
+    /// # Arguments
+    /// * `offset` - Offset within the object to start mapping from
+    /// * `length` - Length of the mapping in bytes
+    /// * `is_shared` - Whether the caller requested a shared mapping
+    ///
+    /// # Returns
+    /// Mapping information on success.
     fn get_mapping_info_with(
         &self,
         offset: usize,
         length: usize,
         _is_shared: bool,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<MemoryMappingInfo, &'static str> {
         self.get_mapping_info(offset, length)
     }
 
@@ -82,10 +139,22 @@ pub trait MemoryMappingOps: Send + Sync {
     /// Default implementation returns a generic "object" string. Implementers
     /// (e.g. VfsFileObject) should override to provide more meaningful names
     /// such as file paths.
+    ///
+    /// # Returns
+    /// A short diagnostic name for this mapping owner.
     fn mmap_owner_name(&self) -> alloc::string::String {
         alloc::string::String::from("object")
     }
 
+    /// Resolve the physical backing page for a fault on an owner-backed mapping.
+    ///
+    /// # Arguments
+    /// * `access` - Access that caused the fault
+    /// * `page_idx` - Page index within the original mapping
+    /// * `vm_start` - Original virtual start address for the mapping
+    ///
+    /// # Returns
+    /// The resolved backing page, or an error describing why the fault cannot be resolved.
     fn resolve_fault(
         &self,
         access: &crate::object::capability::memory_mapping::AccessKind,
@@ -143,8 +212,17 @@ pub trait MemoryMappingOps: Send + Sync {
         true
     }
 
+    /// Release a range of pages owned by this mapping object.
+    ///
+    /// # Arguments
+    /// * `start_page_idx` - First page index to release
+    /// * `page_count` - Number of pages to release
     fn release_pages(&self, _start_page_idx: usize, _page_count: usize) {}
 
+    /// Clone this mapping owner for a forked task.
+    ///
+    /// # Returns
+    /// A cloned mapping owner when the object supports fork-specific ownership.
     fn fork_clone(&self) -> Option<alloc::sync::Arc<dyn MemoryMappingOps>> {
         None
     }
@@ -200,12 +278,12 @@ mod tests {
             &self,
             offset: usize,
             _length: usize,
-        ) -> Result<(usize, usize, bool), &'static str> {
+        ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
             if self.should_fail {
                 Err("Mock get_mapping_info failure")
             } else {
                 // Return mock physical address, read/write permissions, not shared
-                Ok((0x80000000 + offset, 0x3, false))
+                Ok(MemoryMappingInfo::new(0x80000000 + offset, 0x3, false))
             }
         }
 
@@ -247,10 +325,11 @@ mod tests {
         // Test successful get_mapping_info
         let result = mock_obj.get_mapping_info(1024, 8192);
         assert!(result.is_ok());
-        let (paddr, permissions, is_shared) = result.unwrap();
-        assert_eq!(paddr, 0x80000400); // 0x80000000 + 1024
-        assert_eq!(permissions, 0x3);
-        assert!(!is_shared);
+        let info = result.unwrap();
+        assert_eq!(info.paddr, 0x80000400); // 0x80000000 + 1024
+        assert_eq!(info.permissions, 0x3);
+        assert!(!info.is_shared);
+        assert_eq!(info.memory_attribute, MemoryAttribute::Normal);
 
         // Test on_mapped notification
         mock_obj.on_mapped(0x10000000, 0x80000400, 8192, 1024);

--- a/kernel/src/object/capability/memory_mapping/syscall.rs
+++ b/kernel/src/object/capability/memory_mapping/syscall.rs
@@ -184,6 +184,7 @@ pub fn sys_memory_map(trapframe: &mut Trapframe) -> usize {
             vm_start: final_vaddr,
             permissions: prot_perm,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: Some(owner),
         };
 
@@ -211,17 +212,17 @@ pub fn sys_memory_map(trapframe: &mut Trapframe) -> usize {
         return final_vaddr;
     }
 
-    // Shared path: need get_mapping_info_with for pmarea and permissions
-    let (paddr, obj_permissions, _obj_is_shared) =
+    // Shared path: need get_mapping_info_with for pmarea, permissions, and memory attribute.
+    let mapping_info =
         match memory_mappable.get_mapping_info_with(offset, aligned_length, is_shared) {
             Ok(info) => info,
             Err(_) => return usize::MAX,
         };
 
     let vmarea = MemoryArea::new(final_vaddr, final_vaddr + aligned_length - 1);
-    let pmarea = MemoryArea::new(paddr, paddr + aligned_length - 1);
+    let pmarea = MemoryArea::new(mapping_info.paddr, mapping_info.paddr + aligned_length - 1);
 
-    let final_permissions = obj_permissions & {
+    let final_permissions = mapping_info.permissions & {
         let mut perm = 0;
         if (prot & PROT_READ) != 0 {
             perm |= 0x1;
@@ -239,7 +240,8 @@ pub fn sys_memory_map(trapframe: &mut Trapframe) -> usize {
         .handle_table
         .get_arc_clone(handle)
         .and_then(|obj| obj.as_memory_mappable_arc());
-    let vm_map = VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner);
+    let vm_map = VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner)
+        .with_memory_attribute(mapping_info.memory_attribute);
 
     if !is_map_fixed {
         if task.vm_manager.add_memory_map(vm_map.clone()).is_err() {
@@ -251,28 +253,30 @@ pub fn sys_memory_map(trapframe: &mut Trapframe) -> usize {
                 None => return usize::MAX,
             };
             let vmarea = MemoryArea::new(chosen_vaddr, chosen_vaddr + aligned_length - 1);
-            let pmarea = MemoryArea::new(paddr, paddr + aligned_length - 1);
+            let pmarea =
+                MemoryArea::new(mapping_info.paddr, mapping_info.paddr + aligned_length - 1);
             let owner = task
                 .handle_table
                 .get_arc_clone(handle)
                 .and_then(|obj| obj.as_memory_mappable_arc());
             let retry_map =
-                VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner);
+                VirtualMemoryMap::new(pmarea, vmarea, final_permissions, is_shared, owner)
+                    .with_memory_attribute(mapping_info.memory_attribute);
             if task.vm_manager.add_memory_map(retry_map).is_err() {
                 return usize::MAX;
             }
 
-            memory_mappable.on_mapped(chosen_vaddr, paddr, aligned_length, offset);
+            memory_mappable.on_mapped(chosen_vaddr, mapping_info.paddr, aligned_length, offset);
             return chosen_vaddr;
         }
 
-        memory_mappable.on_mapped(final_vaddr, paddr, aligned_length, offset);
+        memory_mappable.on_mapped(final_vaddr, mapping_info.paddr, aligned_length, offset);
         return final_vaddr;
     }
 
     match task.vm_manager.add_memory_map_fixed(vm_map) {
         Ok(removed_mappings) => {
-            memory_mappable.on_mapped(final_vaddr, paddr, aligned_length, offset);
+            memory_mappable.on_mapped(final_vaddr, mapping_info.paddr, aligned_length, offset);
 
             for removed_map in &removed_mappings {
                 if removed_map.is_shared {
@@ -358,6 +362,7 @@ fn handle_anonymous_mapping(
         vm_start: final_vaddr,
         permissions,
         is_shared,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: Some(owner),
     };
 

--- a/kernel/src/object/capability/mod.rs
+++ b/kernel/src/object/capability/mod.rs
@@ -25,7 +25,7 @@ pub use file::{FileObject, SeekFrom};
 pub use control::ControlOps;
 
 // Re-export memory mapping types
-pub use memory_mapping::MemoryMappingOps;
+pub use memory_mapping::{MemoryMappingInfo, MemoryMappingOps};
 
 // Re-export IPC types
 pub use ipc::{EventReceiver, EventSender, EventSubscriber};

--- a/kernel/src/object/handle/tests/mock.rs
+++ b/kernel/src/object/handle/tests/mock.rs
@@ -73,7 +73,7 @@ impl MemoryMappingOps for MockFileObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported")
     }
 
@@ -191,7 +191,7 @@ impl MemoryMappingOps for MockTaskFileObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported")
     }
 

--- a/kernel/src/object/tests/mock.rs
+++ b/kernel/src/object/tests/mock.rs
@@ -73,7 +73,7 @@ impl MemoryMappingOps for MockFileObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported")
     }
 
@@ -191,7 +191,7 @@ impl MemoryMappingOps for MockTaskFileObject {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported")
     }
 

--- a/kernel/src/object/tests/shared_memory.rs
+++ b/kernel/src/object/tests/shared_memory.rs
@@ -40,10 +40,10 @@ fn test_shared_memory_memory_mapping_ops() {
         let result = mem_mappable.get_mapping_info(0, 4096);
         assert!(result.is_ok());
 
-        let (mapped_paddr, mapped_perms, is_shared) = result.unwrap();
-        assert_eq!(mapped_paddr, paddr);
-        assert_eq!(mapped_perms, permissions);
-        assert!(is_shared); // Shared memory should always be shared
+        let info = result.unwrap();
+        assert_eq!(info.paddr, paddr);
+        assert_eq!(info.permissions, permissions);
+        assert!(info.is_shared); // Shared memory should always be shared
 
         // Test supports_mmap
         assert!(mem_mappable.supports_mmap());
@@ -119,20 +119,20 @@ fn test_shared_memory_mapping_offset() {
         let offset1 = 0;
         let result1 = mem_mappable.get_mapping_info(offset1, 4096);
         assert!(result1.is_ok());
-        let (paddr1, _, _) = result1.unwrap();
-        assert_eq!(paddr1, paddr + offset1);
+        let info1 = result1.unwrap();
+        assert_eq!(info1.paddr, paddr + offset1);
 
         let offset2 = 4096;
         let result2 = mem_mappable.get_mapping_info(offset2, 4096);
         assert!(result2.is_ok());
-        let (paddr2, _, _) = result2.unwrap();
-        assert_eq!(paddr2, paddr + offset2);
+        let info2 = result2.unwrap();
+        assert_eq!(info2.paddr, paddr + offset2);
 
         let offset3 = 8192;
         let result3 = mem_mappable.get_mapping_info(offset3, 4096);
         assert!(result3.is_ok());
-        let (paddr3, _, _) = result3.unwrap();
-        assert_eq!(paddr3, paddr + offset3);
+        let info3 = result3.unwrap();
+        assert_eq!(info3.paddr, paddr + offset3);
 
         // Test out of bounds mapping
         let result_oob = mem_mappable.get_mapping_info(size, 1);

--- a/kernel/src/random.rs
+++ b/kernel/src/random.rs
@@ -370,7 +370,7 @@ impl MemoryMappingOps for RandomCharDevice {
         &self,
         _offset: usize,
         _length: usize,
-    ) -> Result<(usize, usize, bool), &'static str> {
+    ) -> Result<crate::object::capability::MemoryMappingInfo, &'static str> {
         Err("Memory mapping not supported for random device")
     }
 }

--- a/kernel/src/task/elf_loader/mod.rs
+++ b/kernel/src/task/elf_loader/mod.rs
@@ -1291,6 +1291,7 @@ fn map_elf_segment(
         vm_start: vmarea.start,
         permissions,
         is_shared: false,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -1127,6 +1127,7 @@ impl Task {
             vm_start: vaddr,
             permissions,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         self.vm_manager
@@ -1165,6 +1166,7 @@ impl Task {
                             vm_start: mmap.vm_start,
                             permissions: mmap.permissions,
                             is_shared: mmap.is_shared,
+                            memory_attribute: mmap.memory_attribute,
                             owner: mmap.owner.clone(),
                         };
                         self.vm_manager
@@ -1190,6 +1192,7 @@ impl Task {
                             vm_start: mmap.vm_start,
                             permissions: mmap.permissions,
                             is_shared: mmap.is_shared,
+                            memory_attribute: mmap.memory_attribute,
                             owner: mmap.owner.clone(),
                         };
                         self.vm_manager
@@ -1354,6 +1357,7 @@ impl Task {
             vm_start: vaddr,
             permissions,
             is_shared: VirtualMemoryRegion::Guard.is_shareable(), // Guard pages can be shared
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         Ok(mmap)
@@ -1640,6 +1644,7 @@ impl Task {
                         vm_start: mmap.vm_start,
                         permissions: mmap.permissions,
                         is_shared: true,
+                        memory_attribute: mmap.memory_attribute,
                         owner: mmap.owner.clone(),
                     };
                     child
@@ -1668,6 +1673,7 @@ impl Task {
                             vm_start: mmap.vm_start,
                             permissions: mmap.permissions,
                             is_shared: false,
+                            memory_attribute: mmap.memory_attribute,
                             owner: Some(cloned_owner),
                         };
                         child
@@ -1683,6 +1689,7 @@ impl Task {
                                 vm_start: mmap.vm_start,
                                 permissions: mmap.permissions,
                                 is_shared: false,
+                                memory_attribute: mmap.memory_attribute,
                                 owner: Some(Arc::clone(owner)),
                             };
                             child
@@ -1708,6 +1715,7 @@ impl Task {
                                 vm_start: vaddr,
                                 permissions,
                                 is_shared: false,
+                                memory_attribute: mmap.memory_attribute,
                                 owner: None,
                             };
                             // SAFETY: src/dst are valid page-aligned ranges of `size` bytes.
@@ -1739,6 +1747,7 @@ impl Task {
                             vm_start: mmap.vm_start,
                             permissions: mmap.permissions,
                             is_shared: false,
+                            memory_attribute: mmap.memory_attribute,
                             owner: Some(cow_owner),
                         };
                         self.vm_manager.with_memmaps_mut(|maps| {
@@ -1773,6 +1782,7 @@ impl Task {
                         vm_start: vaddr,
                         permissions,
                         is_shared: false,
+                        memory_attribute: mmap.memory_attribute,
                         owner: None,
                     };
 
@@ -1800,6 +1810,7 @@ impl Task {
                         vm_start: mmap.vm_start,
                         permissions: mmap.permissions,
                         is_shared: false,
+                        memory_attribute: mmap.memory_attribute,
                         owner: None,
                     };
                     child
@@ -3267,6 +3278,7 @@ mod tests {
             permissions: VirtualMemoryPermission::Read as usize
                 | VirtualMemoryPermission::Write as usize,
             is_shared: true, // This should be shared between parent and child
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
 

--- a/kernel/src/vm/ioremap.rs
+++ b/kernel/src/vm/ioremap.rs
@@ -36,7 +36,7 @@ use spin::{Mutex, Once};
 
 use crate::environment::{IOREMAP_END, IOREMAP_START, PAGE_SIZE};
 use crate::vm::get_kernel_vm_manager;
-use crate::vm::vmem::{MemoryArea, VirtualMemoryMap, VirtualMemoryPermission};
+use crate::vm::vmem::{MemoryArea, MemoryAttribute, VirtualMemoryMap, VirtualMemoryPermission};
 
 // ---------------------------------------------------------------------------
 // Internal allocator
@@ -163,7 +163,8 @@ pub fn ioremap(paddr: usize, size: usize) -> Result<usize, &'static str> {
         VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
         true, // shared: accessible from any address space using the kernel PT
         None,
-    );
+    )
+    .with_memory_attribute(MemoryAttribute::Device);
 
     let km = get_kernel_vm_manager();
 

--- a/kernel/src/vm/manager.rs
+++ b/kernel/src/vm/manager.rs
@@ -354,6 +354,7 @@ impl VirtualMemoryManager {
                         vm_start: existing_map.vm_start,
                         permissions: existing_map.permissions,
                         is_shared: existing_map.is_shared,
+                        memory_attribute: existing_map.memory_attribute,
                         owner: existing_map.owner.clone(),
                     };
                     removed_maps.push(removed_portion);
@@ -380,6 +381,7 @@ impl VirtualMemoryManager {
                         vm_start: existing_map.vm_start,
                         permissions: existing_map.permissions,
                         is_shared: existing_map.is_shared,
+                        memory_attribute: existing_map.memory_attribute,
                         owner: existing_map.owner.clone(),
                     };
                     mappings_to_add.push(before_map);
@@ -396,6 +398,7 @@ impl VirtualMemoryManager {
                         vm_start: existing_map.vm_start,
                         permissions: existing_map.permissions,
                         is_shared: existing_map.is_shared,
+                        memory_attribute: existing_map.memory_attribute,
                         owner: existing_map.owner.clone(),
                     };
                     mappings_to_add.push(after_map);
@@ -611,6 +614,7 @@ impl VirtualMemoryManager {
                                 vm_start: memory_map.vm_start,
                                 permissions: perms,
                                 is_shared: false,
+                                memory_attribute: memory_map.memory_attribute,
                                 owner: None,
                             };
                             match self.add_memory_map_fixed(cow_map) {
@@ -1008,6 +1012,7 @@ impl VirtualMemoryManager {
                         vm_start: existing_map.vm_start,
                         permissions: existing_map.permissions,
                         is_shared: existing_map.is_shared,
+                        memory_attribute: existing_map.memory_attribute,
                         owner: existing_map.owner.clone(),
                     };
                     overwritten_mappings.push(overwritten_map);
@@ -1031,6 +1036,7 @@ impl VirtualMemoryManager {
                         vm_start: existing_map.vm_start,
                         permissions: existing_map.permissions,
                         is_shared: existing_map.is_shared,
+                        memory_attribute: existing_map.memory_attribute,
                         owner: existing_map.owner.clone(),
                     };
                     mappings_to_add.push(before_map);
@@ -1047,6 +1053,7 @@ impl VirtualMemoryManager {
                         vm_start: existing_map.vm_start,
                         permissions: existing_map.permissions,
                         is_shared: existing_map.is_shared,
+                        memory_attribute: existing_map.memory_attribute,
                         owner: existing_map.owner.clone(),
                     };
                     mappings_to_add.push(after_map);
@@ -1132,6 +1139,7 @@ impl VirtualMemoryManager {
                         vm_start: prev_memory_map.vm_start,
                         permissions: prev_memory_map.permissions, // Use permissions from first map
                         is_shared: prev_memory_map.is_shared,
+                        memory_attribute: prev_memory_map.memory_attribute,
                         owner: prev_memory_map.owner.clone(),
                     };
 
@@ -1183,6 +1191,7 @@ impl VirtualMemoryManager {
         // 3. Physical addresses are also contiguous
         map1.permissions == map2.permissions
             && map1.is_shared == map2.is_shared
+            && map1.memory_attribute == map2.memory_attribute
             && map1.pmarea.end + 1 == map2.pmarea.start
     }
 }
@@ -1262,6 +1271,7 @@ mod tests {
             vm_start: vma.start,
             permissions: 0,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         vmm.add_memory_map(map).unwrap();
@@ -1292,6 +1302,7 @@ mod tests {
             vm_start: vma.start,
             permissions: 0,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         vmm.add_memory_map(map).unwrap();
@@ -1319,6 +1330,7 @@ mod tests {
             vm_start: vma1.start,
             permissions: 0,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         let vma2 = MemoryArea {
@@ -1331,6 +1343,7 @@ mod tests {
             vm_start: vma2.start,
             permissions: 0,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         vmm.add_memory_map(map1).unwrap();
@@ -2115,6 +2128,7 @@ mod tests {
             vm_start: vma.start,
             permissions: 0o644,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         let asid = alloc_virtual_address_space();
@@ -2154,6 +2168,7 @@ mod tests {
             vm_start: 0x2000,
             permissions: 0,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
 
@@ -2240,6 +2255,7 @@ mod tests {
             vm_start: 0x4000,
             permissions: 0o644,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: Some(owner),
         };
         manager.add_memory_map(map).unwrap();
@@ -2256,6 +2272,7 @@ mod tests {
             vm_start: 0x5000,
             permissions: 0o600,
             is_shared: false,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         let removed = manager.add_memory_map_fixed(replacement).unwrap();

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -124,6 +124,7 @@ pub fn kernel_vm_init(
             | VirtualMemoryPermission::Write as usize
             | VirtualMemoryPermission::Execute as usize,
         is_shared: true, // Kernel memory should be shared across all processes
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
     get_kernel_vm_manager()
@@ -143,6 +144,7 @@ pub fn kernel_vm_init(
         permissions: VirtualMemoryPermission::Read as usize
             | VirtualMemoryPermission::Write as usize,
         is_shared: true,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
     get_kernel_vm_manager()
@@ -161,6 +163,7 @@ pub fn kernel_vm_init(
         permissions: VirtualMemoryPermission::Read as usize
             | VirtualMemoryPermission::Write as usize,
         is_shared: true,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
     get_kernel_vm_manager()
@@ -188,6 +191,7 @@ pub fn kernel_vm_init(
             permissions: VirtualMemoryPermission::Read as usize
                 | VirtualMemoryPermission::Write as usize,
             is_shared: true,
+            memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
             owner: None,
         };
         if initramfs_hhdm_area.start < hhdm_area.start || initramfs_hhdm_area.end > hhdm_area.end {
@@ -301,6 +305,7 @@ pub fn user_kernel_vm_init(task: &Task) {
             | VirtualMemoryPermission::Write as usize
             | VirtualMemoryPermission::Execute as usize,
         is_shared: true, // Kernel memory should be shared across all processes
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
     task.vm_manager
@@ -324,6 +329,7 @@ pub fn user_kernel_vm_init(task: &Task) {
         permissions: VirtualMemoryPermission::Read as usize
             | VirtualMemoryPermission::Write as usize,
         is_shared: true,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
     task.vm_manager
@@ -342,6 +348,7 @@ pub fn user_kernel_vm_init(task: &Task) {
         permissions: VirtualMemoryPermission::Read as usize
             | VirtualMemoryPermission::Write as usize,
         is_shared: true,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
     task.vm_manager
@@ -456,6 +463,7 @@ pub fn setup_trampoline_for_task_kstack_window(task: &Task) -> Result<(), &'stat
         permissions: VirtualMemoryPermission::Read as usize
             | VirtualMemoryPermission::Write as usize,
         is_shared: true,
+        memory_attribute: crate::vm::vmem::MemoryAttribute::Normal,
         owner: None,
     };
 

--- a/kernel/src/vm/vmem.rs
+++ b/kernel/src/vm/vmem.rs
@@ -16,6 +16,7 @@ use core::fmt;
 ///   compute correct page indices even after partial unmapping.
 /// * `permissions` - The access permissions for this mapping
 /// * `is_shared` - Whether this mapping is shared between processes
+/// * `memory_attribute` - Cacheability/device attribute requested for this mapping
 /// * `owner` - Optional strong reference to the object that provides page fault resolution.
 ///   The mapping owns this reference, so the owner stays alive as long as the mapping exists.
 #[derive(Clone)]
@@ -25,6 +26,7 @@ pub struct VirtualMemoryMap {
     pub vm_start: usize,
     pub permissions: usize,
     pub is_shared: bool,
+    pub memory_attribute: MemoryAttribute,
     pub owner: Option<Arc<dyn MemoryMappingOps>>,
 }
 
@@ -36,6 +38,7 @@ impl fmt::Debug for VirtualMemoryMap {
             .field("vm_start", &self.vm_start)
             .field("permissions", &self.permissions)
             .field("is_shared", &self.is_shared)
+            .field("memory_attribute", &self.memory_attribute)
             .field("has_owner", &self.owner.is_some())
             .finish()
     }
@@ -49,6 +52,7 @@ impl Default for VirtualMemoryMap {
             vm_start: 0,
             permissions: 0,
             is_shared: false,
+            memory_attribute: MemoryAttribute::Normal,
             owner: None,
         }
     }
@@ -79,9 +83,33 @@ impl VirtualMemoryMap {
             vm_start: vmarea.start,
             permissions,
             is_shared,
+            memory_attribute: MemoryAttribute::Normal,
             owner,
         }
     }
+
+    /// Returns this mapping with the requested memory attribute.
+    ///
+    /// # Arguments
+    /// * `memory_attribute` - Cacheability/device attribute to apply when installing the mapping
+    ///
+    /// # Returns
+    /// The mapping descriptor with the supplied memory attribute.
+    pub fn with_memory_attribute(mut self, memory_attribute: MemoryAttribute) -> Self {
+        self.memory_attribute = memory_attribute;
+        self
+    }
+}
+
+/// Cacheability and device attributes for a virtual memory mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryAttribute {
+    /// Normal cacheable memory.
+    Normal,
+    /// Normal memory without CPU cache allocation.
+    NonCacheable,
+    /// Device memory for MMIO regions.
+    Device,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
## Summary

- add `MemoryAttribute` and `MemoryMappingInfo` so mmap providers can declare cacheability/device attributes explicitly
- thread memory attributes through `VirtualMemoryMap`, fixed-map splitting, fork/clone paths, and mmap syscalls
- make AArch64 leaf PTE encoding use the declared memory attribute instead of inferring Device from the IOREMAP VA range
- mark ioremap mappings as Device and framebuffer/display mappings as NonCacheable

## Root cause

AArch64 page-table encoding inferred device memory from the virtual address range, while mmap descriptors had no way to declare the actual memory type. That made framebuffer scanout and other mappings depend on call-site/address heuristics instead of object-owned mapping metadata.

## Validation

- `cargo make test-riscv64` (738 tests)
- `cargo make test-aarch64` (691 tests)
- `cargo make fmt-check`
- `git diff --check`

Closes #487
