### PR TITLE
vm: add framebuffer memory attribute

### DIFF
--- a/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
+++ b/kernel/src/arch/aarch64/vm/mmu/armv8_4k.rs
@@ -542,7 +542,7 @@ impl PageTable {
     /// Level 0 uses a page descriptor (`0b11`); levels 1 and 2 use block
     /// descriptors (`0b01`). Permission, memory type, shareability, and execute
     /// attributes are encoded from the mapping request.
-    fn make_leaf_entry(
+    pub(crate) fn make_leaf_entry(
         vaddr: usize,
         paddr: usize,
         permissions: usize,
@@ -552,14 +552,14 @@ impl PageTable {
         let is_user = VirtualMemoryPermission::User.contained_in(permissions);
         let memory_attr = match memory_attribute {
             MemoryAttribute::Normal => 1,
-            MemoryAttribute::NonCacheable => 2,
+            MemoryAttribute::NonCacheable | MemoryAttribute::Framebuffer => 2,
             MemoryAttribute::Device => 0,
         };
         let shareability = match memory_attribute {
             MemoryAttribute::Device => Shareability::OuterShareable as u64,
-            MemoryAttribute::Normal | MemoryAttribute::NonCacheable => {
-                Shareability::InnerShareable as u64
-            }
+            MemoryAttribute::Normal
+            | MemoryAttribute::NonCacheable
+            | MemoryAttribute::Framebuffer => Shareability::InnerShareable as u64,
         };
 
         let mut entry = 0u64;
@@ -993,6 +993,15 @@ mod tests {
             .walk_to_level(vaddr, 0, false, asid)
             .expect("leaf PTE not found");
         assert_eq!((pte.entry >> 2) & 0b111, 2);
+
+        let framebuffer_entry = PageTable::make_leaf_entry(
+            0x4300_0000,
+            0x8300_0000,
+            VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+            0,
+            MemoryAttribute::Framebuffer,
+        );
+        assert_eq!((framebuffer_entry >> 2) & 0b111, 2);
 
         free_virtual_address_space(asid);
     }

--- a/kernel/src/device/graphics/display_device.rs
+++ b/kernel/src/device/graphics/display_device.rs
@@ -452,7 +452,7 @@ impl MemoryMappingOps for DisplayCharDevice {
             0x3,
             true,
         )
-        .with_memory_attribute(crate::vm::vmem::MemoryAttribute::NonCacheable))
+        .with_memory_attribute(crate::vm::vmem::MemoryAttribute::Framebuffer))
     }
 
     fn on_mapped(&self, vaddr: usize, _paddr: usize, length: usize, _offset: usize) {

--- a/kernel/src/device/graphics/framebuffer_device.rs
+++ b/kernel/src/device/graphics/framebuffer_device.rs
@@ -848,7 +848,7 @@ impl MemoryMappingOps for FramebufferCharDevice {
 
         Ok(
             crate::object::capability::MemoryMappingInfo::new(paddr, permissions, is_shared)
-                .with_memory_attribute(crate::vm::vmem::MemoryAttribute::NonCacheable),
+                .with_memory_attribute(crate::vm::vmem::MemoryAttribute::Framebuffer),
         )
     }
 
@@ -1905,7 +1905,7 @@ mod tests {
         assert!(info.is_shared);
         assert_eq!(
             info.memory_attribute,
-            crate::vm::vmem::MemoryAttribute::NonCacheable
+            crate::vm::vmem::MemoryAttribute::Framebuffer
         );
 
         // Test invalid offset
@@ -1995,7 +1995,7 @@ mod tests {
         assert!(info.is_shared);
         assert_eq!(
             info.memory_attribute,
-            crate::vm::vmem::MemoryAttribute::NonCacheable
+            crate::vm::vmem::MemoryAttribute::Framebuffer
         );
     }
 }

--- a/kernel/src/vm/boot.rs
+++ b/kernel/src/vm/boot.rs
@@ -2,7 +2,7 @@ use crate::arch::vm::mmu::{PageTable as ArchPageTable, PageTableEntry as ArchPag
 use crate::environment::{KERNEL_HEAP_BASE, PAGE_SIZE, SCARLET_HHDM_BASE};
 use crate::mem::pmm;
 use crate::vm::addr::{boot_phys_to_virt, kernel_virt_to_phys};
-use crate::vm::vmem::{MemoryArea, VirtualMemoryPermission};
+use crate::vm::vmem::{MemoryArea, MemoryAttribute, VirtualMemoryPermission};
 
 const BOOT_ASID: u16 = 0;
 
@@ -72,7 +72,13 @@ fn boot_walk(
 }
 
 #[cfg(target_arch = "riscv64")]
-fn boot_map_page(root: *mut ArchPageTable, vaddr: usize, paddr: usize, permissions: usize) {
+fn boot_map_page(
+    root: *mut ArchPageTable,
+    vaddr: usize,
+    paddr: usize,
+    permissions: usize,
+    _memory_attribute: MemoryAttribute,
+) {
     let vaddr = vaddr & !(PAGE_SIZE - 1);
     let paddr = paddr & !(PAGE_SIZE - 1);
     let pte = boot_walk(root, vaddr, true).expect("boot_map_page: failed to allocate walk path");
@@ -141,7 +147,13 @@ fn boot_walk(
 }
 
 #[cfg(target_arch = "aarch64")]
-fn boot_map_page(root: *mut ArchPageTable, vaddr: usize, paddr: usize, permissions: usize) {
+fn boot_map_page(
+    root: *mut ArchPageTable,
+    vaddr: usize,
+    paddr: usize,
+    permissions: usize,
+    memory_attribute: MemoryAttribute,
+) {
     let upper = vaddr >> 48;
     if upper != 0 && upper != 0xffff {
         panic!(
@@ -154,21 +166,13 @@ fn boot_map_page(root: *mut ArchPageTable, vaddr: usize, paddr: usize, permissio
     let paddr = paddr & !(PAGE_SIZE - 1);
     let pte = boot_walk(root, vaddr, true).expect("boot_map_page: failed to allocate walk path");
 
-    let is_write = VirtualMemoryPermission::Write.contained_in(permissions);
-    let ap = if is_write { 0b00 } else { 0b10 };
-
-    let mut entry = 0u64;
-    entry |= 0x3;
-    entry |= 1 << 10;
-    entry |= ((paddr >> 12) as u64 & 0xfffffffff) << 12;
-    entry |= 1 << 2;
-    entry |= (0b11_u64) << 8;
-    entry |= (ap as u64) << 6;
-    if !VirtualMemoryPermission::Execute.contained_in(permissions) {
-        entry |= (1 << 54) | (1 << 53);
-    }
-
-    pte.set_entry(entry);
+    pte.set_entry(ArchPageTable::make_leaf_entry(
+        vaddr,
+        paddr,
+        permissions,
+        0,
+        memory_attribute,
+    ));
     crate::arch::aarch64::clean_dcache_to_poc_range(
         (pte as *const ArchPageTableEntry) as usize,
         core::mem::size_of::<ArchPageTableEntry>(),
@@ -180,6 +184,7 @@ fn boot_map_range(
     varea: MemoryArea,
     parea: MemoryArea,
     permissions: usize,
+    memory_attribute: MemoryAttribute,
 ) {
     if varea.start % PAGE_SIZE != 0
         || parea.start % PAGE_SIZE != 0
@@ -195,7 +200,7 @@ fn boot_map_range(
     let mut vaddr = varea.start;
     let mut paddr = parea.start;
     while vaddr <= varea.end.saturating_sub(PAGE_SIZE - 1) {
-        boot_map_page(root, vaddr, paddr, permissions);
+        boot_map_page(root, vaddr, paddr, permissions, memory_attribute);
         vaddr = vaddr
             .checked_add(PAGE_SIZE)
             .expect("boot_map_range: vaddr overflow");
@@ -259,18 +264,21 @@ pub fn switch_to_boot_page_table(
         VirtualMemoryPermission::Read as usize
             | VirtualMemoryPermission::Write as usize
             | VirtualMemoryPermission::Execute as usize,
+        MemoryAttribute::Normal,
     );
     boot_map_range(
         root,
         direct_map_area,
         direct_map_phys_area,
         VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+        MemoryAttribute::Normal,
     );
     boot_map_range(
         root,
         heap_area,
         heap_phys_area,
         VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+        MemoryAttribute::Normal,
     );
 
     if let Some(initramfs) = initramfs_paddr {
@@ -290,6 +298,7 @@ pub fn switch_to_boot_page_table(
                 initramfs_area,
                 initramfs_phys_area,
                 VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+                MemoryAttribute::Normal,
             );
         }
     }
@@ -311,6 +320,7 @@ pub fn switch_to_boot_page_table(
                 fb_area,
                 fb_phys_area,
                 VirtualMemoryPermission::Read as usize | VirtualMemoryPermission::Write as usize,
+                MemoryAttribute::Framebuffer,
             );
         }
     }

--- a/kernel/src/vm/vmem.rs
+++ b/kernel/src/vm/vmem.rs
@@ -108,6 +108,8 @@ pub enum MemoryAttribute {
     Normal,
     /// Normal memory without CPU cache allocation.
     NonCacheable,
+    /// Framebuffer or VRAM memory that is non-cacheable but permits burst writes.
+    Framebuffer,
     /// Device memory for MMIO regions.
     Device,
 }


### PR DESCRIPTION
## Summary

- Add a `Framebuffer` memory attribute for framebuffer/VRAM mappings.
- Map AArch64 `Framebuffer` as the existing Normal Non-cacheable MAIR slot, separate from MMIO `Device` mappings.
- Use `Framebuffer` for framebuffer/display mmap and Limine boot framebuffer mappings.

## Validation

- `cargo make test-aarch64` — 691 tests passed
- `cargo make test-riscv64` — 738 tests passed
- `cargo make fmt-check`
- `git diff --check`