### PR TITLE
[codex] Improve scheduler placement and task diagnostics

### DIFF
--- a/bundles/desktop/bundle.toml
+++ b/bundles/desktop/bundle.toml
@@ -93,6 +93,12 @@ to = "/system/scarlet/bin/settings"
 
 [[layers]]
 kind = "cargo"
+source = "../../user/std-bin"
+bin = "task_manager"
+to = "/system/scarlet/bin/task_manager"
+
+[[layers]]
+kind = "cargo"
 source = "../../user/bin"
 package = "user-bin"
 bin = "scarlet_skk"
@@ -185,4 +191,3 @@ source = "../../user/bin"
 package = "user-bin"
 bin = "scarlet_mozc"
 to = "/system/scarlet/bin/scarlet_mozc"
-

--- a/bundles/desktop/fs/system/scarlet/etc/stemd.d/apps/org.scarlet-os.desktop.task-manager.desktop
+++ b/bundles/desktop/fs/system/scarlet/etc/stemd.d/apps/org.scarlet-os.desktop.task-manager.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Task Manager
+Exec=/bin/task_manager
+Icon=utilities-system-monitor
+Type=Application
+Terminal=false

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,8 @@ describes the repository at a high level; this page is the documentation map.
   address layout.
 - [Scheduler placement and fairness](architecture/scheduler.md) - capacity-aware
   scheduling policy, hints, fairness, and preemption integration points.
+- [Scheduler benchmark scenarios](architecture/scheduler-benchmarks.md) -
+  repeatable workloads for homogeneous and heterogeneous scheduler checks.
 - [Apple Silicon deployment](../projects/aarch64-apple-limine-full/DEPLOY.md) -
   experimental m1n1/U-Boot/Limine deployment flow.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ describes the repository at a high level; this page is the documentation map.
   AArch64 build, test, linker, and target layout.
 - [Memory map](architecture/memory-map.md) - higher-half kernel and ioremap
   address layout.
+- [Scheduler placement and fairness](architecture/scheduler.md) - capacity-aware
+  scheduling policy, hints, fairness, and preemption integration points.
 - [Apple Silicon deployment](../projects/aarch64-apple-limine-full/DEPLOY.md) -
   experimental m1n1/U-Boot/Limine deployment flow.
 

--- a/docs/architecture/scheduler-benchmarks.md
+++ b/docs/architecture/scheduler-benchmarks.md
@@ -1,0 +1,126 @@
+# Scheduler Benchmark Scenarios
+
+This document defines repeatable scheduler workloads for validating placement,
+utilization tracking, and responsiveness on both homogeneous and heterogeneous
+systems.
+
+The benchmark driver is `sched_bench` from `user/std-bin`.
+
+## Common Commands
+
+Build user binaries for AArch64:
+
+```bash
+cargo make build-userbin-std-debug-aarch64
+```
+
+Run a mixed workload:
+
+```sh
+sched_bench --scenario mixed --threads 8 --seconds 30
+```
+
+Request full-capacity placement for worker threads:
+
+```sh
+sched_bench --scenario cpu --threads 2 --seconds 30 --performance
+```
+
+Observe task placement in another terminal:
+
+```sh
+watch -n 1 top --sort cpu
+```
+
+Observe CPU topology, runnable counts, cpufreq state, and migration counters:
+
+```sh
+watch -n 1 cat /dev/cpuinfo
+```
+
+## Scenarios
+
+`cpu`
+
+: CPU-bound workers. Use this to check that sustained high utilization reaches
+  high-capacity CPUs when they exist.
+
+`bursty`
+
+: Repeated medium compute bursts with short sleeps. Use this to check that
+  short wakeups do not cause excessive migration churn.
+
+`sleepy`
+
+: Mostly sleeping workers with small compute bursts. Use this to check that
+  low-utilization work can remain on lower-capacity or less-loaded CPUs.
+
+`mixed`
+
+: A repeating mix of CPU-bound, bursty, and sleepy workers. Use this as the
+  default regression scenario because it exercises load spreading, wake
+  placement, and idle work stealing together.
+
+## QEMU Homogeneous Baseline
+
+QEMU usually reports balanced cores with equal capacity. Expected behavior:
+
+- `core class` is `balanced` for all CPUs.
+- `cpu capacity` is equal for all online CPUs.
+- `sched_bench --scenario mixed --threads 8 --seconds 30` spreads runnable work
+  across idle CPUs.
+- `scheduler work steals` may increase when queues become uneven.
+- `scheduler promotions` and `scheduler demotions` should normally stay at 0
+  because all capacities are equal.
+
+Regression signal:
+
+- Runnable workers pile up on one CPU while other CPUs stay idle.
+- `scheduler work steals` increases continuously but run queues remain badly
+  imbalanced.
+- `top` shows CPU-bound workers stuck on one CPU for the whole run.
+
+## Apple Silicon Heterogeneous Baseline
+
+Apple Silicon exposes efficiency and performance classes when topology probing
+is available. Expected behavior:
+
+- E cores have lower `cpu capacity` than P cores.
+- `sched_bench --scenario cpu --threads 2 --seconds 30 --performance` gives
+  workers `MIN=1024`, `REQ=1024`, and should place them on P cores when P cores
+  are online and available.
+- `scheduler promotions` can increase when a high-util worker starts on an E
+  core and moves to a P core.
+- `sched_bench --scenario sleepy --threads 4 --seconds 30` should not force P
+  cores to stay busy.
+
+Regression signal:
+
+- `--performance` workers remain on E cores while idle P cores exist.
+- `REQ` in `top` is high but `cpu capacity` of the worker CPU is lower.
+- Repeated promotions/demotions happen for the same workers without workload
+  changes, indicating migration thrash.
+
+## Responsiveness Check
+
+Run the desktop, then start a mixed load:
+
+```sh
+sched_bench --scenario mixed --threads 8 --seconds 60
+```
+
+While it runs:
+
+- Move the pointer and type in a terminal.
+- Keep `top --sort cpu` visible.
+- Check whether SWS, input services, and terminal tasks keep making progress.
+
+Expected behavior:
+
+- Interactive tasks should still appear runnable and should not be buried behind
+  all CPU-bound workers.
+- On Apple Silicon, sustained heavy workers may move to P cores, but small
+  services should not require manual app-name special cases.
+
+This check is currently manual. Once timer preemption and richer scheduler
+metrics exist, it should become an automated regression test.

--- a/docs/architecture/scheduler.md
+++ b/docs/architecture/scheduler.md
@@ -1,0 +1,151 @@
+# Scheduler Placement and Fairness
+
+This document describes the current Scarlet scheduler policy and the intended
+path toward priority, fairness, and preemption-aware scheduling.
+
+## Goals
+
+- Keep runnable tasks distributed across online CPUs.
+- Prefer a CPU whose capacity can satisfy the task's measured or requested
+  utilization.
+- Use user and kernel hints as policy inputs, not as hard affinity.
+- Avoid app-name based scheduler special cases.
+- Keep normal work from being permanently starved by latency-sensitive work.
+
+## Current Model
+
+Scarlet currently uses per-CPU ready queues. A task is associated with one
+scheduler CPU while it is queued or running. Sleeping tasks keep their last CPU
+as placement history.
+
+The scheduler tracks:
+
+- CPU topology: core class, relative capacity, topology domain, and online CPU
+  mask.
+- Per-task utilization: an exponentially decayed `util_avg` in
+  `SCHED_UTIL_SCALE` units.
+- Per-task hints: `util_min` and core preference.
+- Per-CPU load: current task, ready queue weight, utilization clamp, and
+  runnable task count.
+- Migration statistics: promotions, demotions, cooldown skips, and work steals.
+
+The current implementation is not a fully preemptive fair scheduler. Placement
+decisions happen at enqueue, wakeup, idle work stealing, and normal task switch
+boundaries. This is intentional for the current stage: correctness and
+observability are more important than aggressive balancing.
+
+## Placement Capacity
+
+For placement, each task has an effective required capacity:
+
+```text
+effective_util = max(measured util_avg, requested util_min)
+required_capacity = max(preference_floor, effective_util)
+```
+
+The preference floor is:
+
+- `Performance`: full default capacity.
+- `Efficiency` or `Any`: minimum scheduler capacity.
+
+`util_min` is validated in the kernel and must be in `0..=SCHED_UTIL_SCALE`.
+User space can set it for the current task through `std::task::set_sched_util_min`.
+New threads can temporarily override the parent hint through
+`std::thread::Builder::util_min` or `Builder::performance`; the child inherits
+the requested value through clone, then the parent hint is restored.
+
+Hints are best effort. They raise the capacity floor used by placement, but they
+do not pin the task and do not guarantee exclusive CPU time.
+
+## CPU Selection
+
+When a task is enqueued or woken:
+
+1. Pinned tasks stay on their pinned CPU.
+2. The scheduler scans online CPUs.
+3. CPUs below the task's required capacity are skipped when possible.
+4. Among suitable CPUs, the scheduler picks the lowest load score.
+5. Ties use the task's core preference.
+6. If no suitable CPU exists, the least-loaded fallback CPU is used.
+
+The load score is based on runnable task weight divided by CPU capacity. This
+keeps homogeneous systems balanced while still allowing higher-capacity cores to
+absorb more work on heterogeneous systems.
+
+Idle CPUs may steal ready work from busier queues. Work stealing observes the
+same capacity requirement and migration cooldown rules as direct migration.
+
+## Promotion and Demotion
+
+When a task finishes a run and remains ready, the scheduler may migrate it:
+
+- Promotion: if required capacity is above the current CPU capacity, move to a
+  higher-capacity CPU that can satisfy it.
+- Demotion: if current capacity is well above required capacity, move to a
+  lower-capacity CPU only after low utilization is sustained for a minimum
+  window.
+- Cooldown: recently migrated tasks are not moved again immediately.
+
+This prevents rapid P/E bouncing and avoids demoting a task after one quiet
+sample.
+
+## Priority and Fairness
+
+Priority currently influences load weight, not time entitlement. A higher
+priority task makes its CPU look more loaded, which biases future placement away
+from stacking more work on that CPU. This is deliberately weaker than a hard
+priority scheduler.
+
+Minimum viable fairness before full preemption:
+
+- Do not use `util_min` as a permanent monopoly on P cores.
+- Keep work stealing available so idle CPUs can drain overloaded queues.
+- Keep migration cooldowns to prevent thrash.
+- Keep `util_min` bounded by `SCHED_UTIL_SCALE`.
+- Keep latency-sensitive hints visible through diagnostics so bad hints can be
+  found.
+
+Known limitation: without preemption, a CPU-bound task can still run until it
+reaches an existing scheduling boundary. Fair CPU-time distribution requires
+timer-driven preemption.
+
+## Preemption Integration
+
+When timer preemption is added, the scheduler should keep the existing
+placement policy and add a fair runtime policy on top:
+
+1. Charge runtime on every preemption tick.
+2. Maintain per-task virtual runtime or a comparable fairness metric.
+3. Select the next task from the local CPU by fairness first, then placement
+   constraints.
+4. Use priority to weight CPU-time entitlement rather than only load score.
+5. Treat `util_min` and core preference as placement hints, not as extra CPU-time
+   entitlement.
+6. Make migration decisions at controlled points after accounting is updated.
+
+This keeps the current capacity-aware work useful while leaving room for a real
+fair scheduler.
+
+## Queue Invariants
+
+- A task is running on at most one CPU.
+- A ready task is owned by at most one CPU queue.
+- Idle tasks are never enqueued as normal ready work.
+- Cross-CPU movement must claim or release `running_cpu` before the task can be
+  selected elsewhere.
+- Scheduler-driven migration updates the task migration timestamp and count.
+- Diagnostic fields must be derived from scheduler state and must not depend on
+  one-off logging.
+
+## Diagnostics
+
+`/dev/cpuinfo` is a temporary diagnostic device. It exposes per-CPU topology,
+capacity, runnable count, utilization clamp, scheduler migration counters, and
+cpufreq state when available.
+
+`GetTaskInfoList` exposes per-task placement state. User tools such as `top`
+can show the current CPU, measured utilization, requested minimum utilization,
+effective required capacity, core preference, and migration count.
+
+These interfaces are not stable ABI yet. They exist to validate the scheduler
+while the algorithm is still changing.

--- a/docs/architecture/scheduler.md
+++ b/docs/architecture/scheduler.md
@@ -74,6 +74,10 @@ absorb more work on heterogeneous systems.
 
 Idle CPUs may steal ready work from busier queues. Work stealing observes the
 same capacity requirement and migration cooldown rules as direct migration.
+Within a topology domain, the scheduler may also move ready work laterally from
+an overloaded CPU to a less loaded peer CPU with the same effective capacity.
+This keeps P-core and E-core groups from piling runnable work onto one core
+while sibling cores are idle or lightly loaded.
 
 ## Promotion and Demotion
 
@@ -84,10 +88,13 @@ When a task finishes a run and remains ready, the scheduler may migrate it:
 - Demotion: if current capacity is well above required capacity, move to a
   lower-capacity CPU only after low utilization is sustained for a minimum
   window.
+- Lateral balance: if peer CPUs in the same topology domain have meaningfully
+  lower load, move ready work sideways without changing capacity class.
 - Cooldown: recently migrated tasks are not moved again immediately.
 
-This prevents rapid P/E bouncing and avoids demoting a task after one quiet
-sample.
+This prevents rapid P/E bouncing, avoids demoting a task after one quiet sample,
+and keeps load balancing local to the current performance domain unless a
+capacity change is actually needed.
 
 ## Priority and Fairness
 

--- a/kernel/src/arch/aarch64/boot/limine.rs
+++ b/kernel/src/arch/aarch64/boot/limine.rs
@@ -153,6 +153,14 @@ fn register_cpu_topology_from_fdt() {
         }
 
         if let Some(phandle) = cpu_performance_domain_phandle(&cpu) {
+            if let Err(err) = crate::sched::scheduler::register_cpu_topology_domain(cpu_id, phandle)
+            {
+                early_println!(
+                    "[aarch64] Failed to register CPU topology domain for cpu={}: {}",
+                    cpu_id,
+                    err
+                );
+            }
             crate::device::cpufreq::register_cpu_performance_domain(cpu_id, phandle);
         }
     }

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -321,6 +321,10 @@ impl Trapframe {
         self.regs.reg[0] = value; // X0
     }
 
+    pub fn set_tls_pointer(&mut self, ptr: usize) {
+        self.tpidr_el0 = ptr as u64;
+    }
+
     pub fn get_arg(&self, index: usize) -> usize {
         // Arguments are passed in X0-X7 in AArch64
         if index < 8 {

--- a/kernel/src/arch/aarch64/trap/exception.rs
+++ b/kernel/src/arch/aarch64/trap/exception.rs
@@ -10,8 +10,11 @@ use crate::abi::syscall_dispatcher;
 use crate::arch::{Trapframe, get_cpu};
 use crate::object::capability::memory_mapping::{AccessKind, AccessOp};
 use crate::println;
-use crate::sched::scheduler::current_task;
+use crate::sched::scheduler::{current_task, schedule};
 use crate::task::mytask;
+
+const USER_PAGE_FAULT_EXIT_STATUS: i32 = 139;
+const USER_ILLEGAL_INSTRUCTION_EXIT_STATUS: i32 = 132;
 
 /// Get CurrentEL value
 fn get_current_el() -> u64 {
@@ -34,6 +37,12 @@ fn get_hcr_el2() -> u64 {
     let val: u64;
     unsafe { asm!("mrs {}, hcr_el2", out(reg) val) };
     val
+}
+
+fn trap_from_user(trapframe: &Trapframe) -> bool {
+    // SPSR_EL1.M[3:0] records the previous exception level/mode.
+    // EL0t is encoded as 0b0000.
+    trapframe.spsr & 0xf == 0
 }
 
 /// Get DAIF value
@@ -128,6 +137,26 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, trap_kind: usize) {
                 let instr_at_elr = read_user_instruction(trapframe.elr as usize);
                 let instr_before_elr =
                     read_user_instruction((trapframe.elr as usize).wrapping_sub(4));
+                if trap_from_user(trapframe) {
+                    crate::println!(
+                        "[trap] unsupported SVE access trap at ELR={:#x}; instr@ELR={:?} instr@ELR-4={:?}; SVE context is not implemented",
+                        trapframe.elr,
+                        instr_at_elr,
+                        instr_before_elr,
+                    );
+                    terminate_current_user_exception(
+                        trapframe,
+                        esr,
+                        "unsupported SVE instruction",
+                        trapframe.elr as usize,
+                        false,
+                        trapframe.elr,
+                        "SVE context is not implemented",
+                        USER_ILLEGAL_INSTRUCTION_EXIT_STATUS,
+                    );
+                    return;
+                }
+
                 print_trap_info(trapframe, esr);
                 crate::println!(
                     "[trap] unsupported SVE access trap at ELR={:#x}; instr@ELR={:?} instr@ELR-4={:?}; SVE context is not implemented",
@@ -188,10 +217,24 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, trap_kind: usize) {
             }
         }
 
-        // Unknown or unhandled exception.
-        // We must stop here: this indicates a real bring-up bug (e.g. unexpected
-        // asynchronous exception path) and masking would hide the root cause.
+        // Unknown or unhandled exception. User-origin exceptions are reported
+        // and terminate the current task; kernel-origin exceptions stop here
+        // because continuing would hide a real bring-up bug.
         _ => {
+            if trap_from_user(trapframe) {
+                terminate_current_user_exception(
+                    trapframe,
+                    esr,
+                    "unhandled user exception",
+                    trapframe.elr as usize,
+                    false,
+                    trapframe.elr,
+                    "Unhandled lower-EL exception",
+                    USER_ILLEGAL_INSTRUCTION_EXIT_STATUS,
+                );
+                return;
+            }
+
             print_trap_info(trapframe, esr);
 
             crate::println!(
@@ -244,14 +287,22 @@ fn handle_sve_access_trap(trapframe: &mut Trapframe) -> bool {
 }
 
 fn read_user_instruction(instr_addr: usize) -> Option<u32> {
-    let task = current_task(get_cpu().get_cpuid()).unwrap();
+    let (_kva, instr) = read_user_instruction_with_kva(instr_addr)?;
+    Some(instr)
+}
+
+fn read_user_instruction_with_kva(instr_addr: usize) -> Option<(usize, u32)> {
+    let task = current_task(get_cpu().get_cpuid())?;
     let instr_kva = task.vm_manager.translate_to_kva(instr_addr)?;
-    Some(unsafe { core::ptr::read_unaligned(instr_kva as *const u32) })
+    Some((instr_kva, unsafe {
+        core::ptr::read_unaligned(instr_kva as *const u32)
+    }))
 }
 
 /// Handle instruction page fault (like RISC-V cause 12)
 fn handle_instruction_fault(trapframe: &mut Trapframe, vaddr: usize) {
     let task = current_task(get_cpu().get_cpuid()).unwrap();
+    let pc = trapframe.get_current_pc();
 
     let access = AccessKind {
         op: AccessOp::Instruction,
@@ -261,11 +312,15 @@ fn handle_instruction_fault(trapframe: &mut Trapframe, vaddr: usize) {
 
     match task.vm_manager.lazy_map_page_with(access) {
         Ok(_) => (),
-        Err(_) => {
-            print_trap_info(trapframe, get_esr_el1());
-            panic!(
-                "Failed to map page for instruction fault at vaddr: {:#x}",
-                vaddr
+        Err(e) => {
+            terminate_current_user_fault(
+                trapframe,
+                get_esr_el1(),
+                "instruction",
+                vaddr,
+                false,
+                pc,
+                e,
             );
         }
     }
@@ -291,22 +346,152 @@ fn handle_data_fault(trapframe: &mut Trapframe, vaddr: usize, is_write: bool) {
     match task.vm_manager.lazy_map_page_with(access) {
         Ok(_) => (),
         Err(e) => {
-            print_trap_info(trapframe, get_esr_el1());
-            if let Some(task) = current_task(get_cpu().get_cpuid()) {
-                println!(
-                    "Task {} (PID {}) caused data fault at vaddr: {:#x} (write={}) from PC: {:#x}",
-                    task.name.read(),
-                    task.get_id(),
-                    vaddr,
-                    is_write,
-                    pc
-                );
-            }
-            panic!(
-                "Failed to map page for data fault at vaddr: {:#x} (write={}) from PC: {:#x}: {}",
-                vaddr, is_write, pc, e
+            terminate_current_user_fault(trapframe, get_esr_el1(), "data", vaddr, is_write, pc, e);
+        }
+    }
+}
+
+fn terminate_current_user_fault(
+    trapframe: &mut Trapframe,
+    esr: u64,
+    fault_kind: &str,
+    vaddr: usize,
+    is_write: bool,
+    pc: u64,
+    reason: &'static str,
+) {
+    let event_kind = match fault_kind {
+        "instruction" => "instruction fault",
+        "data" => "data fault",
+        other => other,
+    };
+    terminate_current_user_exception(
+        trapframe,
+        esr,
+        event_kind,
+        vaddr,
+        is_write,
+        pc,
+        reason,
+        USER_PAGE_FAULT_EXIT_STATUS,
+    );
+}
+
+fn terminate_current_user_exception(
+    trapframe: &mut Trapframe,
+    esr: u64,
+    event_kind: &str,
+    vaddr: usize,
+    is_write: bool,
+    pc: u64,
+    reason: &'static str,
+    exit_status: i32,
+) {
+    print_trap_info(trapframe, esr);
+    if let Some(task) = current_task(get_cpu().get_cpuid()) {
+        println!(
+            "Task {} (PID {}) caused {} at vaddr: {:#x} (write={}) from PC: {:#x}: {}",
+            task.name.read(),
+            task.get_id(),
+            event_kind,
+            vaddr,
+            is_write,
+            pc,
+            reason
+        );
+        log_user_fault_memory_context(&task, trapframe, vaddr);
+        log_user_code_context(&task, trapframe.elr as usize);
+        task.vcpu.lock().store(trapframe);
+        task.exit(exit_status);
+        schedule(trapframe);
+        return;
+    }
+
+    panic!(
+        "Unhandled {} at vaddr: {:#x} (write={}) from PC: {:#x}: {}",
+        event_kind, vaddr, is_write, pc, reason
+    );
+}
+
+fn log_user_fault_memory_context(task: &crate::task::Task, trapframe: &Trapframe, vaddr: usize) {
+    let brk = task.get_brk();
+    let text_size = task.text_size.load(core::sync::atomic::Ordering::SeqCst);
+    let data_size = task.data_size.load(core::sync::atomic::Ordering::SeqCst);
+    let vcpu_tls = task.vcpu.lock().get_tls_pointer();
+    println!(
+        "[fault] task memory: brk={:#x} text_size={:#x} data_size={:#x} trap_tls={:#x} vcpu_tls={:#x}",
+        brk, text_size, data_size, trapframe.tpidr_el0, vcpu_tls
+    );
+
+    if let Some(map) = task.vm_manager.search_memory_map(vaddr) {
+        println!(
+            "[fault] map hit: va={:#x}-{:#x} pa={:#x}-{:#x} vm_start={:#x} perm={:#x} shared={} attr={:?} owner={}",
+            map.vmarea.start,
+            map.vmarea.end,
+            map.pmarea.start,
+            map.pmarea.end,
+            map.vm_start,
+            map.permissions,
+            map.is_shared,
+            map.memory_attribute,
+            map.owner
+                .as_ref()
+                .map(|owner| owner.mmap_owner_name())
+                .unwrap_or_else(|| alloc::string::String::from("none"))
+        );
+        return;
+    }
+
+    let (prev, next) = task.vm_manager.with_memmaps(|maps| {
+        let prev = maps.range(..=vaddr).next_back().map(|(_, map)| {
+            (
+                map.vmarea.start,
+                map.vmarea.end,
+                map.vm_start,
+                map.permissions,
+            )
+        });
+        let next = maps.range(vaddr..).next().map(|(_, map)| {
+            (
+                map.vmarea.start,
+                map.vmarea.end,
+                map.vm_start,
+                map.permissions,
+            )
+        });
+        (prev, next)
+    });
+
+    match prev {
+        Some((start, end, vm_start, permissions)) => println!(
+            "[fault] previous map: va={:#x}-{:#x} vm_start={:#x} perm={:#x}",
+            start, end, vm_start, permissions
+        ),
+        None => println!("[fault] previous map: none"),
+    }
+
+    match next {
+        Some((start, end, vm_start, permissions)) => println!(
+            "[fault] next map: va={:#x}-{:#x} vm_start={:#x} perm={:#x}",
+            start, end, vm_start, permissions
+        ),
+        None => println!("[fault] next map: none"),
+    }
+}
+
+fn log_user_code_context(task: &crate::task::Task, pc: usize) {
+    match task.vm_manager.translate_to_kva(pc) {
+        Some(kva) => {
+            let w0 = unsafe { core::ptr::read_unaligned(kva as *const u32) };
+            let w1 = unsafe { core::ptr::read_unaligned((kva + 4) as *const u32) };
+            let w2 = unsafe { core::ptr::read_unaligned((kva + 8) as *const u32) };
+            let w3 = unsafe { core::ptr::read_unaligned((kva + 12) as *const u32) };
+            println!(
+                "[fault] code words: pc={:#x} kva={:#x} words={:08x} {:08x} {:08x} {:08x}",
+                pc, kva, w0, w1, w2, w3
             );
         }
+        None => println!("[fault] code words: pc={:#x} unmapped", pc),
     }
 }
 
@@ -321,8 +506,8 @@ fn print_trap_info(trapframe: &Trapframe, esr: u64) {
     crate::println!("ESR_EL1: {:#018x} (EC={:#x}, FSC={:#x})", esr, ec, fsc);
     crate::println!("FAR_EL1: {:#018x}", far);
     crate::println!("ELR_EL1: {:#018x}", trapframe.elr);
-    match read_user_instruction(trapframe.elr as usize) {
-        Some(instr) => crate::println!("INSN_ELR: {:#010x}", instr),
+    match read_user_instruction_with_kva(trapframe.elr as usize) {
+        Some((kva, instr)) => crate::println!("INSN_ELR: {:#010x} (kva={:#x})", instr, kva),
         None => crate::println!("INSN_ELR: <unmapped>"),
     }
 

--- a/kernel/src/arch/aarch64/trap/exception.rs
+++ b/kernel/src/arch/aarch64/trap/exception.rs
@@ -402,7 +402,7 @@ fn terminate_current_user_exception(
         log_user_fault_memory_context(&task, trapframe, vaddr);
         log_user_code_context(&task, trapframe.elr as usize);
         task.vcpu.lock().store(trapframe);
-        task.exit(exit_status);
+        task.exit_group(exit_status);
         schedule(trapframe);
         return;
     }

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -447,6 +447,10 @@ impl Trapframe {
         self.regs.reg[10] = value; // a0
     }
 
+    pub fn set_tls_pointer(&mut self, ptr: usize) {
+        self.regs.set_tp(ptr);
+    }
+
     pub fn get_arg(&self, index: usize) -> usize {
         self.regs.reg[index + 10] // a0 - a7
     }

--- a/kernel/src/arch/riscv64/trap/exception.rs
+++ b/kernel/src/arch/riscv64/trap/exception.rs
@@ -2,11 +2,19 @@ use core::arch::asm;
 use core::panic;
 
 use crate::abi::syscall_dispatcher;
-use crate::arch::trap::print_traplog;
+use crate::arch::trap::{PRIV_U_MODE, prev_mode, print_traplog};
 use crate::arch::{Trapframe, get_cpu};
 use crate::println;
-use crate::sched::scheduler::current_task;
+use crate::sched::scheduler::{current_task, schedule};
 use crate::task::mytask;
+
+const USER_PAGE_FAULT_EXIT_STATUS: i32 = 139;
+const USER_ILLEGAL_INSTRUCTION_EXIT_STATUS: i32 = 132;
+const USER_BREAKPOINT_EXIT_STATUS: i32 = 133;
+
+fn trap_from_user() -> bool {
+    prev_mode() == PRIV_U_MODE
+}
 
 fn log_fatal_page_fault_context(
     trapframe: &Trapframe,
@@ -35,6 +43,43 @@ fn log_fatal_page_fault_context(
     println!(
         "[Trap] epc={:#x} vaddr={:#x} ra={:#x} sp={:#x} fp={:#x}",
         epc, vaddr, ra, sp, fp
+    );
+}
+
+fn terminate_current_user_exception(
+    trapframe: &mut Trapframe,
+    cause: usize,
+    event_kind: &str,
+    vaddr: usize,
+    exit_status: i32,
+) {
+    print_traplog(trapframe);
+    if let Some(task) = current_task(get_cpu().get_cpuid()) {
+        println!(
+            "Task {} (PID {}) caused {} at vaddr: {:#x} from PC: {:#x}",
+            task.name.read(),
+            task.get_id(),
+            event_kind,
+            vaddr,
+            trapframe.epc
+        );
+        log_fatal_page_fault_context(
+            trapframe,
+            cause,
+            vaddr,
+            task.get_id(),
+            &task.name.read(),
+            task.vm_manager.get_asid(),
+        );
+        task.vcpu.lock().store(trapframe);
+        task.exit_group(exit_status);
+        schedule(trapframe);
+        return;
+    }
+
+    panic!(
+        "Unhandled user {} at vaddr: {:#x} from PC: {:#x}",
+        event_kind, vaddr, trapframe.epc
     );
 }
 
@@ -190,6 +235,16 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, cause: usize) {
                 return;
             }
 
+            if trap_from_user() {
+                terminate_current_user_exception(
+                    trapframe,
+                    cause,
+                    "illegal instruction",
+                    trapframe.epc as usize,
+                    USER_ILLEGAL_INSTRUCTION_EXIT_STATUS,
+                );
+                return;
+            }
             print_traplog(trapframe);
             panic!(
                 "Unhandled illegal instruction: inst={:#x} epc={:#x}",
@@ -206,6 +261,16 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, cause: usize) {
                 unreachable!();
             }
 
+            if trap_from_user() {
+                terminate_current_user_exception(
+                    trapframe,
+                    cause,
+                    "breakpoint",
+                    trapframe.epc as usize,
+                    USER_BREAKPOINT_EXIT_STATUS,
+                );
+                return;
+            }
             print_traplog(trapframe);
             panic!("Unhandled breakpoint: epc={:#x}", trapframe.epc);
         }
@@ -240,6 +305,16 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, cause: usize) {
                 match task.vm_manager.lazy_map_page_with(access) {
                     Ok(_) => (),
                     Err(_) => {
+                        if trap_from_user() {
+                            terminate_current_user_exception(
+                                trapframe,
+                                cause,
+                                "instruction page fault",
+                                vaddr,
+                                USER_PAGE_FAULT_EXIT_STATUS,
+                            );
+                            return;
+                        }
                         print_traplog(trapframe);
                         log_fatal_page_fault_context(
                             trapframe,
@@ -285,6 +360,21 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, cause: usize) {
                 match task.vm_manager.lazy_map_page_with(access) {
                     Ok(_) => (),
                     Err(e) => {
+                        if trap_from_user() {
+                            let event_kind = if cause == LOAD_PAGE_FAULT {
+                                "load page fault"
+                            } else {
+                                "store page fault"
+                            };
+                            terminate_current_user_exception(
+                                trapframe,
+                                cause,
+                                event_kind,
+                                vaddr,
+                                USER_PAGE_FAULT_EXIT_STATUS,
+                            );
+                            return;
+                        }
                         print_traplog(trapframe);
                         log_fatal_page_fault_context(
                             trapframe,
@@ -316,6 +406,16 @@ pub fn arch_exception_handler(trapframe: &mut Trapframe, cause: usize) {
             }
         }
         _ => {
+            if trap_from_user() {
+                terminate_current_user_exception(
+                    trapframe,
+                    cause,
+                    "unhandled exception",
+                    trapframe.epc as usize,
+                    USER_ILLEGAL_INSTRUCTION_EXIT_STATUS,
+                );
+                return;
+            }
             print_traplog(trapframe);
             panic!("Unhandled exception: {}", cause);
         }

--- a/kernel/src/drivers/special/cpuinfo.rs
+++ b/kernel/src/drivers/special/cpuinfo.rs
@@ -67,6 +67,13 @@ impl CpuInfoDevice {
             let _ = writeln!(output, "online\t\t: yes");
             let _ = writeln!(output, "core class\t: {}", topology.core_class.as_str());
             let _ = writeln!(output, "cpu capacity\t: {}", topology.capacity);
+            if let Some(domain_id) = topology.domain_id {
+                let _ = writeln!(output, "topology domain\t: 0x{:x}", domain_id);
+                let _ = writeln!(output, "domain cpus\t: 0x{:x}", topology.domain_cpus_mask);
+            } else {
+                let _ = writeln!(output, "topology domain\t: none");
+                let _ = writeln!(output, "domain cpus\t: 0x0");
+            }
             let _ = writeln!(output, "util scale\t: {}", SCHED_UTIL_SCALE);
             if let Some(util) = crate::sched::scheduler::cpu_util_snapshot(cpu_id) {
                 let _ = writeln!(output, "util avg\t: {}", util.util_avg);

--- a/kernel/src/drivers/special/cpuinfo.rs
+++ b/kernel/src/drivers/special/cpuinfo.rs
@@ -53,6 +53,25 @@ impl CpuInfoDevice {
 
     fn render() -> String {
         let mut output = String::new();
+        let migration_stats = crate::sched::scheduler::scheduler_migration_stats();
+
+        let _ = writeln!(output, "scheduler migrations\t: {}", migration_stats.total);
+        let _ = writeln!(
+            output,
+            "scheduler promotions\t: {}",
+            migration_stats.promotions
+        );
+        let _ = writeln!(
+            output,
+            "scheduler demotions\t: {}",
+            migration_stats.demotions
+        );
+        let _ = writeln!(
+            output,
+            "scheduler cooldown skips\t: {}",
+            migration_stats.cooldown_skips
+        );
+        let _ = writeln!(output);
 
         for cpu_id in 0..MAX_NUM_CPUS {
             if !is_cpu_online(cpu_id) {

--- a/kernel/src/drivers/special/cpuinfo.rs
+++ b/kernel/src/drivers/special/cpuinfo.rs
@@ -71,6 +71,11 @@ impl CpuInfoDevice {
             "scheduler cooldown skips\t: {}",
             migration_stats.cooldown_skips
         );
+        let _ = writeln!(
+            output,
+            "scheduler work steals\t: {}",
+            migration_stats.work_steals
+        );
         let _ = writeln!(output);
 
         for cpu_id in 0..MAX_NUM_CPUS {

--- a/kernel/src/drivers/special/cpuinfo.rs
+++ b/kernel/src/drivers/special/cpuinfo.rs
@@ -53,25 +53,6 @@ impl CpuInfoDevice {
 
     fn render() -> String {
         let mut output = String::new();
-        let migration_stats = crate::sched::scheduler::scheduler_migration_stats();
-
-        let _ = writeln!(output, "scheduler migrations\t: {}", migration_stats.total);
-        let _ = writeln!(
-            output,
-            "scheduler promotions\t: {}",
-            migration_stats.promotions
-        );
-        let _ = writeln!(
-            output,
-            "scheduler demotions\t: {}",
-            migration_stats.demotions
-        );
-        let _ = writeln!(
-            output,
-            "scheduler cooldown skips\t: {}",
-            migration_stats.cooldown_skips
-        );
-        let _ = writeln!(output);
 
         for cpu_id in 0..MAX_NUM_CPUS {
             if !is_cpu_online(cpu_id) {

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -1061,6 +1061,24 @@ fn task_min_cpu_capacity_at(task: Option<&Task>, now_ns: u64) -> u32 {
     core::cmp::max(preference_min, task_effective_util(task, now_ns))
 }
 
+/// Return the scheduler capacity required by a task at a point in time.
+///
+/// This combines measured utilization, the task's `util_min` clamp, and its
+/// core preference hint. It is intended for diagnostics and should match the
+/// placement policy's capacity floor.
+///
+/// # Arguments
+///
+/// * `task` - Task whose placement capacity should be reported.
+/// * `now_ns` - Current monotonic timestamp in nanoseconds.
+///
+/// # Returns
+///
+/// Required CPU capacity in scheduler units.
+pub fn task_required_capacity_snapshot(task: &Task, now_ns: u64) -> u32 {
+    task_min_cpu_capacity_at(Some(task), now_ns)
+}
+
 fn cpu_better_for_preference(
     candidate_cpu: usize,
     best_cpu: usize,
@@ -2536,6 +2554,7 @@ mod tests {
         assert!(!ready_queue(0).lock().contains(&task_id));
         assert_eq!(task.running_cpu.load(Ordering::SeqCst), 1);
         assert_eq!(task.last_cpu.load(Ordering::SeqCst), 1);
+        assert_eq!(task.sched_migration_count(), 1);
 
         let stats = scheduler_migration_stats();
         assert_eq!(stats.total, 0);
@@ -2684,6 +2703,7 @@ mod tests {
         assert_eq!(task.running_cpu.load(Ordering::SeqCst), NO_CPU);
         assert_eq!(task.last_cpu.load(Ordering::SeqCst), 1);
         assert!(ready_queue(1).lock().contains(&task_id));
+        assert_eq!(task.sched_migration_count(), 1);
         let stats = scheduler_migration_stats();
         assert_eq!(stats.total, 1);
         assert_eq!(stats.promotions, 1);

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -625,20 +625,29 @@ fn release_deferred_prev(cpu_id: usize) {
             task.state.store(TaskState::Ready, Ordering::SeqCst);
             return;
         }
-        // Requeue the previous task after its context has been saved. At this
-        // point `running_cpu` has been released, so another CPU may safely
-        // claim the saved kernel context from its ready queue.
-        if matches!(task.state.load(Ordering::SeqCst), TaskState::Ready) {
-            let now_ns = get_time_ns();
-            let target_cpu = migration_target_for_task(task, cpu_id, now_ns, true)
-                .filter(|&target_cpu| is_cpu_online(target_cpu))
-                .unwrap_or(cpu_id);
-            if target_cpu != cpu_id {
-                record_scheduler_migration(task, cpu_id, target_cpu, now_ns);
+        match task.state.load(Ordering::SeqCst) {
+            // Requeue the previous task after its context has been saved. At
+            // this point `running_cpu` has been released, so another CPU may
+            // safely claim the saved kernel context from its ready queue.
+            TaskState::Ready => {
+                let now_ns = get_time_ns();
+                let target_cpu = migration_target_for_task(task, cpu_id, now_ns, true)
+                    .filter(|&target_cpu| is_cpu_online(target_cpu))
+                    .unwrap_or(cpu_id);
+                if target_cpu != cpu_id {
+                    record_scheduler_migration(task, cpu_id, target_cpu, now_ns);
+                }
+                task.last_cpu.store(target_cpu, Ordering::SeqCst);
+                push_ready_task(target_cpu, prev_id);
+                notify_remote_ready_task(target_cpu, prev_id, "migrate-ipi-send");
             }
-            task.last_cpu.store(target_cpu, Ordering::SeqCst);
-            push_ready_task(target_cpu, prev_id);
-            notify_remote_ready_task(target_cpu, prev_id, "migrate-ipi-send");
+            TaskState::Zombie => {
+                finalize_zombie(prev_id, task.get_parent_id());
+            }
+            TaskState::Terminated => {
+                cleanup_zombie(prev_id);
+            }
+            TaskState::Running | TaskState::Blocked(_) | TaskState::NotInitialized => {}
         }
     }
 }
@@ -2888,5 +2897,26 @@ mod tests {
         let stats = scheduler_migration_stats();
         assert_eq!(stats.total, 1);
         assert_eq!(stats.promotions, 1);
+    }
+
+    #[test_case]
+    fn test_deferred_release_cleans_terminated_task() {
+        reset();
+        register_online_cpu(0);
+
+        let task_id = register_task(Task::new(
+            "DetachedThreadTask".to_string(),
+            1,
+            TaskType::Kernel,
+        ));
+        let task = TaskPool::get_task(task_id).unwrap();
+        task.state.store(TaskState::Terminated, Ordering::SeqCst);
+        task.running_cpu.store(0, Ordering::SeqCst);
+        let generation = get_task_pool().task_generation(task_id).unwrap();
+        SCHEDULE_PREV_TASK[0].store(encode_prev_task(task_id, generation), Ordering::SeqCst);
+
+        release_deferred_prev(0);
+
+        assert!(TaskPool::get_task(task_id).is_none());
     }
 }

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -521,7 +521,7 @@ pub struct CpuUtilSnapshot {
 /// Scheduler migration accounting snapshot.
 #[derive(Debug, Clone, Copy)]
 pub struct SchedulerMigrationStats {
-    /// Number of scheduler-driven CPU migrations.
+    /// Number of capacity-directed scheduler migrations.
     pub total: u64,
     /// Number of migrations to a higher-capacity CPU.
     pub promotions: u64,
@@ -1187,6 +1187,9 @@ fn steal_candidate_from_cpu(
         if !task_can_run_on_cpu(task, target_cpu, now_ns) {
             continue;
         }
+        if migration_cooldown_active(task, now_ns, false) {
+            continue;
+        }
 
         candidate = Some(task_id);
     }
@@ -1257,8 +1260,7 @@ fn steal_ready_task_for_cpu(target_cpu: usize, now_ns: u64) -> Option<usize> {
         return None;
     }
 
-    record_scheduler_migration(task, victim_cpu, target_cpu, now_ns);
-    SCHED_WORK_STEALS.fetch_add(1, Ordering::SeqCst);
+    record_work_steal(task, now_ns);
     Some(task_id)
 }
 
@@ -1346,29 +1348,34 @@ fn migration_target_for_task(
     let required_capacity = task_min_cpu_capacity_at(Some(task), now_ns);
 
     if required_capacity > current_capacity {
-        if migration_cooldown_active(task, now_ns, record_skip) {
-            return None;
-        }
-
         let target_cpu = select_target_cpu_at(Some(task), now_ns);
         let target_capacity = cpu_capacity(target_cpu);
         if target_cpu != current_cpu
             && target_capacity > current_capacity
             && target_capacity >= required_capacity
         {
+            if migration_cooldown_active(task, now_ns, record_skip) {
+                return None;
+            }
             return Some(target_cpu);
         }
         return None;
     }
 
     if current_capacity > required_capacity.saturating_add(SCHED_DEMOTION_MARGIN) {
+        let target_cpu = select_lower_capacity_cpu(task, current_cpu, required_capacity)?;
         if migration_cooldown_active(task, now_ns, record_skip) {
             return None;
         }
-        return select_lower_capacity_cpu(task, current_cpu, required_capacity);
+        return Some(target_cpu);
     }
 
     None
+}
+
+fn record_work_steal(task: &Task, now_ns: u64) {
+    SCHED_WORK_STEALS.fetch_add(1, Ordering::SeqCst);
+    task.mark_sched_migrated(now_ns);
 }
 
 fn record_scheduler_migration(task: &Task, from_cpu: usize, to_cpu: usize, now_ns: u64) {
@@ -2516,8 +2523,31 @@ mod tests {
         assert_eq!(task.last_cpu.load(Ordering::SeqCst), 1);
 
         let stats = scheduler_migration_stats();
-        assert_eq!(stats.total, 1);
+        assert_eq!(stats.total, 0);
         assert_eq!(stats.work_steals, 1);
+    }
+
+    #[test_case]
+    fn test_idle_cpu_does_not_steal_recently_migrated_task() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Balanced, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Balanced, 0).unwrap();
+
+        let task_id = register_task(Task::new("CoolingTask".to_string(), 1, TaskType::Kernel));
+        let task = TaskPool::get_task(task_id).unwrap();
+        task.state.store(TaskState::Ready, Ordering::SeqCst);
+        task.mark_sched_migrated(10_000_000);
+        push_ready_task(0, task_id);
+
+        assert_eq!(steal_ready_task_for_cpu(1, 20_000_000), None);
+        assert!(ready_queue(0).lock().contains(&task_id));
+
+        let stats = scheduler_migration_stats();
+        assert_eq!(stats.total, 0);
+        assert_eq!(stats.work_steals, 0);
+        assert_eq!(stats.cooldown_skips, 0);
     }
 
     #[test_case]
@@ -2538,6 +2568,22 @@ mod tests {
     }
 
     #[test_case]
+    fn test_migration_cooldown_skip_counts_when_target_exists() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Efficiency, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+
+        let task = Task::new("CoolingPromotionTask".to_string(), 1, TaskType::Kernel);
+        task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
+        task.mark_sched_migrated(10_000_000);
+
+        assert_eq!(migration_target_for_task(&task, 0, 20_000_000, true), None);
+        assert_eq!(scheduler_migration_stats().cooldown_skips, 1);
+    }
+
+    #[test_case]
     fn test_migration_target_demotes_low_util_task() {
         reset();
         register_online_cpu(0);
@@ -2551,6 +2597,21 @@ mod tests {
             migration_target_for_task(&task, 0, 10_000_000, false),
             Some(1)
         );
+    }
+
+    #[test_case]
+    fn test_migration_cooldown_skip_requires_target_cpu() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Balanced, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Balanced, 0).unwrap();
+
+        let task = Task::new("NoTargetTask".to_string(), 1, TaskType::Kernel);
+        task.mark_sched_migrated(10_000_000);
+
+        assert_eq!(migration_target_for_task(&task, 0, 20_000_000, true), None);
+        assert_eq!(scheduler_migration_stats().cooldown_skips, 0);
     }
 
     #[test_case]

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -412,6 +412,8 @@ const EFFICIENCY_CPU_CAPACITY: u32 = 512;
 const PERFORMANCE_CPU_CAPACITY: u32 = 1536;
 const TASK_LOAD_SCALE: u64 = 1024;
 const MAX_PRIORITY_LOAD_BONUS: u64 = 1024;
+const SCHED_MIGRATION_COOLDOWN_NS: u64 = 100_000_000;
+const SCHED_DEMOTION_MARGIN: u32 = 128;
 
 static CPU_CORE_CLASSES: [AtomicU8; MAX_NUM_CPUS] =
     [const { AtomicU8::new(CpuCoreClass::Balanced as u8) }; MAX_NUM_CPUS];
@@ -420,6 +422,10 @@ static CPU_CAPACITIES: [AtomicU32; MAX_NUM_CPUS] =
 const INVALID_CPU_TOPOLOGY_DOMAIN: u32 = u32::MAX;
 static CPU_TOPOLOGY_DOMAINS: [AtomicU32; MAX_NUM_CPUS] =
     [const { AtomicU32::new(INVALID_CPU_TOPOLOGY_DOMAIN) }; MAX_NUM_CPUS];
+static SCHED_MIGRATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static SCHED_MIGRATION_PROMOTIONS: AtomicU64 = AtomicU64::new(0);
+static SCHED_MIGRATION_DEMOTIONS: AtomicU64 = AtomicU64::new(0);
+static SCHED_MIGRATION_COOLDOWN_SKIPS: AtomicU64 = AtomicU64::new(0);
 
 /// Coarse CPU core class used for heterogeneous scheduling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -508,6 +514,19 @@ pub struct CpuUtilSnapshot {
     pub capacity: u32,
     /// Number of non-idle runnable tasks seen by this CPU.
     pub runnable_tasks: usize,
+}
+
+/// Scheduler migration accounting snapshot.
+#[derive(Debug, Clone, Copy)]
+pub struct SchedulerMigrationStats {
+    /// Number of scheduler-driven CPU migrations.
+    pub total: u64,
+    /// Number of migrations to a higher-capacity CPU.
+    pub promotions: u64,
+    /// Number of migrations to a lower-capacity CPU.
+    pub demotions: u64,
+    /// Number of migration opportunities skipped by cooldown.
+    pub cooldown_skips: u64,
 }
 
 pub fn note_idle_to_user_handoff(cpu_id: usize, task_id: usize) {
@@ -600,14 +619,20 @@ fn release_deferred_prev(cpu_id: usize) {
             task.state.store(TaskState::Ready, Ordering::SeqCst);
             return;
         }
-        // Requeue the previous task on the CPU that just switched away from it.
-        // Kernel-context resume paths are kept CPU-local until the scheduler
-        // has explicit cross-CPU context migration support. Wakeup and clone
-        // placement still provide capacity-aware distribution for tasks before
-        // they have a suspended kernel context.
+        // Requeue the previous task after its context has been saved. At this
+        // point `running_cpu` has been released, so another CPU may safely
+        // claim the saved kernel context from its ready queue.
         if matches!(task.state.load(Ordering::SeqCst), TaskState::Ready) {
-            task.last_cpu.store(cpu_id, Ordering::SeqCst);
-            push_ready_task(cpu_id, prev_id);
+            let now_ns = get_time_ns();
+            let target_cpu = migration_target_for_task(task, cpu_id, now_ns, true)
+                .filter(|&target_cpu| is_cpu_online(target_cpu))
+                .unwrap_or(cpu_id);
+            if target_cpu != cpu_id {
+                record_scheduler_migration(task, cpu_id, target_cpu, now_ns);
+            }
+            task.last_cpu.store(target_cpu, Ordering::SeqCst);
+            push_ready_task(target_cpu, prev_id);
+            notify_remote_ready_task(target_cpu, prev_id, "migrate-ipi-send");
         }
     }
 }
@@ -686,6 +711,20 @@ pub fn cpu_util_snapshot(cpu_id: usize) -> Option<CpuUtilSnapshot> {
         capacity: cpu_capacity(cpu_id),
         runnable_tasks: CPU_RUNNABLE_TASKS[cpu_id].load(Ordering::SeqCst),
     })
+}
+
+/// Return scheduler migration counters.
+///
+/// # Returns
+///
+/// Current scheduler migration accounting snapshot.
+pub fn scheduler_migration_stats() -> SchedulerMigrationStats {
+    SchedulerMigrationStats {
+        total: SCHED_MIGRATIONS_TOTAL.load(Ordering::SeqCst),
+        promotions: SCHED_MIGRATION_PROMOTIONS.load(Ordering::SeqCst),
+        demotions: SCHED_MIGRATION_DEMOTIONS.load(Ordering::SeqCst),
+        cooldown_skips: SCHED_MIGRATION_COOLDOWN_SKIPS.load(Ordering::SeqCst),
+    }
 }
 
 fn account_task_switch(cpu_id: usize, old_id: Option<usize>, next_id: Option<usize>) {
@@ -1073,6 +1112,169 @@ fn select_target_cpu(task: Option<&Task>) -> usize {
     select_target_cpu_at(task, get_time_ns())
 }
 
+fn select_enqueue_cpu_for_task(task: &Task, requested_cpu: usize, now_ns: u64) -> usize {
+    if let Some(pinned_cpu) = task.pinned_cpu {
+        return pinned_cpu;
+    }
+
+    if is_cpu_online(requested_cpu)
+        && cpu_capacity(requested_cpu) >= task_min_cpu_capacity_at(Some(task), now_ns)
+    {
+        requested_cpu
+    } else {
+        select_target_cpu_at(Some(task), now_ns)
+    }
+}
+
+fn select_wake_cpu_for_task(task: &Task, now_ns: u64) -> usize {
+    if let Some(pinned_cpu) = task.pinned_cpu {
+        return pinned_cpu;
+    }
+
+    let min_capacity = task_min_cpu_capacity_at(Some(task), now_ns);
+    let selected = select_target_cpu_at(Some(task), now_ns);
+    let selected_score = cpu_load_score(selected);
+    let last = task.last_cpu.load(Ordering::SeqCst);
+    if is_cpu_online(last)
+        && cpu_capacity(last) >= min_capacity
+        && cpu_load_score(last) <= selected_score
+    {
+        last
+    } else {
+        let current = get_cpu().get_cpuid();
+        if is_cpu_online(current)
+            && cpu_capacity(current) >= min_capacity
+            && cpu_load_score(current) <= selected_score
+        {
+            current
+        } else {
+            selected
+        }
+    }
+}
+
+fn select_lower_capacity_cpu(task: &Task, current_cpu: usize, min_capacity: u32) -> Option<usize> {
+    let cpus = ONLINE_CPUS.lock();
+    let current_capacity = cpu_capacity(current_cpu);
+    let preference = task.core_preference();
+    let mut best: Option<(usize, u64)> = None;
+
+    for &cpu_id in cpus.iter() {
+        if cpu_id == current_cpu {
+            continue;
+        }
+
+        let capacity = cpu_capacity(cpu_id);
+        if capacity >= current_capacity || capacity < min_capacity {
+            continue;
+        }
+
+        let score = cpu_load_score(cpu_id);
+        if best
+            .map(|(best_cpu, best_score)| {
+                score < best_score
+                    || (score == best_score
+                        && (cpu_better_for_preference(cpu_id, best_cpu, preference)
+                            || cpu_capacity(cpu_id) < cpu_capacity(best_cpu)))
+            })
+            .unwrap_or(true)
+        {
+            best = Some((cpu_id, score));
+        }
+    }
+
+    best.map(|(cpu_id, _)| cpu_id)
+}
+
+fn migration_cooldown_active(task: &Task, now_ns: u64, record_skip: bool) -> bool {
+    let last_migration_ns = task.sched_last_migration_ns();
+    let active = last_migration_ns != 0
+        && now_ns.saturating_sub(last_migration_ns) < SCHED_MIGRATION_COOLDOWN_NS;
+    if active && record_skip {
+        SCHED_MIGRATION_COOLDOWN_SKIPS.fetch_add(1, Ordering::SeqCst);
+    }
+    active
+}
+
+fn migration_target_for_task(
+    task: &Task,
+    current_cpu: usize,
+    now_ns: u64,
+    record_skip: bool,
+) -> Option<usize> {
+    if task.pinned_cpu.is_some() || !is_cpu_online(current_cpu) {
+        return None;
+    }
+
+    let current_capacity = cpu_capacity(current_cpu);
+    let required_capacity = task_min_cpu_capacity_at(Some(task), now_ns);
+
+    if required_capacity > current_capacity {
+        if migration_cooldown_active(task, now_ns, record_skip) {
+            return None;
+        }
+
+        let target_cpu = select_target_cpu_at(Some(task), now_ns);
+        let target_capacity = cpu_capacity(target_cpu);
+        if target_cpu != current_cpu
+            && target_capacity > current_capacity
+            && target_capacity >= required_capacity
+        {
+            return Some(target_cpu);
+        }
+        return None;
+    }
+
+    if current_capacity > required_capacity.saturating_add(SCHED_DEMOTION_MARGIN) {
+        if migration_cooldown_active(task, now_ns, record_skip) {
+            return None;
+        }
+        return select_lower_capacity_cpu(task, current_cpu, required_capacity);
+    }
+
+    None
+}
+
+fn record_scheduler_migration(task: &Task, from_cpu: usize, to_cpu: usize, now_ns: u64) {
+    if from_cpu == to_cpu {
+        return;
+    }
+
+    let from_capacity = cpu_capacity(from_cpu);
+    let to_capacity = cpu_capacity(to_cpu);
+    SCHED_MIGRATIONS_TOTAL.fetch_add(1, Ordering::SeqCst);
+    if to_capacity > from_capacity {
+        SCHED_MIGRATION_PROMOTIONS.fetch_add(1, Ordering::SeqCst);
+    } else if to_capacity < from_capacity {
+        SCHED_MIGRATION_DEMOTIONS.fetch_add(1, Ordering::SeqCst);
+    }
+    task.mark_sched_migrated(now_ns);
+}
+
+fn notify_remote_ready_task(target_cpu: usize, task_id: usize, label: &'static str) {
+    if !is_cpu_online(target_cpu) || target_cpu == get_cpu().get_cpuid() {
+        return;
+    }
+
+    let seq = DEBUG_ENQUEUE_SEQ.fetch_add(1, Ordering::SeqCst) + 1;
+    DEBUG_REMOTE_ENQUEUE_TASK[target_cpu].store(encode_task_id(Some(task_id)), Ordering::SeqCst);
+    DEBUG_REMOTE_ENQUEUE_FROM_CPU[target_cpu].store(get_cpu().get_cpuid(), Ordering::SeqCst);
+    DEBUG_REMOTE_ENQUEUE_SEQ[target_cpu].store(seq, Ordering::SeqCst);
+    if DEBUG_SMP_TASK_FLOW {
+        println!(
+            "[SMPDBG {}] seq={} from_cpu={} target_cpu={} task={} name={} ready_len={}",
+            label,
+            seq,
+            get_cpu().get_cpuid(),
+            target_cpu,
+            task_id,
+            debug_task_name(task_id),
+            ready_queue(target_cpu).lock().len(),
+        );
+    }
+    crate::arch::send_reschedule_ipi(target_cpu);
+}
+
 pub fn for_each_online_cpu<F: FnMut(usize)>(mut f: F) {
     let cpus = ONLINE_CPUS.lock();
     for &cpu_id in cpus.iter() {
@@ -1300,13 +1502,27 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                     TaskState::Running | TaskState::Ready
                 )
             {
-                ot.state.store(TaskState::Running, Ordering::SeqCst);
-                ot.time_slice.store(
-                    ot.default_time_slice.load(Ordering::SeqCst),
-                    Ordering::SeqCst,
-                );
-                set_current_task_id(cpu_id, Some(oid));
-                return (old_id, Some(oid));
+                if migration_target_for_task(ot, cpu_id, get_time_ns(), false).is_some() {
+                    let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+                    if idle_id != 0
+                        && oid != idle_id
+                        && let Some(idle_task) = TaskPool::get_task(idle_id)
+                        && try_claim_ready_task(idle_task, cpu_id)
+                    {
+                        next_id = Some(idle_id);
+                    }
+                }
+                if next_id.is_none() {
+                    ot.state.store(TaskState::Running, Ordering::SeqCst);
+                    ot.time_slice.store(
+                        ot.default_time_slice.load(Ordering::SeqCst),
+                        Ordering::SeqCst,
+                    );
+                    set_current_task_id(cpu_id, Some(oid));
+                    return (old_id, Some(oid));
+                }
+                // Fall through to the normal context-switch path. The old task
+                // will be released and migrated from release_deferred_prev().
             }
         }
     }
@@ -1395,17 +1611,7 @@ pub fn enqueue_task(task_id: usize, cpu_id: usize) {
     let _irq_guard = IrqGuard::new();
     let current_cpu = get_cpu().get_cpuid();
     let target_cpu = TaskPool::get_task(task_id)
-        .map(|task| {
-            if let Some(pinned_cpu) = task.pinned_cpu {
-                pinned_cpu
-            } else if is_cpu_online(cpu_id)
-                && cpu_capacity(cpu_id) >= task_min_cpu_capacity_at(Some(task), get_time_ns())
-            {
-                cpu_id
-            } else {
-                select_target_cpu(Some(task))
-            }
-        })
+        .map(|task| select_enqueue_cpu_for_task(task, cpu_id, get_time_ns()))
         .unwrap_or(cpu_id);
     let seq = DEBUG_ENQUEUE_SEQ.fetch_add(1, Ordering::SeqCst) + 1;
     if let Some(task) = TaskPool::get_task(task_id) {
@@ -1622,31 +1828,7 @@ pub fn wake_task(task_id: usize) -> bool {
         let Some(task) = TaskPool::get_task(task_id) else {
             return false;
         };
-        if let Some(pinned) = task.pinned_cpu {
-            pinned
-        } else {
-            let now_ns = get_time_ns();
-            let min_capacity = task_min_cpu_capacity_at(Some(task), now_ns);
-            let selected = select_target_cpu_at(Some(task), now_ns);
-            let selected_score = cpu_load_score(selected);
-            let last = task.last_cpu.load(Ordering::SeqCst);
-            if is_cpu_online(last)
-                && cpu_capacity(last) >= min_capacity
-                && cpu_load_score(last) <= selected_score
-            {
-                last
-            } else {
-                let current = get_cpu().get_cpuid();
-                if is_cpu_online(current)
-                    && cpu_capacity(current) >= min_capacity
-                    && cpu_load_score(current) <= selected_score
-                {
-                    current
-                } else {
-                    selected
-                }
-            }
-        }
+        select_wake_cpu_for_task(task, get_time_ns())
     };
     wake_task_on(task_id, target_cpu)
 }
@@ -1863,12 +2045,15 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
                 crate::arch::switch::switch_to(from_ctx_ptr, to_ctx_ptr);
             }
 
+            let resumed_cpu_id = get_cpu().get_cpuid();
+
             if DEBUG_SMP_TASK_FLOW {
-                let (expected_task, _from_cpu, seq) = debug_remote_enqueue_snapshot(cpu_id);
+                let (expected_task, _from_cpu, seq) = debug_remote_enqueue_snapshot(resumed_cpu_id);
                 if expected_task.is_some() {
                     println!(
-                        "[SMPDBG kctx-resume] cpu={} resumed={} resumed_name={} switched_from={} expected_task={:?} seq={}",
+                        "[SMPDBG kctx-resume] from_cpu={} resumed_cpu={} resumed={} resumed_name={} switched_from={} expected_task={:?} seq={}",
                         cpu_id,
+                        resumed_cpu_id,
                         from_task_id,
                         debug_task_name(from_task_id),
                         to_task_id,
@@ -1878,7 +2063,11 @@ fn kernel_context_switch(cpu_id: usize, from_task_id: usize, to_task_id: usize) 
                 }
             }
 
-            release_deferred_prev(cpu_id);
+            // The saved kernel context may resume on a different CPU after
+            // scheduler migration. Release the deferred previous task for the
+            // CPU we are actually running on now, not for the CPU that saved
+            // this stack frame before the switch.
+            release_deferred_prev(resumed_cpu_id);
 
             #[cfg(feature = "hypervisor")]
             {
@@ -1956,6 +2145,10 @@ pub fn reset() {
     NEXT_CPU.store(0, Ordering::SeqCst);
     DEBUG_TICK.store(0, Ordering::SeqCst);
     DEBUG_ENQUEUE_SEQ.store(0, Ordering::SeqCst);
+    SCHED_MIGRATIONS_TOTAL.store(0, Ordering::SeqCst);
+    SCHED_MIGRATION_PROMOTIONS.store(0, Ordering::SeqCst);
+    SCHED_MIGRATION_DEMOTIONS.store(0, Ordering::SeqCst);
+    SCHED_MIGRATION_COOLDOWN_SKIPS.store(0, Ordering::SeqCst);
     TOTAL_BUSY_CPU_TIME_NS.store(0, Ordering::SeqCst);
     TOTAL_IDLE_CPU_TIME_NS.store(0, Ordering::SeqCst);
     ONLINE_CPUS.lock().clear();
@@ -2138,5 +2331,68 @@ mod tests {
         task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
 
         assert_eq!(select_cpu_for_task(&task), 1);
+    }
+
+    #[test_case]
+    fn test_migration_target_promotes_over_capacity_task() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Efficiency, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+
+        let task = Task::new("MigratingTask".to_string(), 1, TaskType::Kernel);
+        task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
+
+        assert_eq!(
+            migration_target_for_task(&task, 0, 20_000_000, false),
+            Some(1)
+        );
+    }
+
+    #[test_case]
+    fn test_migration_target_demotes_low_util_task() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Efficiency, 0).unwrap();
+
+        let task = Task::new("LowUtilTask".to_string(), 1, TaskType::Kernel);
+
+        assert_eq!(
+            migration_target_for_task(&task, 0, 10_000_000, false),
+            Some(1)
+        );
+    }
+
+    #[test_case]
+    fn test_deferred_release_migrates_ready_task() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Efficiency, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+
+        let task_id = register_task(Task::new(
+            "DeferredMigrationTask".to_string(),
+            1,
+            TaskType::Kernel,
+        ));
+        let task = TaskPool::get_task(task_id).unwrap();
+        task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
+        task.state.store(TaskState::Ready, Ordering::SeqCst);
+        task.running_cpu.store(0, Ordering::SeqCst);
+        let generation = get_task_pool().task_generation(task_id).unwrap();
+        SCHEDULE_PREV_TASK[0].store(encode_prev_task(task_id, generation), Ordering::SeqCst);
+
+        release_deferred_prev(0);
+
+        assert_eq!(task.running_cpu.load(Ordering::SeqCst), NO_CPU);
+        assert_eq!(task.last_cpu.load(Ordering::SeqCst), 1);
+        assert!(ready_queue(1).lock().contains(&task_id));
+        let stats = scheduler_migration_stats();
+        assert_eq!(stats.total, 1);
+        assert_eq!(stats.promotions, 1);
     }
 }

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -416,6 +416,7 @@ const SCHED_MIGRATION_COOLDOWN_NS: u64 = 100_000_000;
 const SCHED_DEMOTION_MARGIN: u32 = 128;
 const SCHED_DEMOTION_SUSTAIN_NS: u64 = 250_000_000;
 const SCHED_STEAL_SCAN_LIMIT: usize = 8;
+const SCHED_LATERAL_BALANCE_MARGIN: u64 = TASK_LOAD_SCALE / 4;
 
 static CPU_CORE_CLASSES: [AtomicU8; MAX_NUM_CPUS] =
     [const { AtomicU8::new(CpuCoreClass::Balanced as u8) }; MAX_NUM_CPUS];
@@ -1019,6 +1020,22 @@ fn runnable_task_weight(task_id: usize) -> u64 {
     task_load_weight(TaskPool::get_task(task_id))
 }
 
+fn task_load_score_on_cpu(task: &Task, cpu_id: usize) -> u64 {
+    task_load_weight(Some(task)).saturating_mul(TASK_LOAD_SCALE) / cpu_capacity(cpu_id) as u64
+}
+
+fn task_present_on_cpu(cpu_id: usize, task_id: usize) -> bool {
+    if task_id == 0 {
+        return false;
+    }
+
+    if current_task_id(cpu_id) == Some(task_id) {
+        return true;
+    }
+
+    ready_queue(cpu_id).lock().contains(&task_id)
+}
+
 fn cpu_runnable_weight(cpu_id: usize) -> u64 {
     let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
     let mut weight = 0u64;
@@ -1042,6 +1059,30 @@ fn cpu_runnable_weight(cpu_id: usize) -> u64 {
 fn cpu_load_score(cpu_id: usize) -> u64 {
     let capacity = cpu_capacity(cpu_id) as u64;
     cpu_runnable_weight(cpu_id).saturating_mul(TASK_LOAD_SCALE) / capacity
+}
+
+fn cpu_load_score_with_task(cpu_id: usize, task: &Task) -> u64 {
+    let score = cpu_load_score(cpu_id);
+    if task
+        .registered_id()
+        .is_some_and(|task_id| task_present_on_cpu(cpu_id, task_id))
+    {
+        score
+    } else {
+        score.saturating_add(task_load_score_on_cpu(task, cpu_id))
+    }
+}
+
+fn cpu_load_score_without_task(cpu_id: usize, task: &Task) -> u64 {
+    let score = cpu_load_score(cpu_id);
+    if task
+        .registered_id()
+        .is_some_and(|task_id| task_present_on_cpu(cpu_id, task_id))
+    {
+        score.saturating_sub(task_load_score_on_cpu(task, cpu_id))
+    } else {
+        score
+    }
 }
 
 fn task_effective_util(task: Option<&Task>, now_ns: u64) -> u32 {
@@ -1343,6 +1384,65 @@ fn select_lower_capacity_cpu(task: &Task, current_cpu: usize, min_capacity: u32)
     best.map(|(cpu_id, _)| cpu_id)
 }
 
+fn same_balance_domain(current_cpu: usize, candidate_cpu: usize) -> bool {
+    match (
+        cpu_topology_domain(current_cpu),
+        cpu_topology_domain(candidate_cpu),
+    ) {
+        (Some(current_domain), Some(candidate_domain)) => current_domain == candidate_domain,
+        (None, None) => cpu_capacity(current_cpu) == cpu_capacity(candidate_cpu),
+        _ => false,
+    }
+}
+
+fn select_lateral_balance_cpu(
+    task: &Task,
+    current_cpu: usize,
+    now_ns: u64,
+    required_capacity: u32,
+) -> Option<usize> {
+    let cpus = ONLINE_CPUS.lock();
+    if cpus.len() <= 1 {
+        return None;
+    }
+
+    let current_score = cpu_load_score_with_task(current_cpu, task);
+    let current_after = cpu_load_score_without_task(current_cpu, task);
+    let mut best: Option<(usize, u64)> = None;
+
+    for &cpu_id in cpus.iter() {
+        if cpu_id == current_cpu {
+            continue;
+        }
+        if !same_balance_domain(current_cpu, cpu_id) {
+            continue;
+        }
+        if cpu_capacity(cpu_id) < required_capacity {
+            continue;
+        }
+        if !task_can_run_on_cpu(task, cpu_id, now_ns) {
+            continue;
+        }
+
+        let target_score = cpu_load_score(cpu_id);
+        let target_after = target_score.saturating_add(task_load_score_on_cpu(task, cpu_id));
+        let before_max = current_score.max(target_score);
+        let after_max = current_after.max(target_after);
+        if after_max.saturating_add(SCHED_LATERAL_BALANCE_MARGIN) >= before_max {
+            continue;
+        }
+
+        if best
+            .map(|(_, best_after)| target_after < best_after)
+            .unwrap_or(true)
+        {
+            best = Some((cpu_id, target_after));
+        }
+    }
+
+    best.map(|(cpu_id, _)| cpu_id)
+}
+
 fn migration_cooldown_active(task: &Task, now_ns: u64, record_skip: bool) -> bool {
     let last_migration_ns = task.sched_last_migration_ns();
     let active = last_migration_ns != 0
@@ -1388,21 +1488,29 @@ fn migration_target_for_task(
     }
 
     if current_capacity > required_capacity.saturating_add(SCHED_DEMOTION_MARGIN) {
-        let Some(target_cpu) = select_lower_capacity_cpu(task, current_cpu, required_capacity)
-        else {
+        if let Some(target_cpu) = select_lower_capacity_cpu(task, current_cpu, required_capacity) {
+            if demotion_low_util_sustained(task, now_ns) {
+                if migration_cooldown_active(task, now_ns, record_skip) {
+                    return None;
+                }
+                return Some(target_cpu);
+            }
+        } else {
             task.clear_sched_low_util();
-            return None;
-        };
-        if !demotion_low_util_sustained(task, now_ns) {
-            return None;
         }
+    } else {
+        task.clear_sched_low_util();
+    }
+
+    if let Some(target_cpu) =
+        select_lateral_balance_cpu(task, current_cpu, now_ns, required_capacity)
+    {
         if migration_cooldown_active(task, now_ns, record_skip) {
             return None;
         }
         return Some(target_cpu);
     }
 
-    task.clear_sched_low_util();
     None
 }
 
@@ -2636,6 +2744,79 @@ mod tests {
         assert_eq!(
             migration_target_for_task(&task, 0, 10_000_000 + SCHED_DEMOTION_SUSTAIN_NS, false),
             Some(1)
+        );
+    }
+
+    #[test_case]
+    fn test_migration_target_balances_within_topology_domain() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology_domain(0, 0xd).unwrap();
+        register_cpu_topology_domain(1, 0xd).unwrap();
+
+        let resident_id = register_task(Task::new("ResidentTask".to_string(), 1, TaskType::Kernel));
+        let resident = TaskPool::get_task(resident_id).unwrap();
+        resident.state.store(TaskState::Running, Ordering::SeqCst);
+        resident.running_cpu.store(0, Ordering::SeqCst);
+        set_current_task_id(0, Some(resident_id));
+
+        let migrating_id = register_task(Task::new("PackedTask".to_string(), 1, TaskType::Kernel));
+        let migrating = TaskPool::get_task(migrating_id).unwrap();
+        migrating.state.store(TaskState::Ready, Ordering::SeqCst);
+
+        assert_eq!(
+            migration_target_for_task(migrating, 0, 20_000_000, false),
+            Some(1)
+        );
+    }
+
+    #[test_case]
+    fn test_migration_target_keeps_single_task_local() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology_domain(0, 0xd).unwrap();
+        register_cpu_topology_domain(1, 0xd).unwrap();
+
+        let task_id = register_task(Task::new("SingleTask".to_string(), 1, TaskType::Kernel));
+        let task = TaskPool::get_task(task_id).unwrap();
+        task.state.store(TaskState::Running, Ordering::SeqCst);
+        task.running_cpu.store(0, Ordering::SeqCst);
+        set_current_task_id(0, Some(task_id));
+
+        assert_eq!(migration_target_for_task(task, 0, 20_000_000, false), None);
+    }
+
+    #[test_case]
+    fn test_lateral_balance_stays_inside_topology_domain() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology_domain(0, 0xd).unwrap();
+        register_cpu_topology_domain(1, 0xe).unwrap();
+
+        let resident_id =
+            register_task(Task::new("DomainResident".to_string(), 1, TaskType::Kernel));
+        let resident = TaskPool::get_task(resident_id).unwrap();
+        resident.state.store(TaskState::Running, Ordering::SeqCst);
+        resident.running_cpu.store(0, Ordering::SeqCst);
+        set_current_task_id(0, Some(resident_id));
+
+        let migrating_id =
+            register_task(Task::new("DomainPinned".to_string(), 1, TaskType::Kernel));
+        let migrating = TaskPool::get_task(migrating_id).unwrap();
+        migrating.state.store(TaskState::Ready, Ordering::SeqCst);
+
+        assert_eq!(
+            migration_target_for_task(migrating, 0, 20_000_000, false),
+            None
         );
     }
 

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -417,6 +417,9 @@ static CPU_CORE_CLASSES: [AtomicU8; MAX_NUM_CPUS] =
     [const { AtomicU8::new(CpuCoreClass::Balanced as u8) }; MAX_NUM_CPUS];
 static CPU_CAPACITIES: [AtomicU32; MAX_NUM_CPUS] =
     [const { AtomicU32::new(DEFAULT_CPU_CAPACITY) }; MAX_NUM_CPUS];
+const INVALID_CPU_TOPOLOGY_DOMAIN: u32 = u32::MAX;
+static CPU_TOPOLOGY_DOMAINS: [AtomicU32; MAX_NUM_CPUS] =
+    [const { AtomicU32::new(INVALID_CPU_TOPOLOGY_DOMAIN) }; MAX_NUM_CPUS];
 
 /// Coarse CPU core class used for heterogeneous scheduling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -475,6 +478,10 @@ pub struct CpuTopology {
     pub core_class: CpuCoreClass,
     /// Relative compute capacity in scheduler units.
     pub capacity: u32,
+    /// Optional scheduler topology domain ID.
+    pub domain_id: Option<u32>,
+    /// CPU mask for CPUs registered in the same topology domain.
+    pub domain_cpus_mask: u64,
 }
 
 /// Scheduler CPU accounting snapshot.
@@ -777,6 +784,26 @@ pub fn register_online_cpu(cpu_id: usize) {
     }
 }
 
+fn cpu_mask_bit(cpu_id: usize) -> u64 {
+    if cpu_id >= u64::BITS as usize {
+        0
+    } else {
+        1u64 << cpu_id
+    }
+}
+
+/// Return a bitmask of scheduler-online CPUs.
+///
+/// # Returns
+///
+/// A CPU mask with bit `n` set when scheduler CPU `n` is online. CPU IDs that
+/// do not fit in a 64-bit mask are omitted.
+pub fn online_cpu_mask() -> u64 {
+    let cpus = ONLINE_CPUS.lock();
+    cpus.iter()
+        .fold(0u64, |mask, &cpu_id| mask | cpu_mask_bit(cpu_id))
+}
+
 fn sanitize_cpu_capacity(core_class: CpuCoreClass, capacity: u32) -> u32 {
     let capacity = if capacity == 0 {
         core_class.default_capacity()
@@ -818,6 +845,78 @@ pub fn register_cpu_topology(
     Ok(())
 }
 
+/// Register scheduler topology domain information for a CPU.
+///
+/// Architecture code should call this when firmware exposes a stable CPU
+/// grouping, such as an Apple Silicon performance/DVFS domain. The scheduler
+/// treats missing domain information as "unknown" rather than as a stable ABI.
+///
+/// # Arguments
+///
+/// * `cpu_id` - Scheduler CPU ID.
+/// * `domain_id` - Platform topology domain identifier.
+///
+/// # Returns
+///
+/// `Ok(())` on success, or an error if the CPU ID or domain ID is invalid.
+pub fn register_cpu_topology_domain(cpu_id: usize, domain_id: u32) -> Result<(), &'static str> {
+    if cpu_id >= MAX_NUM_CPUS {
+        return Err("CPU ID out of bounds");
+    }
+    if domain_id == INVALID_CPU_TOPOLOGY_DOMAIN {
+        return Err("Invalid CPU topology domain");
+    }
+
+    CPU_TOPOLOGY_DOMAINS[cpu_id].store(domain_id, Ordering::SeqCst);
+    Ok(())
+}
+
+/// Return the registered topology domain for a CPU.
+///
+/// # Arguments
+///
+/// * `cpu_id` - Scheduler CPU ID.
+///
+/// # Returns
+///
+/// The registered domain ID, or `None` if the CPU ID is invalid or the
+/// platform did not provide domain information.
+pub fn cpu_topology_domain(cpu_id: usize) -> Option<u32> {
+    if cpu_id >= MAX_NUM_CPUS {
+        return None;
+    }
+
+    let domain_id = CPU_TOPOLOGY_DOMAINS[cpu_id].load(Ordering::SeqCst);
+    (domain_id != INVALID_CPU_TOPOLOGY_DOMAIN).then_some(domain_id)
+}
+
+fn cpu_topology_domain_mask(domain_id: u32) -> u64 {
+    let mut mask = 0u64;
+    for cpu_id in 0..MAX_NUM_CPUS {
+        if cpu_topology_domain(cpu_id) == Some(domain_id) {
+            mask |= cpu_mask_bit(cpu_id);
+        }
+    }
+    mask
+}
+
+/// Return the online CPU mask for a scheduler topology domain.
+///
+/// # Arguments
+///
+/// * `domain_id` - Platform topology domain identifier.
+///
+/// # Returns
+///
+/// A CPU mask containing online CPUs in the requested domain. CPU IDs that do
+/// not fit in a 64-bit mask are omitted.
+pub fn cpu_topology_domain_online_mask(domain_id: u32) -> u64 {
+    let cpus = ONLINE_CPUS.lock();
+    cpus.iter()
+        .filter(|&&cpu_id| cpu_topology_domain(cpu_id) == Some(domain_id))
+        .fold(0u64, |mask, &cpu_id| mask | cpu_mask_bit(cpu_id))
+}
+
 /// Return scheduler topology information for a CPU.
 ///
 /// # Arguments
@@ -833,10 +932,13 @@ pub fn cpu_topology(cpu_id: usize) -> Option<CpuTopology> {
     }
 
     let core_class = CpuCoreClass::from_u8(CPU_CORE_CLASSES[cpu_id].load(Ordering::SeqCst));
+    let domain_id = cpu_topology_domain(cpu_id);
     Some(CpuTopology {
         cpu_id,
         core_class,
         capacity: sanitize_cpu_capacity(core_class, CPU_CAPACITIES[cpu_id].load(Ordering::SeqCst)),
+        domain_id,
+        domain_cpus_mask: domain_id.map(cpu_topology_domain_mask).unwrap_or(0),
     })
 }
 
@@ -1810,6 +1912,7 @@ pub fn reset() {
         PENDING_IDLE_TO_USER_TRAP_TASK[cpu_id].store(0, Ordering::SeqCst);
         CPU_CORE_CLASSES[cpu_id].store(CpuCoreClass::Balanced as u8, Ordering::SeqCst);
         CPU_CAPACITIES[cpu_id].store(DEFAULT_CPU_CAPACITY, Ordering::SeqCst);
+        CPU_TOPOLOGY_DOMAINS[cpu_id].store(INVALID_CPU_TOPOLOGY_DOMAIN, Ordering::SeqCst);
         DEBUG_REMOTE_ENQUEUE_TASK[cpu_id].store(0, Ordering::SeqCst);
         DEBUG_REMOTE_ENQUEUE_FROM_CPU[cpu_id].store(NO_CPU, Ordering::SeqCst);
         DEBUG_REMOTE_ENQUEUE_SEQ[cpu_id].store(0, Ordering::SeqCst);
@@ -1920,6 +2023,30 @@ mod tests {
             topology.capacity,
             CpuCoreClass::Efficiency.default_capacity()
         );
+        assert_eq!(topology.domain_id, None);
+        assert_eq!(topology.domain_cpus_mask, 0);
+    }
+
+    #[test_case]
+    fn test_register_cpu_topology_domain() {
+        reset();
+        register_cpu_topology(0, CpuCoreClass::Efficiency, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology(2, CpuCoreClass::Performance, 0).unwrap();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_online_cpu(2);
+
+        register_cpu_topology_domain(0, 0xa).unwrap();
+        register_cpu_topology_domain(2, 0xa).unwrap();
+        register_cpu_topology_domain(1, 0xd).unwrap();
+
+        let topology = cpu_topology(0).unwrap();
+        assert_eq!(topology.domain_id, Some(0xa));
+        assert_eq!(topology.domain_cpus_mask, 0b101);
+        assert_eq!(cpu_topology_domain_online_mask(0xa), 0b101);
+        assert_eq!(cpu_topology_domain_online_mask(0xd), 0b010);
+        assert_eq!(online_cpu_mask(), 0b111);
     }
 
     #[test_case]

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -412,8 +412,6 @@ const EFFICIENCY_CPU_CAPACITY: u32 = 512;
 const PERFORMANCE_CPU_CAPACITY: u32 = 1536;
 const TASK_LOAD_SCALE: u64 = 1024;
 const MAX_PRIORITY_LOAD_BONUS: u64 = 1024;
-const SCHED_MIGRATION_COOLDOWN_NS: u64 = 100_000_000;
-const SCHED_DEMOTION_MARGIN: u32 = 128;
 
 static CPU_CORE_CLASSES: [AtomicU8; MAX_NUM_CPUS] =
     [const { AtomicU8::new(CpuCoreClass::Balanced as u8) }; MAX_NUM_CPUS];
@@ -422,10 +420,6 @@ static CPU_CAPACITIES: [AtomicU32; MAX_NUM_CPUS] =
 const INVALID_CPU_TOPOLOGY_DOMAIN: u32 = u32::MAX;
 static CPU_TOPOLOGY_DOMAINS: [AtomicU32; MAX_NUM_CPUS] =
     [const { AtomicU32::new(INVALID_CPU_TOPOLOGY_DOMAIN) }; MAX_NUM_CPUS];
-static SCHED_MIGRATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
-static SCHED_MIGRATION_PROMOTIONS: AtomicU64 = AtomicU64::new(0);
-static SCHED_MIGRATION_DEMOTIONS: AtomicU64 = AtomicU64::new(0);
-static SCHED_MIGRATION_COOLDOWN_SKIPS: AtomicU64 = AtomicU64::new(0);
 
 /// Coarse CPU core class used for heterogeneous scheduling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -514,19 +508,6 @@ pub struct CpuUtilSnapshot {
     pub capacity: u32,
     /// Number of non-idle runnable tasks seen by this CPU.
     pub runnable_tasks: usize,
-}
-
-/// Scheduler migration accounting snapshot.
-#[derive(Debug, Clone, Copy)]
-pub struct SchedulerMigrationStats {
-    /// Number of scheduler-driven CPU migrations.
-    pub total: u64,
-    /// Number of migrations to a higher-capacity CPU.
-    pub promotions: u64,
-    /// Number of migrations to a lower-capacity CPU.
-    pub demotions: u64,
-    /// Number of migration opportunities skipped by cooldown.
-    pub cooldown_skips: u64,
 }
 
 pub fn note_idle_to_user_handoff(cpu_id: usize, task_id: usize) {
@@ -619,21 +600,14 @@ fn release_deferred_prev(cpu_id: usize) {
             task.state.store(TaskState::Ready, Ordering::SeqCst);
             return;
         }
-        // Requeue the previous task after its context has been saved. The
-        // normal path keeps it CPU-local, but sustained utilization can promote
-        // or demote it across capacity classes once it is safe to resume from
-        // another ready queue.
+        // Requeue the previous task on the CPU that just switched away from it.
+        // Kernel-context resume paths are kept CPU-local until the scheduler
+        // has explicit cross-CPU context migration support. Wakeup and clone
+        // placement still provide capacity-aware distribution for tasks before
+        // they have a suspended kernel context.
         if matches!(task.state.load(Ordering::SeqCst), TaskState::Ready) {
-            let now_ns = get_time_ns();
-            let target_cpu = migration_target_for_task(task, cpu_id, now_ns, true)
-                .filter(|&target_cpu| is_cpu_online(target_cpu))
-                .unwrap_or(cpu_id);
-            if target_cpu != cpu_id {
-                record_scheduler_migration(task, cpu_id, target_cpu, now_ns);
-            }
-            task.last_cpu.store(target_cpu, Ordering::SeqCst);
-            push_ready_task(target_cpu, prev_id);
-            notify_remote_ready_task(target_cpu, prev_id, "migrate-ipi-send");
+            task.last_cpu.store(cpu_id, Ordering::SeqCst);
+            push_ready_task(cpu_id, prev_id);
         }
     }
 }
@@ -712,20 +686,6 @@ pub fn cpu_util_snapshot(cpu_id: usize) -> Option<CpuUtilSnapshot> {
         capacity: cpu_capacity(cpu_id),
         runnable_tasks: CPU_RUNNABLE_TASKS[cpu_id].load(Ordering::SeqCst),
     })
-}
-
-/// Return scheduler migration counters.
-///
-/// # Returns
-///
-/// Current scheduler migration accounting snapshot.
-pub fn scheduler_migration_stats() -> SchedulerMigrationStats {
-    SchedulerMigrationStats {
-        total: SCHED_MIGRATIONS_TOTAL.load(Ordering::SeqCst),
-        promotions: SCHED_MIGRATION_PROMOTIONS.load(Ordering::SeqCst),
-        demotions: SCHED_MIGRATION_DEMOTIONS.load(Ordering::SeqCst),
-        cooldown_skips: SCHED_MIGRATION_COOLDOWN_SKIPS.load(Ordering::SeqCst),
-    }
 }
 
 fn account_task_switch(cpu_id: usize, old_id: Option<usize>, next_id: Option<usize>) {
@@ -1113,128 +1073,6 @@ fn select_target_cpu(task: Option<&Task>) -> usize {
     select_target_cpu_at(task, get_time_ns())
 }
 
-fn select_lower_capacity_cpu(task: &Task, current_cpu: usize, min_capacity: u32) -> Option<usize> {
-    let cpus = ONLINE_CPUS.lock();
-    let current_capacity = cpu_capacity(current_cpu);
-    let preference = task.core_preference();
-    let mut best: Option<(usize, u64)> = None;
-
-    for &cpu_id in cpus.iter() {
-        if cpu_id == current_cpu {
-            continue;
-        }
-
-        let capacity = cpu_capacity(cpu_id);
-        if capacity >= current_capacity || capacity < min_capacity {
-            continue;
-        }
-
-        let score = cpu_load_score(cpu_id);
-        if best
-            .map(|(best_cpu, best_score)| {
-                score < best_score
-                    || (score == best_score
-                        && (cpu_better_for_preference(cpu_id, best_cpu, preference)
-                            || cpu_capacity(cpu_id) < cpu_capacity(best_cpu)))
-            })
-            .unwrap_or(true)
-        {
-            best = Some((cpu_id, score));
-        }
-    }
-
-    best.map(|(cpu_id, _)| cpu_id)
-}
-
-fn migration_cooldown_active(task: &Task, now_ns: u64, record_skip: bool) -> bool {
-    let last_migration_ns = task.sched_last_migration_ns();
-    let active = last_migration_ns != 0
-        && now_ns.saturating_sub(last_migration_ns) < SCHED_MIGRATION_COOLDOWN_NS;
-    if active && record_skip {
-        SCHED_MIGRATION_COOLDOWN_SKIPS.fetch_add(1, Ordering::SeqCst);
-    }
-    active
-}
-
-fn migration_target_for_task(
-    task: &Task,
-    current_cpu: usize,
-    now_ns: u64,
-    record_skip: bool,
-) -> Option<usize> {
-    if task.pinned_cpu.is_some() || !is_cpu_online(current_cpu) {
-        return None;
-    }
-
-    let current_capacity = cpu_capacity(current_cpu);
-    let required_capacity = task_min_cpu_capacity_at(Some(task), now_ns);
-
-    if required_capacity > current_capacity {
-        if migration_cooldown_active(task, now_ns, record_skip) {
-            return None;
-        }
-
-        let target_cpu = select_target_cpu_at(Some(task), now_ns);
-        let target_capacity = cpu_capacity(target_cpu);
-        if target_cpu != current_cpu
-            && target_capacity > current_capacity
-            && target_capacity >= required_capacity
-        {
-            return Some(target_cpu);
-        }
-        return None;
-    }
-
-    if current_capacity > required_capacity.saturating_add(SCHED_DEMOTION_MARGIN) {
-        if migration_cooldown_active(task, now_ns, record_skip) {
-            return None;
-        }
-        return select_lower_capacity_cpu(task, current_cpu, required_capacity);
-    }
-
-    None
-}
-
-fn record_scheduler_migration(task: &Task, from_cpu: usize, to_cpu: usize, now_ns: u64) {
-    if from_cpu == to_cpu {
-        return;
-    }
-
-    let from_capacity = cpu_capacity(from_cpu);
-    let to_capacity = cpu_capacity(to_cpu);
-    SCHED_MIGRATIONS_TOTAL.fetch_add(1, Ordering::SeqCst);
-    if to_capacity > from_capacity {
-        SCHED_MIGRATION_PROMOTIONS.fetch_add(1, Ordering::SeqCst);
-    } else if to_capacity < from_capacity {
-        SCHED_MIGRATION_DEMOTIONS.fetch_add(1, Ordering::SeqCst);
-    }
-    task.mark_sched_migrated(now_ns);
-}
-
-fn notify_remote_ready_task(target_cpu: usize, task_id: usize, label: &'static str) {
-    if !is_cpu_online(target_cpu) || target_cpu == get_cpu().get_cpuid() {
-        return;
-    }
-
-    let seq = DEBUG_ENQUEUE_SEQ.fetch_add(1, Ordering::SeqCst) + 1;
-    DEBUG_REMOTE_ENQUEUE_TASK[target_cpu].store(encode_task_id(Some(task_id)), Ordering::SeqCst);
-    DEBUG_REMOTE_ENQUEUE_FROM_CPU[target_cpu].store(get_cpu().get_cpuid(), Ordering::SeqCst);
-    DEBUG_REMOTE_ENQUEUE_SEQ[target_cpu].store(seq, Ordering::SeqCst);
-    if DEBUG_SMP_TASK_FLOW {
-        println!(
-            "[SMPDBG {}] seq={} from_cpu={} target_cpu={} task={} name={} ready_len={}",
-            label,
-            seq,
-            get_cpu().get_cpuid(),
-            target_cpu,
-            task_id,
-            debug_task_name(task_id),
-            ready_queue(target_cpu).lock().len(),
-        );
-    }
-    crate::arch::send_reschedule_ipi(target_cpu);
-}
-
 pub fn for_each_online_cpu<F: FnMut(usize)>(mut f: F) {
     let cpus = ONLINE_CPUS.lock();
     for &cpu_id in cpus.iter() {
@@ -1462,27 +1300,13 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                     TaskState::Running | TaskState::Ready
                 )
             {
-                if migration_target_for_task(ot, cpu_id, get_time_ns(), false).is_some() {
-                    let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
-                    if idle_id != 0
-                        && oid != idle_id
-                        && let Some(idle_task) = TaskPool::get_task(idle_id)
-                        && try_claim_ready_task(idle_task, cpu_id)
-                    {
-                        next_id = Some(idle_id);
-                    }
-                }
-                if next_id.is_none() {
-                    ot.state.store(TaskState::Running, Ordering::SeqCst);
-                    ot.time_slice.store(
-                        ot.default_time_slice.load(Ordering::SeqCst),
-                        Ordering::SeqCst,
-                    );
-                    set_current_task_id(cpu_id, Some(oid));
-                    return (old_id, Some(oid));
-                }
-                // Fall through to the normal context-switch path. The old task
-                // will be released and migrated from release_deferred_prev().
+                ot.state.store(TaskState::Running, Ordering::SeqCst);
+                ot.time_slice.store(
+                    ot.default_time_slice.load(Ordering::SeqCst),
+                    Ordering::SeqCst,
+                );
+                set_current_task_id(cpu_id, Some(oid));
+                return (old_id, Some(oid));
             }
         }
     }
@@ -2134,10 +1958,6 @@ pub fn reset() {
     DEBUG_ENQUEUE_SEQ.store(0, Ordering::SeqCst);
     TOTAL_BUSY_CPU_TIME_NS.store(0, Ordering::SeqCst);
     TOTAL_IDLE_CPU_TIME_NS.store(0, Ordering::SeqCst);
-    SCHED_MIGRATIONS_TOTAL.store(0, Ordering::SeqCst);
-    SCHED_MIGRATION_PROMOTIONS.store(0, Ordering::SeqCst);
-    SCHED_MIGRATION_DEMOTIONS.store(0, Ordering::SeqCst);
-    SCHED_MIGRATION_COOLDOWN_SKIPS.store(0, Ordering::SeqCst);
     ONLINE_CPUS.lock().clear();
     ZOMBIE_QUEUE.lock().clear();
     BLOCKED_QUEUE.lock().clear();
@@ -2318,38 +2138,5 @@ mod tests {
         task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
 
         assert_eq!(select_cpu_for_task(&task), 1);
-    }
-
-    #[test_case]
-    fn test_migration_target_promotes_over_capacity_task() {
-        reset();
-        register_online_cpu(0);
-        register_online_cpu(1);
-        register_cpu_topology(0, CpuCoreClass::Efficiency, 0).unwrap();
-        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
-
-        let task = Task::new("PromoteTask".to_string(), 1, TaskType::Kernel);
-        task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
-
-        assert_eq!(
-            migration_target_for_task(&task, 0, 20_000_000, false),
-            Some(1)
-        );
-    }
-
-    #[test_case]
-    fn test_migration_target_demotes_low_util_task() {
-        reset();
-        register_online_cpu(0);
-        register_online_cpu(1);
-        register_cpu_topology(0, CpuCoreClass::Performance, 0).unwrap();
-        register_cpu_topology(1, CpuCoreClass::Efficiency, 0).unwrap();
-
-        let task = Task::new("DemoteTask".to_string(), 1, TaskType::Kernel);
-
-        assert_eq!(
-            migration_target_for_task(&task, 0, 10_000_000, false),
-            Some(1)
-        );
     }
 }

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -414,6 +414,7 @@ const TASK_LOAD_SCALE: u64 = 1024;
 const MAX_PRIORITY_LOAD_BONUS: u64 = 1024;
 const SCHED_MIGRATION_COOLDOWN_NS: u64 = 100_000_000;
 const SCHED_DEMOTION_MARGIN: u32 = 128;
+const SCHED_STEAL_SCAN_LIMIT: usize = 8;
 
 static CPU_CORE_CLASSES: [AtomicU8; MAX_NUM_CPUS] =
     [const { AtomicU8::new(CpuCoreClass::Balanced as u8) }; MAX_NUM_CPUS];
@@ -426,6 +427,7 @@ static SCHED_MIGRATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static SCHED_MIGRATION_PROMOTIONS: AtomicU64 = AtomicU64::new(0);
 static SCHED_MIGRATION_DEMOTIONS: AtomicU64 = AtomicU64::new(0);
 static SCHED_MIGRATION_COOLDOWN_SKIPS: AtomicU64 = AtomicU64::new(0);
+static SCHED_WORK_STEALS: AtomicU64 = AtomicU64::new(0);
 
 /// Coarse CPU core class used for heterogeneous scheduling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -527,6 +529,8 @@ pub struct SchedulerMigrationStats {
     pub demotions: u64,
     /// Number of migration opportunities skipped by cooldown.
     pub cooldown_skips: u64,
+    /// Number of ready tasks moved by idle-core work stealing.
+    pub work_steals: u64,
 }
 
 pub fn note_idle_to_user_handoff(cpu_id: usize, task_id: usize) {
@@ -670,6 +674,16 @@ fn cpu_instant_util(cpu_id: usize) -> (u32, u32, usize) {
         util_min = util_min.max(task_util_min_by_id(task_id));
     }
 
+    let queue = ready_queue(cpu_id).lock();
+    for &task_id in queue.iter() {
+        if task_id == idle_id {
+            continue;
+        }
+        runnable_tasks = runnable_tasks.saturating_add(1);
+        util_min = util_min.max(task_util_min_by_id(task_id));
+    }
+    drop(queue);
+
     (
         util.max(util_min).min(SCHED_UTIL_SCALE),
         util_min,
@@ -724,6 +738,7 @@ pub fn scheduler_migration_stats() -> SchedulerMigrationStats {
         promotions: SCHED_MIGRATION_PROMOTIONS.load(Ordering::SeqCst),
         demotions: SCHED_MIGRATION_DEMOTIONS.load(Ordering::SeqCst),
         cooldown_skips: SCHED_MIGRATION_COOLDOWN_SKIPS.load(Ordering::SeqCst),
+        work_steals: SCHED_WORK_STEALS.load(Ordering::SeqCst),
     }
 }
 
@@ -1117,13 +1132,134 @@ fn select_enqueue_cpu_for_task(task: &Task, requested_cpu: usize, now_ns: u64) -
         return pinned_cpu;
     }
 
+    let selected = select_target_cpu_at(Some(task), now_ns);
+    let selected_score = cpu_load_score(selected);
     if is_cpu_online(requested_cpu)
         && cpu_capacity(requested_cpu) >= task_min_cpu_capacity_at(Some(task), now_ns)
+        && cpu_load_score(requested_cpu) <= selected_score
     {
         requested_cpu
     } else {
-        select_target_cpu_at(Some(task), now_ns)
+        selected
     }
+}
+
+fn task_can_run_on_cpu(task: &Task, cpu_id: usize, now_ns: u64) -> bool {
+    if task
+        .pinned_cpu
+        .is_some_and(|pinned_cpu| pinned_cpu != cpu_id)
+    {
+        return false;
+    }
+
+    cpu_capacity(cpu_id) >= task_min_cpu_capacity_at(Some(task), now_ns)
+}
+
+fn steal_candidate_from_cpu(
+    victim_cpu: usize,
+    target_cpu: usize,
+    now_ns: u64,
+) -> Option<(usize, u64)> {
+    let idle_id = IDLE_TASK_IDS[victim_cpu].load(Ordering::SeqCst);
+    let queue = ready_queue(victim_cpu).lock();
+    let mut weight = 0u64;
+    let mut candidate = None;
+
+    for &task_id in queue.iter() {
+        if task_id == idle_id {
+            continue;
+        }
+
+        weight = weight.saturating_add(runnable_task_weight(task_id));
+        if candidate.is_some() {
+            continue;
+        }
+
+        let Some(task) = TaskPool::get_task(task_id) else {
+            continue;
+        };
+        if task.running_cpu.load(Ordering::SeqCst) != NO_CPU {
+            continue;
+        }
+        if !matches!(task.state.load(Ordering::SeqCst), TaskState::Ready) {
+            continue;
+        }
+        if !task_can_run_on_cpu(task, target_cpu, now_ns) {
+            continue;
+        }
+
+        candidate = Some(task_id);
+    }
+
+    candidate.map(|task_id| (task_id, weight))
+}
+
+fn remove_ready_task_from_cpu(cpu_id: usize, task_id: usize) -> bool {
+    let mut queue = ready_queue(cpu_id).lock();
+    let Some(index) = queue.iter().position(|&queued_id| queued_id == task_id) else {
+        return false;
+    };
+    queue.remove(index).is_some()
+}
+
+fn steal_ready_task_for_cpu(target_cpu: usize, now_ns: u64) -> Option<usize> {
+    let cpus = ONLINE_CPUS.lock();
+    if cpus.len() <= 1 || !cpus.contains(&target_cpu) {
+        return None;
+    }
+
+    let start = NEXT_CPU.fetch_add(1, Ordering::Relaxed);
+    let mut scanned = 0usize;
+    let mut best: Option<(usize, usize, u64)> = None;
+
+    for offset in 0..cpus.len() {
+        if scanned >= SCHED_STEAL_SCAN_LIMIT {
+            break;
+        }
+
+        let victim_cpu = cpus[(start + offset) % cpus.len()];
+        if victim_cpu == target_cpu {
+            continue;
+        }
+        scanned = scanned.saturating_add(1);
+
+        let Some((task_id, weight)) = steal_candidate_from_cpu(victim_cpu, target_cpu, now_ns)
+        else {
+            continue;
+        };
+        if weight == 0 {
+            continue;
+        }
+
+        if best
+            .map(|(_, _, best_weight)| weight > best_weight)
+            .unwrap_or(true)
+        {
+            best = Some((victim_cpu, task_id, weight));
+        }
+    }
+    drop(cpus);
+
+    let (victim_cpu, task_id, _) = best?;
+    if !remove_ready_task_from_cpu(victim_cpu, task_id) {
+        return None;
+    }
+
+    let Some(task) = TaskPool::get_task(task_id) else {
+        return None;
+    };
+    if !try_claim_ready_task(task, target_cpu) {
+        if matches!(task.state.load(Ordering::SeqCst), TaskState::Ready)
+            && task.running_cpu.load(Ordering::SeqCst) == NO_CPU
+        {
+            push_ready_task(victim_cpu, task_id);
+        }
+        return None;
+    }
+
+    record_scheduler_migration(task, victim_cpu, target_cpu, now_ns);
+    SCHED_WORK_STEALS.fetch_add(1, Ordering::SeqCst);
+    Some(task_id)
 }
 
 fn select_wake_cpu_for_task(task: &Task, now_ns: u64) -> usize {
@@ -1491,6 +1627,16 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
             None => {
                 break 'outer;
             }
+        }
+    }
+
+    if next_id.is_none() {
+        let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+        let current_is_idle = old_id
+            .map(|task_id| idle_id != 0 && task_id == idle_id)
+            .unwrap_or(true);
+        if current_is_idle {
+            next_id = steal_ready_task_for_cpu(cpu_id, get_time_ns());
         }
     }
 
@@ -2149,6 +2295,7 @@ pub fn reset() {
     SCHED_MIGRATION_PROMOTIONS.store(0, Ordering::SeqCst);
     SCHED_MIGRATION_DEMOTIONS.store(0, Ordering::SeqCst);
     SCHED_MIGRATION_COOLDOWN_SKIPS.store(0, Ordering::SeqCst);
+    SCHED_WORK_STEALS.store(0, Ordering::SeqCst);
     TOTAL_BUSY_CPU_TIME_NS.store(0, Ordering::SeqCst);
     TOTAL_IDLE_CPU_TIME_NS.store(0, Ordering::SeqCst);
     ONLINE_CPUS.lock().clear();
@@ -2331,6 +2478,46 @@ mod tests {
         task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
 
         assert_eq!(select_cpu_for_task(&task), 1);
+    }
+
+    #[test_case]
+    fn test_enqueue_prefers_idle_cpu_over_requested_busy_cpu() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Balanced, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Balanced, 0).unwrap();
+
+        let first_id = register_task(Task::new("FirstTask".to_string(), 1, TaskType::Kernel));
+        enqueue_task(first_id, 0);
+        assert!(ready_queue(0).lock().contains(&first_id));
+
+        let second_id = register_task(Task::new("SecondTask".to_string(), 1, TaskType::Kernel));
+        enqueue_task(second_id, 0);
+        assert!(ready_queue(1).lock().contains(&second_id));
+    }
+
+    #[test_case]
+    fn test_idle_cpu_steals_ready_task_from_busy_queue() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Balanced, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Balanced, 0).unwrap();
+
+        let task_id = register_task(Task::new("StealableTask".to_string(), 1, TaskType::Kernel));
+        let task = TaskPool::get_task(task_id).unwrap();
+        task.state.store(TaskState::Ready, Ordering::SeqCst);
+        push_ready_task(0, task_id);
+
+        assert_eq!(steal_ready_task_for_cpu(1, 20_000_000), Some(task_id));
+        assert!(!ready_queue(0).lock().contains(&task_id));
+        assert_eq!(task.running_cpu.load(Ordering::SeqCst), 1);
+        assert_eq!(task.last_cpu.load(Ordering::SeqCst), 1);
+
+        let stats = scheduler_migration_stats();
+        assert_eq!(stats.total, 1);
+        assert_eq!(stats.work_steals, 1);
     }
 
     #[test_case]

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -412,6 +412,8 @@ const EFFICIENCY_CPU_CAPACITY: u32 = 512;
 const PERFORMANCE_CPU_CAPACITY: u32 = 1536;
 const TASK_LOAD_SCALE: u64 = 1024;
 const MAX_PRIORITY_LOAD_BONUS: u64 = 1024;
+const SCHED_MIGRATION_COOLDOWN_NS: u64 = 100_000_000;
+const SCHED_DEMOTION_MARGIN: u32 = 128;
 
 static CPU_CORE_CLASSES: [AtomicU8; MAX_NUM_CPUS] =
     [const { AtomicU8::new(CpuCoreClass::Balanced as u8) }; MAX_NUM_CPUS];
@@ -420,6 +422,10 @@ static CPU_CAPACITIES: [AtomicU32; MAX_NUM_CPUS] =
 const INVALID_CPU_TOPOLOGY_DOMAIN: u32 = u32::MAX;
 static CPU_TOPOLOGY_DOMAINS: [AtomicU32; MAX_NUM_CPUS] =
     [const { AtomicU32::new(INVALID_CPU_TOPOLOGY_DOMAIN) }; MAX_NUM_CPUS];
+static SCHED_MIGRATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static SCHED_MIGRATION_PROMOTIONS: AtomicU64 = AtomicU64::new(0);
+static SCHED_MIGRATION_DEMOTIONS: AtomicU64 = AtomicU64::new(0);
+static SCHED_MIGRATION_COOLDOWN_SKIPS: AtomicU64 = AtomicU64::new(0);
 
 /// Coarse CPU core class used for heterogeneous scheduling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -508,6 +514,19 @@ pub struct CpuUtilSnapshot {
     pub capacity: u32,
     /// Number of non-idle runnable tasks seen by this CPU.
     pub runnable_tasks: usize,
+}
+
+/// Scheduler migration accounting snapshot.
+#[derive(Debug, Clone, Copy)]
+pub struct SchedulerMigrationStats {
+    /// Number of scheduler-driven CPU migrations.
+    pub total: u64,
+    /// Number of migrations to a higher-capacity CPU.
+    pub promotions: u64,
+    /// Number of migrations to a lower-capacity CPU.
+    pub demotions: u64,
+    /// Number of migration opportunities skipped by cooldown.
+    pub cooldown_skips: u64,
 }
 
 pub fn note_idle_to_user_handoff(cpu_id: usize, task_id: usize) {
@@ -600,12 +619,21 @@ fn release_deferred_prev(cpu_id: usize) {
             task.state.store(TaskState::Ready, Ordering::SeqCst);
             return;
         }
-        // Requeue the previous task on the CPU that just switched away from it.
-        // This keeps kernel-context resume paths CPU-local. New task placement
-        // and wakeups provide SMP distribution without stealing suspended
-        // kernel contexts from another CPU's ready queue.
+        // Requeue the previous task after its context has been saved. The
+        // normal path keeps it CPU-local, but sustained utilization can promote
+        // or demote it across capacity classes once it is safe to resume from
+        // another ready queue.
         if matches!(task.state.load(Ordering::SeqCst), TaskState::Ready) {
-            push_ready_task(cpu_id, prev_id);
+            let now_ns = get_time_ns();
+            let target_cpu = migration_target_for_task(task, cpu_id, now_ns, true)
+                .filter(|&target_cpu| is_cpu_online(target_cpu))
+                .unwrap_or(cpu_id);
+            if target_cpu != cpu_id {
+                record_scheduler_migration(task, cpu_id, target_cpu, now_ns);
+            }
+            task.last_cpu.store(target_cpu, Ordering::SeqCst);
+            push_ready_task(target_cpu, prev_id);
+            notify_remote_ready_task(target_cpu, prev_id, "migrate-ipi-send");
         }
     }
 }
@@ -684,6 +712,20 @@ pub fn cpu_util_snapshot(cpu_id: usize) -> Option<CpuUtilSnapshot> {
         capacity: cpu_capacity(cpu_id),
         runnable_tasks: CPU_RUNNABLE_TASKS[cpu_id].load(Ordering::SeqCst),
     })
+}
+
+/// Return scheduler migration counters.
+///
+/// # Returns
+///
+/// Current scheduler migration accounting snapshot.
+pub fn scheduler_migration_stats() -> SchedulerMigrationStats {
+    SchedulerMigrationStats {
+        total: SCHED_MIGRATIONS_TOTAL.load(Ordering::SeqCst),
+        promotions: SCHED_MIGRATION_PROMOTIONS.load(Ordering::SeqCst),
+        demotions: SCHED_MIGRATION_DEMOTIONS.load(Ordering::SeqCst),
+        cooldown_skips: SCHED_MIGRATION_COOLDOWN_SKIPS.load(Ordering::SeqCst),
+    }
 }
 
 fn account_task_switch(cpu_id: usize, old_id: Option<usize>, next_id: Option<usize>) {
@@ -987,13 +1029,21 @@ fn cpu_load_score(cpu_id: usize) -> u64 {
     cpu_runnable_weight(cpu_id).saturating_mul(TASK_LOAD_SCALE) / capacity
 }
 
-fn task_min_cpu_capacity(task: Option<&Task>) -> u32 {
+fn task_effective_util(task: Option<&Task>, now_ns: u64) -> u32 {
+    let Some(task) = task else {
+        return 0;
+    };
+
+    core::cmp::max(task.sched_util_avg_snapshot(now_ns), task.sched_util_min())
+        .min(SCHED_UTIL_SCALE)
+}
+
+fn task_min_cpu_capacity_at(task: Option<&Task>, now_ns: u64) -> u32 {
     let preference_min = match task.map(Task::core_preference) {
         Some(TaskCorePreference::Performance) => DEFAULT_CPU_CAPACITY,
         _ => MIN_CPU_CAPACITY,
     };
-    let util_min = task.map(Task::sched_util_min).unwrap_or(0);
-    core::cmp::max(preference_min, util_min)
+    core::cmp::max(preference_min, task_effective_util(task, now_ns))
 }
 
 fn cpu_better_for_preference(
@@ -1007,11 +1057,11 @@ fn cpu_better_for_preference(
     match preference {
         TaskCorePreference::Efficiency => candidate_capacity < best_capacity,
         TaskCorePreference::Performance => candidate_capacity > best_capacity,
-        TaskCorePreference::Any => false,
+        TaskCorePreference::Any => candidate_capacity < best_capacity,
     }
 }
 
-fn select_target_cpu(task: Option<&Task>) -> usize {
+fn select_target_cpu_at(task: Option<&Task>, now_ns: u64) -> usize {
     let cpus = ONLINE_CPUS.lock();
     if cpus.is_empty() {
         return 0;
@@ -1020,7 +1070,7 @@ fn select_target_cpu(task: Option<&Task>) -> usize {
     let preference = task
         .map(Task::core_preference)
         .unwrap_or(TaskCorePreference::Any);
-    let min_capacity = task_min_cpu_capacity(task);
+    let min_capacity = task_min_cpu_capacity_at(task, now_ns);
     let start = NEXT_CPU.fetch_add(1, Ordering::Relaxed);
     let mut fallback: Option<(usize, u64)> = None;
     let mut best: Option<(usize, u64)> = None;
@@ -1057,6 +1107,132 @@ fn select_target_cpu(task: Option<&Task>) -> usize {
     }
 
     best.or(fallback).map(|(cpu_id, _)| cpu_id).unwrap_or(0)
+}
+
+fn select_target_cpu(task: Option<&Task>) -> usize {
+    select_target_cpu_at(task, get_time_ns())
+}
+
+fn select_lower_capacity_cpu(task: &Task, current_cpu: usize, min_capacity: u32) -> Option<usize> {
+    let cpus = ONLINE_CPUS.lock();
+    let current_capacity = cpu_capacity(current_cpu);
+    let preference = task.core_preference();
+    let mut best: Option<(usize, u64)> = None;
+
+    for &cpu_id in cpus.iter() {
+        if cpu_id == current_cpu {
+            continue;
+        }
+
+        let capacity = cpu_capacity(cpu_id);
+        if capacity >= current_capacity || capacity < min_capacity {
+            continue;
+        }
+
+        let score = cpu_load_score(cpu_id);
+        if best
+            .map(|(best_cpu, best_score)| {
+                score < best_score
+                    || (score == best_score
+                        && (cpu_better_for_preference(cpu_id, best_cpu, preference)
+                            || cpu_capacity(cpu_id) < cpu_capacity(best_cpu)))
+            })
+            .unwrap_or(true)
+        {
+            best = Some((cpu_id, score));
+        }
+    }
+
+    best.map(|(cpu_id, _)| cpu_id)
+}
+
+fn migration_cooldown_active(task: &Task, now_ns: u64, record_skip: bool) -> bool {
+    let last_migration_ns = task.sched_last_migration_ns();
+    let active = last_migration_ns != 0
+        && now_ns.saturating_sub(last_migration_ns) < SCHED_MIGRATION_COOLDOWN_NS;
+    if active && record_skip {
+        SCHED_MIGRATION_COOLDOWN_SKIPS.fetch_add(1, Ordering::SeqCst);
+    }
+    active
+}
+
+fn migration_target_for_task(
+    task: &Task,
+    current_cpu: usize,
+    now_ns: u64,
+    record_skip: bool,
+) -> Option<usize> {
+    if task.pinned_cpu.is_some() || !is_cpu_online(current_cpu) {
+        return None;
+    }
+
+    let current_capacity = cpu_capacity(current_cpu);
+    let required_capacity = task_min_cpu_capacity_at(Some(task), now_ns);
+
+    if required_capacity > current_capacity {
+        if migration_cooldown_active(task, now_ns, record_skip) {
+            return None;
+        }
+
+        let target_cpu = select_target_cpu_at(Some(task), now_ns);
+        let target_capacity = cpu_capacity(target_cpu);
+        if target_cpu != current_cpu
+            && target_capacity > current_capacity
+            && target_capacity >= required_capacity
+        {
+            return Some(target_cpu);
+        }
+        return None;
+    }
+
+    if current_capacity > required_capacity.saturating_add(SCHED_DEMOTION_MARGIN) {
+        if migration_cooldown_active(task, now_ns, record_skip) {
+            return None;
+        }
+        return select_lower_capacity_cpu(task, current_cpu, required_capacity);
+    }
+
+    None
+}
+
+fn record_scheduler_migration(task: &Task, from_cpu: usize, to_cpu: usize, now_ns: u64) {
+    if from_cpu == to_cpu {
+        return;
+    }
+
+    let from_capacity = cpu_capacity(from_cpu);
+    let to_capacity = cpu_capacity(to_cpu);
+    SCHED_MIGRATIONS_TOTAL.fetch_add(1, Ordering::SeqCst);
+    if to_capacity > from_capacity {
+        SCHED_MIGRATION_PROMOTIONS.fetch_add(1, Ordering::SeqCst);
+    } else if to_capacity < from_capacity {
+        SCHED_MIGRATION_DEMOTIONS.fetch_add(1, Ordering::SeqCst);
+    }
+    task.mark_sched_migrated(now_ns);
+}
+
+fn notify_remote_ready_task(target_cpu: usize, task_id: usize, label: &'static str) {
+    if !is_cpu_online(target_cpu) || target_cpu == get_cpu().get_cpuid() {
+        return;
+    }
+
+    let seq = DEBUG_ENQUEUE_SEQ.fetch_add(1, Ordering::SeqCst) + 1;
+    DEBUG_REMOTE_ENQUEUE_TASK[target_cpu].store(encode_task_id(Some(task_id)), Ordering::SeqCst);
+    DEBUG_REMOTE_ENQUEUE_FROM_CPU[target_cpu].store(get_cpu().get_cpuid(), Ordering::SeqCst);
+    DEBUG_REMOTE_ENQUEUE_SEQ[target_cpu].store(seq, Ordering::SeqCst);
+    if DEBUG_SMP_TASK_FLOW {
+        println!(
+            "[SMPDBG {}] seq={} from_cpu={} target_cpu={} task={} name={} ready_len={}",
+            label,
+            seq,
+            get_cpu().get_cpuid(),
+            target_cpu,
+            task_id,
+            debug_task_name(task_id),
+            ready_queue(target_cpu).lock().len(),
+        );
+    }
+    crate::arch::send_reschedule_ipi(target_cpu);
 }
 
 pub fn for_each_online_cpu<F: FnMut(usize)>(mut f: F) {
@@ -1286,13 +1462,27 @@ fn pick_next(cpu: &Arch) -> (Option<usize>, Option<usize>) {
                     TaskState::Running | TaskState::Ready
                 )
             {
-                ot.state.store(TaskState::Running, Ordering::SeqCst);
-                ot.time_slice.store(
-                    ot.default_time_slice.load(Ordering::SeqCst),
-                    Ordering::SeqCst,
-                );
-                set_current_task_id(cpu_id, Some(oid));
-                return (old_id, Some(oid));
+                if migration_target_for_task(ot, cpu_id, get_time_ns(), false).is_some() {
+                    let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+                    if idle_id != 0
+                        && oid != idle_id
+                        && let Some(idle_task) = TaskPool::get_task(idle_id)
+                        && try_claim_ready_task(idle_task, cpu_id)
+                    {
+                        next_id = Some(idle_id);
+                    }
+                }
+                if next_id.is_none() {
+                    ot.state.store(TaskState::Running, Ordering::SeqCst);
+                    ot.time_slice.store(
+                        ot.default_time_slice.load(Ordering::SeqCst),
+                        Ordering::SeqCst,
+                    );
+                    set_current_task_id(cpu_id, Some(oid));
+                    return (old_id, Some(oid));
+                }
+                // Fall through to the normal context-switch path. The old task
+                // will be released and migrated from release_deferred_prev().
             }
         }
     }
@@ -1380,39 +1570,53 @@ pub fn register_task(task: Task) -> usize {
 pub fn enqueue_task(task_id: usize, cpu_id: usize) {
     let _irq_guard = IrqGuard::new();
     let current_cpu = get_cpu().get_cpuid();
+    let target_cpu = TaskPool::get_task(task_id)
+        .map(|task| {
+            if let Some(pinned_cpu) = task.pinned_cpu {
+                pinned_cpu
+            } else if is_cpu_online(cpu_id)
+                && cpu_capacity(cpu_id) >= task_min_cpu_capacity_at(Some(task), get_time_ns())
+            {
+                cpu_id
+            } else {
+                select_target_cpu(Some(task))
+            }
+        })
+        .unwrap_or(cpu_id);
     let seq = DEBUG_ENQUEUE_SEQ.fetch_add(1, Ordering::SeqCst) + 1;
     if let Some(task) = TaskPool::get_task(task_id) {
-        task.last_cpu.store(cpu_id, Ordering::SeqCst);
+        task.last_cpu.store(target_cpu, Ordering::SeqCst);
     }
-    push_ready_task(cpu_id, task_id);
+    push_ready_task(target_cpu, task_id);
     if DEBUG_SMP_TASK_FLOW {
         println!(
             "[SMPDBG enqueue] seq={} from_cpu={} target_cpu={} task={} name={} remote={} ready_len={}",
             seq,
             current_cpu,
-            cpu_id,
+            target_cpu,
             task_id,
             debug_task_name(task_id),
-            cpu_id != current_cpu,
-            ready_queue(cpu_id).lock().len(),
+            target_cpu != current_cpu,
+            ready_queue(target_cpu).lock().len(),
         );
     }
-    if is_cpu_online(cpu_id) && cpu_id != get_cpu().get_cpuid() {
-        DEBUG_REMOTE_ENQUEUE_TASK[cpu_id].store(encode_task_id(Some(task_id)), Ordering::SeqCst);
-        DEBUG_REMOTE_ENQUEUE_FROM_CPU[cpu_id].store(current_cpu, Ordering::SeqCst);
-        DEBUG_REMOTE_ENQUEUE_SEQ[cpu_id].store(seq, Ordering::SeqCst);
+    if is_cpu_online(target_cpu) && target_cpu != get_cpu().get_cpuid() {
+        DEBUG_REMOTE_ENQUEUE_TASK[target_cpu]
+            .store(encode_task_id(Some(task_id)), Ordering::SeqCst);
+        DEBUG_REMOTE_ENQUEUE_FROM_CPU[target_cpu].store(current_cpu, Ordering::SeqCst);
+        DEBUG_REMOTE_ENQUEUE_SEQ[target_cpu].store(seq, Ordering::SeqCst);
         if DEBUG_SMP_TASK_FLOW {
             println!(
                 "[SMPDBG ipi-send] seq={} from_cpu={} target_cpu={} task={} name={} ready_len={}",
                 seq,
                 current_cpu,
-                cpu_id,
+                target_cpu,
                 task_id,
                 debug_task_name(task_id),
-                ready_queue(cpu_id).lock().len(),
+                ready_queue(target_cpu).lock().len(),
             );
         }
-        crate::arch::send_reschedule_ipi(cpu_id);
+        crate::arch::send_reschedule_ipi(target_cpu);
     }
 }
 
@@ -1597,17 +1801,25 @@ pub fn wake_task(task_id: usize) -> bool {
         if let Some(pinned) = task.pinned_cpu {
             pinned
         } else {
+            let now_ns = get_time_ns();
+            let min_capacity = task_min_cpu_capacity_at(Some(task), now_ns);
+            let selected = select_target_cpu_at(Some(task), now_ns);
+            let selected_score = cpu_load_score(selected);
             let last = task.last_cpu.load(Ordering::SeqCst);
-            if is_cpu_online(last) && cpu_capacity(last) >= task_min_cpu_capacity(Some(task)) {
+            if is_cpu_online(last)
+                && cpu_capacity(last) >= min_capacity
+                && cpu_load_score(last) <= selected_score
+            {
                 last
             } else {
                 let current = get_cpu().get_cpuid();
                 if is_cpu_online(current)
-                    && cpu_capacity(current) >= task_min_cpu_capacity(Some(task))
+                    && cpu_capacity(current) >= min_capacity
+                    && cpu_load_score(current) <= selected_score
                 {
                     current
                 } else {
-                    select_target_cpu(Some(task))
+                    selected
                 }
             }
         }
@@ -1922,6 +2134,10 @@ pub fn reset() {
     DEBUG_ENQUEUE_SEQ.store(0, Ordering::SeqCst);
     TOTAL_BUSY_CPU_TIME_NS.store(0, Ordering::SeqCst);
     TOTAL_IDLE_CPU_TIME_NS.store(0, Ordering::SeqCst);
+    SCHED_MIGRATIONS_TOTAL.store(0, Ordering::SeqCst);
+    SCHED_MIGRATION_PROMOTIONS.store(0, Ordering::SeqCst);
+    SCHED_MIGRATION_DEMOTIONS.store(0, Ordering::SeqCst);
+    SCHED_MIGRATION_COOLDOWN_SKIPS.store(0, Ordering::SeqCst);
     ONLINE_CPUS.lock().clear();
     ZOMBIE_QUEUE.lock().clear();
     BLOCKED_QUEUE.lock().clear();
@@ -2075,5 +2291,65 @@ mod tests {
         task.set_core_preference(TaskCorePreference::Efficiency);
 
         assert_eq!(select_cpu_for_task(&task), 1);
+    }
+
+    #[test_case]
+    fn test_select_cpu_for_light_any_task_prefers_efficiency_on_tie() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Efficiency, 0).unwrap();
+
+        let task = Task::new("LightTask".to_string(), 1, TaskType::Kernel);
+
+        assert_eq!(select_cpu_for_task(&task), 1);
+    }
+
+    #[test_case]
+    fn test_select_cpu_for_requested_heavy_task_prefers_capacity() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Efficiency, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+
+        let task = Task::new("HeavyTask".to_string(), 1, TaskType::Kernel);
+        task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
+
+        assert_eq!(select_cpu_for_task(&task), 1);
+    }
+
+    #[test_case]
+    fn test_migration_target_promotes_over_capacity_task() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Efficiency, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Performance, 0).unwrap();
+
+        let task = Task::new("PromoteTask".to_string(), 1, TaskType::Kernel);
+        task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
+
+        assert_eq!(
+            migration_target_for_task(&task, 0, 20_000_000, false),
+            Some(1)
+        );
+    }
+
+    #[test_case]
+    fn test_migration_target_demotes_low_util_task() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Efficiency, 0).unwrap();
+
+        let task = Task::new("DemoteTask".to_string(), 1, TaskType::Kernel);
+
+        assert_eq!(
+            migration_target_for_task(&task, 0, 10_000_000, false),
+            Some(1)
+        );
     }
 }

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -690,6 +690,10 @@ fn account_task_switch(cpu_id: usize, old_id: Option<usize>, next_id: Option<usi
         if let Some(task) = TaskPool::get_task(old_id) {
             let delta_ns = task.stop_cpu_accounting(now_ns);
             charge_finished_cpu_time(cpu_id, old_id, delta_ns);
+            let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+            if old_id != idle_id {
+                task.account_sched_util_running(now_ns);
+            }
         }
     }
 
@@ -1315,6 +1319,13 @@ pub fn enqueue_task(task_id: usize, cpu_id: usize) {
 pub fn sched_on_tick(cpu_id: usize, trapframe: &mut Trapframe) {
     let _tick = DEBUG_TICK.fetch_add(1, Ordering::Relaxed);
     update_cpu_util_avg(cpu_id);
+    let idle_id = IDLE_TASK_IDS[cpu_id].load(Ordering::SeqCst);
+    if let Some(task_id) = current_task_id(cpu_id)
+        && task_id != idle_id
+        && let Some(task) = TaskPool::get_task(task_id)
+    {
+        task.account_sched_util_running(get_time_ns());
+    }
     crate::device::cpufreq::on_scheduler_tick(cpu_id);
 
     if let Some(task_id) = current_task_id(cpu_id) {

--- a/kernel/src/sched/scheduler.rs
+++ b/kernel/src/sched/scheduler.rs
@@ -414,6 +414,7 @@ const TASK_LOAD_SCALE: u64 = 1024;
 const MAX_PRIORITY_LOAD_BONUS: u64 = 1024;
 const SCHED_MIGRATION_COOLDOWN_NS: u64 = 100_000_000;
 const SCHED_DEMOTION_MARGIN: u32 = 128;
+const SCHED_DEMOTION_SUSTAIN_NS: u64 = 250_000_000;
 const SCHED_STEAL_SCAN_LIMIT: usize = 8;
 
 static CPU_CORE_CLASSES: [AtomicU8; MAX_NUM_CPUS] =
@@ -1334,6 +1335,11 @@ fn migration_cooldown_active(task: &Task, now_ns: u64, record_skip: bool) -> boo
     active
 }
 
+fn demotion_low_util_sustained(task: &Task, now_ns: u64) -> bool {
+    let low_util_since_ns = task.note_sched_low_util(now_ns);
+    now_ns.saturating_sub(low_util_since_ns) >= SCHED_DEMOTION_SUSTAIN_NS
+}
+
 fn migration_target_for_task(
     task: &Task,
     current_cpu: usize,
@@ -1348,6 +1354,7 @@ fn migration_target_for_task(
     let required_capacity = task_min_cpu_capacity_at(Some(task), now_ns);
 
     if required_capacity > current_capacity {
+        task.clear_sched_low_util();
         let target_cpu = select_target_cpu_at(Some(task), now_ns);
         let target_capacity = cpu_capacity(target_cpu);
         if target_cpu != current_cpu
@@ -1363,13 +1370,21 @@ fn migration_target_for_task(
     }
 
     if current_capacity > required_capacity.saturating_add(SCHED_DEMOTION_MARGIN) {
-        let target_cpu = select_lower_capacity_cpu(task, current_cpu, required_capacity)?;
+        let Some(target_cpu) = select_lower_capacity_cpu(task, current_cpu, required_capacity)
+        else {
+            task.clear_sched_low_util();
+            return None;
+        };
+        if !demotion_low_util_sustained(task, now_ns) {
+            return None;
+        }
         if migration_cooldown_active(task, now_ns, record_skip) {
             return None;
         }
         return Some(target_cpu);
     }
 
+    task.clear_sched_low_util();
     None
 }
 
@@ -2593,9 +2608,39 @@ mod tests {
 
         let task = Task::new("LowUtilTask".to_string(), 1, TaskType::Kernel);
 
+        assert_eq!(migration_target_for_task(&task, 0, 10_000_000, false), None);
+        assert_eq!(task.sched_low_util_since_ns(), 10_000_000);
         assert_eq!(
-            migration_target_for_task(&task, 0, 10_000_000, false),
+            migration_target_for_task(&task, 0, 10_000_000 + SCHED_DEMOTION_SUSTAIN_NS - 1, false),
+            None
+        );
+        assert_eq!(
+            migration_target_for_task(&task, 0, 10_000_000 + SCHED_DEMOTION_SUSTAIN_NS, false),
             Some(1)
+        );
+    }
+
+    #[test_case]
+    fn test_migration_demotion_tracking_resets_without_lower_target() {
+        reset();
+        register_online_cpu(0);
+        register_online_cpu(1);
+        register_cpu_topology(0, CpuCoreClass::Performance, 0).unwrap();
+        register_cpu_topology(1, CpuCoreClass::Efficiency, 0).unwrap();
+
+        let task = Task::new("DemotionResetTask".to_string(), 1, TaskType::Kernel);
+
+        assert_eq!(migration_target_for_task(&task, 0, 10_000_000, false), None);
+        assert_eq!(task.sched_low_util_since_ns(), 10_000_000);
+
+        task.set_sched_util_min(SCHED_UTIL_SCALE).unwrap();
+        assert_eq!(migration_target_for_task(&task, 0, 20_000_000, false), None);
+        assert_eq!(task.sched_low_util_since_ns(), 0);
+
+        task.set_sched_util_min(0).unwrap();
+        assert_eq!(
+            migration_target_for_task(&task, 0, 10_000_000 + SCHED_DEMOTION_SUSTAIN_NS, false),
+            None
         );
     }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -503,8 +503,6 @@ pub struct Task {
     sched_util_avg: AtomicU32,
     /// Last timestamp at which measured scheduler utilization was updated.
     sched_util_last_update_ns: AtomicU64,
-    /// Last timestamp at which the scheduler migrated this task.
-    sched_last_migration_ns: AtomicU64,
     /// Time slice for scheduling
     pub time_slice: AtomicU32,
     pub default_time_slice: AtomicU32,
@@ -695,7 +693,6 @@ impl Task {
             sched_util_min: AtomicU32::new(0),
             sched_util_avg: AtomicU32::new(0),
             sched_util_last_update_ns: AtomicU64::new(0),
-            sched_last_migration_ns: AtomicU64::new(0),
             time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             default_time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             cpu_time_ns: AtomicU64::new(0),
@@ -884,25 +881,6 @@ impl Task {
         self.sched_util_last_update_ns
             .store(now_ns, Ordering::SeqCst);
         next
-    }
-
-    /// Return the last scheduler migration timestamp for this task.
-    ///
-    /// # Returns
-    ///
-    /// Monotonic timestamp in nanoseconds, or `0` if this task has not been
-    /// migrated by the scheduler.
-    pub fn sched_last_migration_ns(&self) -> u64 {
-        self.sched_last_migration_ns.load(Ordering::SeqCst)
-    }
-
-    /// Record that the scheduler migrated this task.
-    ///
-    /// # Arguments
-    ///
-    /// * `now_ns` - Current monotonic timestamp in nanoseconds.
-    pub fn mark_sched_migrated(&self, now_ns: u64) {
-        self.sched_last_migration_ns.store(now_ns, Ordering::SeqCst);
     }
 
     /// Mark the task as running for CPU accounting.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -507,6 +507,10 @@ pub struct Task {
     ///
     /// Used to rate-limit scheduler-driven cross-CPU movement.
     sched_last_migration_ns: AtomicU64,
+    /// First timestamp at which this task was observed below its current CPU capacity.
+    ///
+    /// Used to avoid demoting a task after only one low-utilization sample.
+    sched_low_util_since_ns: AtomicU64,
     /// Time slice for scheduling
     pub time_slice: AtomicU32,
     pub default_time_slice: AtomicU32,
@@ -698,6 +702,7 @@ impl Task {
             sched_util_avg: AtomicU32::new(0),
             sched_util_last_update_ns: AtomicU64::new(0),
             sched_last_migration_ns: AtomicU64::new(0),
+            sched_low_util_since_ns: AtomicU64::new(0),
             time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             default_time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             cpu_time_ns: AtomicU64::new(0),
@@ -905,6 +910,44 @@ impl Task {
     /// * `now_ns` - Current monotonic timestamp in nanoseconds.
     pub fn mark_sched_migrated(&self, now_ns: u64) {
         self.sched_last_migration_ns.store(now_ns, Ordering::SeqCst);
+        self.clear_sched_low_util();
+    }
+
+    /// Return the timestamp at which this task first looked eligible for demotion.
+    ///
+    /// # Returns
+    ///
+    /// Monotonic timestamp in nanoseconds, or `0` if no low-utilization window
+    /// is currently being tracked.
+    pub fn sched_low_util_since_ns(&self) -> u64 {
+        self.sched_low_util_since_ns.load(Ordering::SeqCst)
+    }
+
+    /// Record that this task is still below its current CPU capacity.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ns` - Current monotonic timestamp in nanoseconds.
+    ///
+    /// # Returns
+    ///
+    /// The first timestamp in the current low-utilization window.
+    pub fn note_sched_low_util(&self, now_ns: u64) -> u64 {
+        let observed_ns = now_ns.max(1);
+        match self.sched_low_util_since_ns.compare_exchange(
+            0,
+            observed_ns,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => observed_ns,
+            Err(since_ns) => since_ns,
+        }
+    }
+
+    /// Clear the tracked low-utilization demotion window for this task.
+    pub fn clear_sched_low_util(&self) {
+        self.sched_low_util_since_ns.store(0, Ordering::SeqCst);
     }
 
     /// Mark the task as running for CPU accounting.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -90,7 +90,10 @@ pub struct TaskInfo {
     pub state: u8,
     /// Task type: 0 = Kernel, 1 = User.
     pub task_type: u8,
-    /// CPU the task last ran on (MAX_CPU = no CPU).
+    /// Scheduler CPU where the task is running or queued.
+    ///
+    /// For sleeping tasks, this remains the last scheduler CPU associated with
+    /// the task. `u8::MAX` means no CPU is currently known.
     pub cpu_id: u8,
     /// Reserved for future use.
     pub _reserved: u8,
@@ -104,6 +107,16 @@ pub struct TaskInfo {
     pub cpu_time_ns: u64,
     /// Measured scheduler utilization in capacity units.
     pub sched_util_avg: u32,
+    /// Minimum scheduler utilization requested by this task.
+    pub sched_util_min: u32,
+    /// Effective CPU capacity required for placement.
+    pub sched_required_capacity: u32,
+    /// Scheduler core preference hint as a `TaskCorePreference` discriminant.
+    pub core_preference: u8,
+    /// Reserved for future use.
+    pub _reserved2: [u8; 3],
+    /// Number of scheduler-directed migrations for this task.
+    pub sched_migration_count: u64,
 }
 
 impl TaskInfo {
@@ -507,6 +520,8 @@ pub struct Task {
     ///
     /// Used to rate-limit scheduler-driven cross-CPU movement.
     sched_last_migration_ns: AtomicU64,
+    /// Number of scheduler-directed migrations for this task.
+    sched_migration_count: AtomicU64,
     /// First timestamp at which this task was observed below its current CPU capacity.
     ///
     /// Used to avoid demoting a task after only one low-utilization sample.
@@ -702,6 +717,7 @@ impl Task {
             sched_util_avg: AtomicU32::new(0),
             sched_util_last_update_ns: AtomicU64::new(0),
             sched_last_migration_ns: AtomicU64::new(0),
+            sched_migration_count: AtomicU64::new(0),
             sched_low_util_since_ns: AtomicU64::new(0),
             time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             default_time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
@@ -903,6 +919,15 @@ impl Task {
         self.sched_last_migration_ns.load(Ordering::SeqCst)
     }
 
+    /// Return the number of scheduler-directed migrations for this task.
+    ///
+    /// # Returns
+    ///
+    /// Count of scheduler placement moves, including work steals.
+    pub fn sched_migration_count(&self) -> u64 {
+        self.sched_migration_count.load(Ordering::SeqCst)
+    }
+
     /// Record that the scheduler migrated this task.
     ///
     /// # Arguments
@@ -910,6 +935,7 @@ impl Task {
     /// * `now_ns` - Current monotonic timestamp in nanoseconds.
     pub fn mark_sched_migrated(&self, now_ns: u64) {
         self.sched_last_migration_ns.store(now_ns, Ordering::SeqCst);
+        self.sched_migration_count.fetch_add(1, Ordering::SeqCst);
         self.clear_sched_low_util();
     }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -503,6 +503,10 @@ pub struct Task {
     sched_util_avg: AtomicU32,
     /// Last timestamp at which measured scheduler utilization was updated.
     sched_util_last_update_ns: AtomicU64,
+    /// Last timestamp at which the scheduler migrated this task.
+    ///
+    /// Used to rate-limit scheduler-driven cross-CPU movement.
+    sched_last_migration_ns: AtomicU64,
     /// Time slice for scheduling
     pub time_slice: AtomicU32,
     pub default_time_slice: AtomicU32,
@@ -693,6 +697,7 @@ impl Task {
             sched_util_min: AtomicU32::new(0),
             sched_util_avg: AtomicU32::new(0),
             sched_util_last_update_ns: AtomicU64::new(0),
+            sched_last_migration_ns: AtomicU64::new(0),
             time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             default_time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             cpu_time_ns: AtomicU64::new(0),
@@ -881,6 +886,25 @@ impl Task {
         self.sched_util_last_update_ns
             .store(now_ns, Ordering::SeqCst);
         next
+    }
+
+    /// Return the last scheduler migration timestamp for this task.
+    ///
+    /// # Returns
+    ///
+    /// Monotonic timestamp in nanoseconds, or `0` if this task has not been
+    /// migrated by the scheduler.
+    pub fn sched_last_migration_ns(&self) -> u64 {
+        self.sched_last_migration_ns.load(Ordering::SeqCst)
+    }
+
+    /// Record that the scheduler migrated this task.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ns` - Current monotonic timestamp in nanoseconds.
+    pub fn mark_sched_migrated(&self, now_ns: u64) {
+        self.sched_last_migration_ns.store(now_ns, Ordering::SeqCst);
     }
 
     /// Mark the task as running for CPU accounting.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -1077,6 +1077,16 @@ impl Task {
         self.id
     }
 
+    /// Return the task ID if this task has been registered with the scheduler.
+    ///
+    /// # Returns
+    ///
+    /// `Some(task_id)` for scheduler-visible tasks, or `None` for freshly
+    /// constructed tasks that have not been inserted into the task pool yet.
+    pub(crate) fn registered_id(&self) -> Option<usize> {
+        (self.id != 0).then_some(self.id)
+    }
+
     /// Set the task ID (used by TaskPool during task addition)
     pub fn set_id(&mut self, id: usize) {
         self.id = id;

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -57,6 +57,9 @@ const INIT_TASK_ID: usize = 1;
 const LOG_EXIT_GROUP_SIBLINGS: bool = false;
 /// Scheduler utilization scale used for task placement hints.
 pub const SCHED_UTIL_SCALE: u32 = 1024;
+const SCHED_UTIL_DECAY_INTERVAL_NS: u64 = 10_000_000;
+const SCHED_UTIL_DECAY_NUM: u32 = 7;
+const SCHED_UTIL_DECAY_DEN: u32 = 8;
 
 /// Lock type used for the architecture kernel context.
 ///
@@ -99,6 +102,8 @@ pub struct TaskInfo {
     pub name: [u8; 64],
     /// Cumulative CPU time consumed by this task, in nanoseconds.
     pub cpu_time_ns: u64,
+    /// Measured scheduler utilization in capacity units.
+    pub sched_util_avg: u32,
 }
 
 impl TaskInfo {
@@ -494,6 +499,10 @@ pub struct Task {
     core_preference: AtomicU8,
     /// Minimum scheduler utilization required by this task.
     sched_util_min: AtomicU32,
+    /// Measured scheduler utilization for this task.
+    sched_util_avg: AtomicU32,
+    /// Last timestamp at which measured scheduler utilization was updated.
+    sched_util_last_update_ns: AtomicU64,
     /// Time slice for scheduling
     pub time_slice: AtomicU32,
     pub default_time_slice: AtomicU32,
@@ -682,6 +691,8 @@ impl Task {
             priority: AtomicU32::new(priority),
             core_preference: AtomicU8::new(TaskCorePreference::Any.to_u8()),
             sched_util_min: AtomicU32::new(0),
+            sched_util_avg: AtomicU32::new(0),
+            sched_util_last_update_ns: AtomicU64::new(0),
             time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             default_time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             cpu_time_ns: AtomicU64::new(0),
@@ -795,6 +806,81 @@ impl Task {
         }
         self.sched_util_min.store(util_min, Ordering::SeqCst);
         Ok(())
+    }
+
+    fn decay_sched_util_avg(avg: u32, elapsed_ns: u64) -> u32 {
+        let mut periods = elapsed_ns / SCHED_UTIL_DECAY_INTERVAL_NS;
+        if periods == 0 {
+            return avg;
+        }
+
+        let mut next = avg as u64;
+        periods = periods.min(64);
+        for _ in 0..periods {
+            next = next.saturating_mul(SCHED_UTIL_DECAY_NUM as u64) / SCHED_UTIL_DECAY_DEN as u64;
+            if next == 0 {
+                break;
+            }
+        }
+
+        next.min(SCHED_UTIL_SCALE as u64) as u32
+    }
+
+    /// Return the measured scheduler utilization for this task.
+    ///
+    /// # Returns
+    ///
+    /// Measured utilization in scheduler capacity units, where
+    /// [`SCHED_UTIL_SCALE`] represents a full-capacity CPU.
+    pub fn sched_util_avg(&self) -> u32 {
+        self.sched_util_avg.load(Ordering::SeqCst)
+    }
+
+    /// Return a decayed measured scheduler utilization snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ns` - Current monotonic timestamp in nanoseconds.
+    ///
+    /// # Returns
+    ///
+    /// Measured utilization in scheduler capacity units after applying sleep
+    /// decay since the last update.
+    pub fn sched_util_avg_snapshot(&self, now_ns: u64) -> u32 {
+        let avg = self.sched_util_avg();
+        let last_update_ns = self.sched_util_last_update_ns.load(Ordering::SeqCst);
+        if avg == 0 || last_update_ns == 0 {
+            return avg;
+        }
+
+        Self::decay_sched_util_avg(avg, now_ns.saturating_sub(last_update_ns))
+    }
+
+    /// Account a scheduler utilization sample while this task is running.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ns` - Current monotonic timestamp in nanoseconds.
+    ///
+    /// # Returns
+    ///
+    /// Updated measured utilization in scheduler capacity units.
+    pub fn account_sched_util_running(&self, now_ns: u64) -> u32 {
+        let last_update_ns = self.sched_util_last_update_ns.load(Ordering::SeqCst);
+        if last_update_ns != 0
+            && now_ns.saturating_sub(last_update_ns) < SCHED_UTIL_DECAY_INTERVAL_NS
+        {
+            return self.sched_util_avg();
+        }
+
+        let avg = self.sched_util_avg_snapshot(now_ns);
+        let next = avg
+            .saturating_add((SCHED_UTIL_SCALE.saturating_sub(avg).saturating_add(1)) / 2)
+            .min(SCHED_UTIL_SCALE);
+        self.sched_util_avg.store(next, Ordering::SeqCst);
+        self.sched_util_last_update_ns
+            .store(now_ns, Ordering::SeqCst);
+        next
     }
 
     /// Mark the task as running for CPU accounting.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -516,6 +516,10 @@ pub struct Task {
     sched_util_avg: AtomicU32,
     /// Last timestamp at which measured scheduler utilization was updated.
     sched_util_last_update_ns: AtomicU64,
+    /// CPU runtime accumulated for the current scheduler utilization window.
+    sched_util_window_runtime_ns: AtomicU64,
+    /// Last timestamp charged into the scheduler utilization window.
+    sched_util_accounted_until_ns: AtomicU64,
     /// Last timestamp at which the scheduler migrated this task.
     ///
     /// Used to rate-limit scheduler-driven cross-CPU movement.
@@ -716,6 +720,8 @@ impl Task {
             sched_util_min: AtomicU32::new(0),
             sched_util_avg: AtomicU32::new(0),
             sched_util_last_update_ns: AtomicU64::new(0),
+            sched_util_window_runtime_ns: AtomicU64::new(0),
+            sched_util_accounted_until_ns: AtomicU64::new(0),
             sched_last_migration_ns: AtomicU64::new(0),
             sched_migration_count: AtomicU64::new(0),
             sched_low_util_since_ns: AtomicU64::new(0),
@@ -882,7 +888,11 @@ impl Task {
         Self::decay_sched_util_avg(avg, now_ns.saturating_sub(last_update_ns))
     }
 
-    /// Account a scheduler utilization sample while this task is running.
+    /// Account scheduler utilization runtime while this task is running.
+    ///
+    /// Utilization is based on CPU runtime accumulated over a sampling window,
+    /// not merely on whether the task ran at least once. This keeps short
+    /// wakeups from looking like full-capacity CPU-bound work.
     ///
     /// # Arguments
     ///
@@ -892,17 +902,37 @@ impl Task {
     ///
     /// Updated measured utilization in scheduler capacity units.
     pub fn account_sched_util_running(&self, now_ns: u64) -> u32 {
+        let last_accounted_ns = self
+            .sched_util_accounted_until_ns
+            .swap(now_ns, Ordering::SeqCst);
+        if last_accounted_ns != 0 {
+            let delta_ns = now_ns.saturating_sub(last_accounted_ns);
+            self.sched_util_window_runtime_ns
+                .fetch_add(delta_ns, Ordering::SeqCst);
+        }
+
         let last_update_ns = self.sched_util_last_update_ns.load(Ordering::SeqCst);
-        if last_update_ns != 0
-            && now_ns.saturating_sub(last_update_ns) < SCHED_UTIL_DECAY_INTERVAL_NS
-        {
+        if last_update_ns == 0 {
+            self.sched_util_last_update_ns
+                .store(now_ns, Ordering::SeqCst);
             return self.sched_util_avg();
         }
 
+        let elapsed_ns = now_ns.saturating_sub(last_update_ns);
+        if elapsed_ns < SCHED_UTIL_DECAY_INTERVAL_NS {
+            return self.sched_util_avg();
+        }
+
+        let runtime_ns = self.sched_util_window_runtime_ns.swap(0, Ordering::SeqCst);
+        let sample = ((runtime_ns as u128 * SCHED_UTIL_SCALE as u128) / elapsed_ns as u128)
+            .min(SCHED_UTIL_SCALE as u128) as u32;
         let avg = self.sched_util_avg_snapshot(now_ns);
-        let next = avg
-            .saturating_add((SCHED_UTIL_SCALE.saturating_sub(avg).saturating_add(1)) / 2)
-            .min(SCHED_UTIL_SCALE);
+        let next = if sample > avg {
+            avg.saturating_add(sample.saturating_sub(avg).saturating_add(1) / 2)
+        } else {
+            avg.saturating_mul(7).saturating_add(sample) / 8
+        }
+        .min(SCHED_UTIL_SCALE);
         self.sched_util_avg.store(next, Ordering::SeqCst);
         self.sched_util_last_update_ns
             .store(now_ns, Ordering::SeqCst);
@@ -983,6 +1013,8 @@ impl Task {
     /// * `now_ns` - Current monotonic timestamp in nanoseconds.
     pub fn start_cpu_accounting(&self, now_ns: u64) {
         self.cpu_run_start_ns.store(now_ns, Ordering::SeqCst);
+        self.sched_util_accounted_until_ns
+            .store(now_ns, Ordering::SeqCst);
     }
 
     /// Stop charging CPU time to this task and return the elapsed delta.
@@ -2862,6 +2894,38 @@ mod tests {
         assert_eq!(task.get_brk(), 0x1008);
         task.set_brk(0x1000).unwrap();
         assert_eq!(task.get_brk(), 0x1000);
+    }
+
+    #[test_case]
+    fn test_sched_util_short_bursts_track_runtime_fraction() {
+        let task = super::Task::new("BurstyTask".to_string(), 1, super::TaskType::Kernel);
+        const MS: u64 = 1_000_000;
+
+        task.start_cpu_accounting(1 * MS);
+        assert_eq!(task.account_sched_util_running(2 * MS), 0);
+
+        task.start_cpu_accounting(101 * MS);
+        let util = task.account_sched_util_running(102 * MS);
+        assert!(util < 64, "short burst util should stay low: {}", util);
+    }
+
+    #[test_case]
+    fn test_sched_util_sustained_runtime_rises() {
+        let task = super::Task::new("CpuTask".to_string(), 1, super::TaskType::Kernel);
+        const MS: u64 = 1_000_000;
+
+        task.start_cpu_accounting(1 * MS);
+        assert_eq!(
+            task.account_sched_util_running(1 * MS + super::SCHED_UTIL_DECAY_INTERVAL_NS),
+            0
+        );
+        let util =
+            task.account_sched_util_running(1 * MS + super::SCHED_UTIL_DECAY_INTERVAL_NS * 2);
+        assert!(
+            util >= super::SCHED_UTIL_SCALE / 2,
+            "sustained util={}",
+            util
+        );
     }
 
     #[test_case]

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -503,6 +503,8 @@ pub struct Task {
     sched_util_avg: AtomicU32,
     /// Last timestamp at which measured scheduler utilization was updated.
     sched_util_last_update_ns: AtomicU64,
+    /// Last timestamp at which the scheduler migrated this task.
+    sched_last_migration_ns: AtomicU64,
     /// Time slice for scheduling
     pub time_slice: AtomicU32,
     pub default_time_slice: AtomicU32,
@@ -693,6 +695,7 @@ impl Task {
             sched_util_min: AtomicU32::new(0),
             sched_util_avg: AtomicU32::new(0),
             sched_util_last_update_ns: AtomicU64::new(0),
+            sched_last_migration_ns: AtomicU64::new(0),
             time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             default_time_slice: AtomicU32::new(DEFAULT_TIME_SLICE),
             cpu_time_ns: AtomicU64::new(0),
@@ -881,6 +884,25 @@ impl Task {
         self.sched_util_last_update_ns
             .store(now_ns, Ordering::SeqCst);
         next
+    }
+
+    /// Return the last scheduler migration timestamp for this task.
+    ///
+    /// # Returns
+    ///
+    /// Monotonic timestamp in nanoseconds, or `0` if this task has not been
+    /// migrated by the scheduler.
+    pub fn sched_last_migration_ns(&self) -> u64 {
+        self.sched_last_migration_ns.load(Ordering::SeqCst)
+    }
+
+    /// Record that the scheduler migrated this task.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ns` - Current monotonic timestamp in nanoseconds.
+    pub fn mark_sched_migrated(&self, now_ns: u64) {
+        self.sched_last_migration_ns.store(now_ns, Ordering::SeqCst);
     }
 
     /// Mark the task as running for CPU accounting.

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -341,8 +341,9 @@ pub fn sys_set_tls(trapframe: &mut Trapframe) -> usize {
         }
     }
 
-    // Set TLS pointer using architecture-specific VCPU method
-    task.vcpu.lock().set_tls_pointer(tls_ptr);
+    // The current task's live register state is the syscall trapframe. The VCPU
+    // save area is updated from the trapframe only when the scheduler stores it.
+    trapframe.set_tls_pointer(tls_ptr);
 
     trapframe.increment_pc_next(task);
     0 // Success

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -1436,6 +1436,7 @@ pub fn sys_get_task_info_list(trapframe: &mut Trapframe) -> usize {
             tgid,
             name,
             cpu_time_ns: target.cpu_time_snapshot_ns(now_ns),
+            sched_util_avg: target.sched_util_avg_snapshot(now_ns),
         };
 
         let info_bytes = unsafe {

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -1408,7 +1408,8 @@ pub fn sys_get_task_info_list(trapframe: &mut Trapframe) -> usize {
             super::TaskType::Kernel => 0,
             super::TaskType::User => 1,
         };
-        let cpu_id = target.last_cpu.load(Ordering::SeqCst) as u8; // saturates on MAX
+        let last_cpu = target.last_cpu.load(Ordering::SeqCst);
+        let cpu_id = u8::try_from(last_cpu).unwrap_or(u8::MAX);
 
         let exit_status = target.exit_status.load(Ordering::SeqCst);
 
@@ -1437,6 +1438,13 @@ pub fn sys_get_task_info_list(trapframe: &mut Trapframe) -> usize {
             name,
             cpu_time_ns: target.cpu_time_snapshot_ns(now_ns),
             sched_util_avg: target.sched_util_avg_snapshot(now_ns),
+            sched_util_min: target.sched_util_min(),
+            sched_required_capacity: crate::sched::scheduler::task_required_capacity_snapshot(
+                target, now_ns,
+            ),
+            core_preference: target.core_preference().to_u8(),
+            _reserved2: [0; 3],
+            sched_migration_count: target.sched_migration_count(),
         };
 
         let info_bytes = unsafe {

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -242,7 +242,14 @@ pub fn sys_clone(trapframe: &mut Trapframe) -> usize {
             /* Return the child task PID (namespace-local) to the parent task */
             child_ns_pid
         }
-        Err(_) => {
+        Err(err) => {
+            crate::println!(
+                "[clone] failed: parent={} name={} flags={:#x} reason={}",
+                parent_task.get_id(),
+                parent_task.name.read().as_str(),
+                clone_flags.get_raw(),
+                err
+            );
             usize::MAX /* Return -1 on error */
         }
     }

--- a/kernel/src/task/syscall.rs
+++ b/kernel/src/task/syscall.rs
@@ -72,14 +72,19 @@ pub fn sys_putchar(trapframe: &mut Trapframe) -> usize {
     trapframe.increment_pc_next(task);
     if let Some(ch) = char::from_u32(c) {
         let manager = DeviceManager::get_manager();
-        if let Some(device_id) = manager.get_first_device_by_type(crate::device::DeviceType::Char) {
-            if let Some(char_device) = manager.get_device(device_id).unwrap().as_char_device() {
-                // Use CharDevice trait methods to write
-                if let Err(e) = char_device.write_byte(ch as u8) {
-                    crate::print!("Error writing character: {}", e);
-                    return usize::MAX; // -1
-                }
-                // Successfully written character
+        if let Some(device) = manager.get_device_by_name("tty0")
+            && let Some(char_device) = device.as_char_device()
+            && char_device.can_write()
+            && char_device.write_byte(ch as u8).is_ok()
+        {
+            return 0;
+        }
+
+        for (_name, device) in manager.get_named_devices() {
+            if let Some(char_device) = device.as_char_device()
+                && char_device.can_write()
+                && char_device.write_byte(ch as u8).is_ok()
+            {
                 return 0;
             }
         }

--- a/kernel/src/vm/manager.rs
+++ b/kernel/src/vm/manager.rs
@@ -125,6 +125,12 @@ impl VirtualMemoryManager {
         self.inner.write().private_page_allocations.push(alloc);
     }
 
+    fn sync_executable_page_for_mapping(permissions: usize, paddr: usize) {
+        if VirtualMemoryPermission::Execute.contained_in(permissions) {
+            crate::arch::sync_icache_for_execution(phys_to_virt(paddr), PAGE_SIZE);
+        }
+    }
+
     /// Sets the ASID (Address Space ID) for the virtual memory manager.
     ///
     /// # Arguments
@@ -637,6 +643,7 @@ impl VirtualMemoryManager {
                                 }
                             }
                             self.track_private_page_allocation(new_alloc);
+                            Self::sync_executable_page_for_mapping(perms, new_paddr);
                             root_pagetable.map(
                                 self.get_asid(),
                                 page_vaddr,
@@ -666,6 +673,7 @@ impl VirtualMemoryManager {
         };
 
         if let Some(root_pagetable) = self.get_root_page_table() {
+            Self::sync_executable_page_for_mapping(perms, page_paddr);
             root_pagetable.map(
                 self.get_asid(),
                 page_vaddr,

--- a/user/bin/src/sws/main.rs
+++ b/user/bin/src/sws/main.rs
@@ -24,6 +24,7 @@ use std::task::{SCHED_UTIL_SCALE, set_sched_util_min};
 const STEMD_SERVICE_READY_CMD: u8 = 0x06;
 const STEMD_NOTIFY_RETRIES: usize = 100;
 const STEMD_NOTIFY_DELAY_MS: u64 = 50;
+const SWS_COMPOSITOR_UTIL_MIN: u32 = SCHED_UTIL_SCALE * 7 / 8;
 
 fn notify_service_ready(service_name: &str) {
     for attempt in 0..STEMD_NOTIFY_RETRIES {
@@ -89,7 +90,7 @@ fn main() -> i32 {
     println!("Compositor ready. Starting main loop...");
     notify_service_ready("sws");
 
-    if set_sched_util_min(SCHED_UTIL_SCALE).is_err() {
+    if set_sched_util_min(SWS_COMPOSITOR_UTIL_MIN).is_err() {
         println!("[sws] Failed to set compositor scheduler utilization hint");
     }
 

--- a/user/bin/src/video_player.rs
+++ b/user/bin/src/video_player.rs
@@ -35,7 +35,7 @@ use std::handle::capability::memory_mapping::{flags as mmap_flags, munmap, prot}
 use std::io::{ErrorKind, Read, SeekFrom};
 use std::socket::Socket;
 use std::sync::Mutex;
-use std::task::exit;
+use std::task::{SCHED_UTIL_SCALE, exit};
 use std::{format, println, thread};
 #[cfg(feature = "mp4-aac")]
 use symphonia_codec_aac::AacDecoder;
@@ -99,6 +99,8 @@ const VVIDEO_DESTROY_SESSION: u32 = 0x5606;
 const VIRTIO_VIDEO_FORMAT_H264: u32 = 4098;
 const VIRTIO_VIDEO_FORMAT_AV1: u32 = 4103;
 const SCARLET_AV1_ACCESS_UNIT_MAGIC: &[u8; 4] = b"SVA1";
+const VIDEO_DECODE_UTIL_MIN: u32 = SCHED_UTIL_SCALE * 7 / 8;
+const VIDEO_DISPLAY_UTIL_MIN: u32 = SCHED_UTIL_SCALE * 3 / 4;
 
 #[repr(C)]
 #[derive(Clone, Copy, Default)]
@@ -949,7 +951,7 @@ fn start_decoder_thread(
 ) {
     thread::Builder::new()
         .name("video-decode")
-        .performance()
+        .util_min(VIDEO_DECODE_UTIL_MIN)
         .spawn(move || {
             let display_queue = Arc::new(DisplayQueue::new(clock.clone()));
             start_display_thread(
@@ -1027,7 +1029,7 @@ fn start_display_thread(
 ) {
     thread::Builder::new()
         .name("video-display")
-        .performance()
+        .util_min(VIDEO_DISPLAY_UTIL_MIN)
         .spawn(move || {
             loop {
                 let Some(item) = queue.pop() else {

--- a/user/lib/std/src/task.rs
+++ b/user/lib/std/src/task.rs
@@ -850,6 +850,7 @@ pub struct TaskInfo {
     tgid: usize,
     name: crate::string::String,
     cpu_time_ns: u64,
+    sched_util_avg: u32,
 }
 
 impl TaskInfo {
@@ -888,6 +889,10 @@ impl TaskInfo {
     /// Cumulative CPU time consumed by this task, in nanoseconds.
     pub fn cpu_time_ns(&self) -> u64 {
         self.cpu_time_ns
+    }
+    /// Measured scheduler utilization in capacity units.
+    pub fn sched_util_avg(&self) -> u32 {
+        self.sched_util_avg
     }
 }
 
@@ -945,6 +950,7 @@ pub struct RawTaskInfo {
     pub tgid: usize,
     pub name: [u8; 64],
     pub cpu_time_ns: u64,
+    pub sched_util_avg: u32,
 }
 
 /// Opaque raw CPU usage layout shared with the kernel (`#[repr(C)]`).
@@ -979,6 +985,7 @@ impl RawTaskInfo {
             tgid: self.tgid,
             name,
             cpu_time_ns: self.cpu_time_ns,
+            sched_util_avg: self.sched_util_avg,
         }
     }
 }
@@ -1023,6 +1030,7 @@ pub fn info_raw() -> crate::vec::Vec<RawTaskInfo> {
     let mut buf = crate::vec![RawTaskInfo {
         pid: 0, ppid: 0, state: 0, task_type: 0, cpu_id: 0,
         _reserved: 0, exit_status: 0, tgid: 0, name: [0; 64], cpu_time_ns: 0,
+        sched_util_avg: 0,
     }; total];
     let n = syscall2(
         Syscall::GetTaskInfoList,

--- a/user/lib/std/src/task.rs
+++ b/user/lib/std/src/task.rs
@@ -825,6 +825,56 @@ impl core::fmt::Display for TaskType {
     }
 }
 
+/// Scheduler hint for heterogeneous CPU placement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskCorePreference {
+    /// No explicit core-class preference.
+    Any,
+    /// Prefer energy-efficient cores when load permits.
+    Efficiency,
+    /// Prefer higher-capacity cores.
+    Performance,
+}
+
+impl TaskCorePreference {
+    /// Decode a raw kernel discriminant.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - Raw `TaskCorePreference` discriminant.
+    ///
+    /// # Returns
+    ///
+    /// Decoded core preference, or [`TaskCorePreference::Any`] for unknown
+    /// values.
+    pub fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Efficiency,
+            2 => Self::Performance,
+            _ => Self::Any,
+        }
+    }
+
+    /// Return a compact string representation.
+    ///
+    /// # Returns
+    ///
+    /// `"any"`, `"efficiency"`, or `"performance"`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Any => "any",
+            Self::Efficiency => "efficiency",
+            Self::Performance => "performance",
+        }
+    }
+}
+
+impl core::fmt::Display for TaskCorePreference {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Snapshot of a single task's metadata.
 ///
 /// This is the user-space mirror of `kernel::task::TaskInfo`.
@@ -851,6 +901,10 @@ pub struct TaskInfo {
     name: crate::string::String,
     cpu_time_ns: u64,
     sched_util_avg: u32,
+    sched_util_min: u32,
+    sched_required_capacity: u32,
+    core_preference: TaskCorePreference,
+    sched_migration_count: u64,
 }
 
 impl TaskInfo {
@@ -893,6 +947,22 @@ impl TaskInfo {
     /// Measured scheduler utilization in capacity units.
     pub fn sched_util_avg(&self) -> u32 {
         self.sched_util_avg
+    }
+    /// Minimum scheduler utilization requested by this task.
+    pub fn sched_util_min(&self) -> u32 {
+        self.sched_util_min
+    }
+    /// Effective CPU capacity required for scheduler placement.
+    pub fn sched_required_capacity(&self) -> u32 {
+        self.sched_required_capacity
+    }
+    /// Core preference hint used by scheduler placement.
+    pub fn core_preference(&self) -> TaskCorePreference {
+        self.core_preference
+    }
+    /// Number of scheduler-directed migrations for this task.
+    pub fn sched_migration_count(&self) -> u64 {
+        self.sched_migration_count
     }
 }
 
@@ -951,6 +1021,11 @@ pub struct RawTaskInfo {
     pub name: [u8; 64],
     pub cpu_time_ns: u64,
     pub sched_util_avg: u32,
+    pub sched_util_min: u32,
+    pub sched_required_capacity: u32,
+    pub core_preference: u8,
+    pub _reserved2: [u8; 3],
+    pub sched_migration_count: u64,
 }
 
 /// Opaque raw CPU usage layout shared with the kernel (`#[repr(C)]`).
@@ -986,6 +1061,10 @@ impl RawTaskInfo {
             name,
             cpu_time_ns: self.cpu_time_ns,
             sched_util_avg: self.sched_util_avg,
+            sched_util_min: self.sched_util_min,
+            sched_required_capacity: self.sched_required_capacity,
+            core_preference: TaskCorePreference::from_u8(self.core_preference),
+            sched_migration_count: self.sched_migration_count,
         }
     }
 }
@@ -1030,7 +1109,8 @@ pub fn info_raw() -> crate::vec::Vec<RawTaskInfo> {
     let mut buf = crate::vec![RawTaskInfo {
         pid: 0, ppid: 0, state: 0, task_type: 0, cpu_id: 0,
         _reserved: 0, exit_status: 0, tgid: 0, name: [0; 64], cpu_time_ns: 0,
-        sched_util_avg: 0,
+        sched_util_avg: 0, sched_util_min: 0, sched_required_capacity: 0,
+        core_preference: 0, _reserved2: [0; 3], sched_migration_count: 0,
     }; total];
     let n = syscall2(
         Syscall::GetTaskInfoList,

--- a/user/std-bin/Cargo.toml
+++ b/user/std-bin/Cargo.toml
@@ -63,6 +63,10 @@ name = "top"
 path = "src/top.rs"
 
 [[bin]]
+name = "task_manager"
+path = "src/task_manager.rs"
+
+[[bin]]
 name = "date"
 path = "src/date.rs"
 

--- a/user/std-bin/Cargo.toml
+++ b/user/std-bin/Cargo.toml
@@ -63,6 +63,10 @@ name = "top"
 path = "src/top.rs"
 
 [[bin]]
+name = "sched_bench"
+path = "src/sched_bench.rs"
+
+[[bin]]
 name = "task_manager"
 path = "src/task_manager.rs"
 

--- a/user/std-bin/src/sched_bench.rs
+++ b/user/std-bin/src/sched_bench.rs
@@ -1,0 +1,288 @@
+use std::env;
+use std::process::ExitCode;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use scarlet_sys::{SCHED_UTIL_SCALE, Syscall, syscall1};
+
+const DEFAULT_THREADS: usize = 4;
+const DEFAULT_SECONDS: u64 = 15;
+
+#[derive(Clone, Copy)]
+enum Scenario {
+    Cpu,
+    Bursty,
+    Sleepy,
+    Mixed,
+}
+
+impl Scenario {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "cpu" => Some(Self::Cpu),
+            "bursty" => Some(Self::Bursty),
+            "sleepy" => Some(Self::Sleepy),
+            "mixed" => Some(Self::Mixed),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Bursty => "bursty",
+            Self::Sleepy => "sleepy",
+            Self::Mixed => "mixed",
+        }
+    }
+
+    fn worker_kind(self, worker_id: usize) -> WorkerKind {
+        match self {
+            Self::Cpu => WorkerKind::Cpu,
+            Self::Bursty => WorkerKind::Bursty,
+            Self::Sleepy => WorkerKind::Sleepy,
+            Self::Mixed => match worker_id % 3 {
+                0 => WorkerKind::Cpu,
+                1 => WorkerKind::Bursty,
+                _ => WorkerKind::Sleepy,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WorkerKind {
+    Cpu,
+    Bursty,
+    Sleepy,
+}
+
+struct Config {
+    scenario: Scenario,
+    threads: usize,
+    seconds: u64,
+    performance: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            scenario: Scenario::Mixed,
+            threads: DEFAULT_THREADS,
+            seconds: DEFAULT_SECONDS,
+            performance: false,
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let Ok(config) = parse_args() else {
+        print_usage();
+        return ExitCode::from(2);
+    };
+
+    println!(
+        "[sched_bench] scenario={} threads={} seconds={} util_min={}",
+        config.scenario.as_str(),
+        config.threads,
+        config.seconds,
+        if config.performance {
+            SCHED_UTIL_SCALE
+        } else {
+            0
+        },
+    );
+    println!("[sched_bench] sample with: top --sort cpu");
+    println!("[sched_bench] inspect placement with: cat /dev/cpuinfo");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let mut counters = Vec::new();
+    let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
+
+    for worker_id in 0..config.threads {
+        let counter = Arc::new(AtomicU64::new(0));
+        let checksum = Arc::new(AtomicU64::new(worker_id as u64));
+        let stop_for_worker = stop.clone();
+        let counter_for_worker = counter.clone();
+        let checksum_for_worker = checksum.clone();
+        let kind = config.scenario.worker_kind(worker_id);
+        let util_min = if config.performance {
+            SCHED_UTIL_SCALE
+        } else {
+            0
+        };
+
+        let spawn_result = thread::Builder::new().spawn(move || {
+            run_worker(
+                worker_id,
+                kind,
+                util_min,
+                stop_for_worker,
+                counter_for_worker,
+                checksum_for_worker,
+            );
+        });
+
+        match spawn_result {
+            Ok(handle) => {
+                counters.push((counter, checksum));
+                handles.push(handle);
+            }
+            Err(error) => {
+                println!(
+                    "[sched_bench] failed to spawn worker {}: {}",
+                    worker_id, error
+                );
+                stop.store(true, Ordering::SeqCst);
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    let started_at = Instant::now();
+    let mut previous_total = 0u64;
+    while started_at.elapsed() < Duration::from_secs(config.seconds) {
+        thread::sleep(Duration::from_secs(1));
+        let total = total_iterations(&counters);
+        let delta = total.saturating_sub(previous_total);
+        previous_total = total;
+        println!(
+            "[sched_bench] t={:>3}s iter/s={:>12} total={:>14}",
+            started_at.elapsed().as_secs(),
+            delta,
+            total,
+        );
+    }
+
+    stop.store(true, Ordering::SeqCst);
+    for handle in handles {
+        let _ = handle.join();
+    }
+
+    let total = total_iterations(&counters);
+    let checksum = total_checksum(&counters);
+    println!(
+        "[sched_bench] done total={} checksum=0x{:016x}",
+        total, checksum
+    );
+    ExitCode::SUCCESS
+}
+
+fn parse_args() -> Result<Config, ()> {
+    let args: Vec<String> = env::args().collect();
+    let mut config = Config::default();
+    let mut index = 1;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--scenario" | "-s" => {
+                index += 1;
+                let Some(value) = args.get(index) else {
+                    return Err(());
+                };
+                config.scenario = Scenario::parse(value).ok_or(())?;
+            }
+            "--threads" | "-t" => {
+                index += 1;
+                let Some(value) = args.get(index) else {
+                    return Err(());
+                };
+                config.threads = value.parse::<usize>().map_err(|_| ())?;
+            }
+            "--seconds" | "-d" => {
+                index += 1;
+                let Some(value) = args.get(index) else {
+                    return Err(());
+                };
+                config.seconds = value.parse::<u64>().map_err(|_| ())?;
+            }
+            "--performance" | "-p" => {
+                config.performance = true;
+            }
+            "--help" | "-h" => {
+                return Err(());
+            }
+            _ => return Err(()),
+        }
+        index += 1;
+    }
+
+    if config.threads == 0 || config.seconds == 0 {
+        return Err(());
+    }
+    Ok(config)
+}
+
+fn print_usage() {
+    println!(
+        "usage: sched_bench [--scenario cpu|bursty|sleepy|mixed] [--threads N] [--seconds N] [--performance]"
+    );
+    println!("  --performance requests util_min=1024 for worker threads");
+}
+
+fn run_worker(
+    worker_id: usize,
+    kind: WorkerKind,
+    util_min: u32,
+    stop: Arc<AtomicBool>,
+    counter: Arc<AtomicU64>,
+    checksum: Arc<AtomicU64>,
+) {
+    if util_min != 0 {
+        let result = syscall1(Syscall::SetTaskUtilMin, util_min as usize);
+        if result == usize::MAX {
+            println!(
+                "[sched_bench] worker {} failed to set util_min={}",
+                worker_id, util_min
+            );
+        }
+    }
+
+    let mut state = worker_id as u64 ^ 0x9e37_79b9_7f4a_7c15;
+    while !stop.load(Ordering::Relaxed) {
+        match kind {
+            WorkerKind::Cpu => {
+                state = burn(state, 90_000);
+                counter.fetch_add(90_000, Ordering::Relaxed);
+            }
+            WorkerKind::Bursty => {
+                state = burn(state, 35_000);
+                counter.fetch_add(35_000, Ordering::Relaxed);
+                thread::sleep(Duration::from_millis(4));
+            }
+            WorkerKind::Sleepy => {
+                state = burn(state, 6_000);
+                counter.fetch_add(6_000, Ordering::Relaxed);
+                thread::sleep(Duration::from_millis(18));
+            }
+        }
+        checksum.store(state, Ordering::Relaxed);
+    }
+}
+
+fn burn(mut state: u64, iterations: u64) -> u64 {
+    for _ in 0..iterations {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        state ^= state.rotate_left(17);
+    }
+    state
+}
+
+fn total_iterations(counters: &[(Arc<AtomicU64>, Arc<AtomicU64>)]) -> u64 {
+    counters
+        .iter()
+        .map(|(counter, _)| counter.load(Ordering::Relaxed))
+        .sum()
+}
+
+fn total_checksum(counters: &[(Arc<AtomicU64>, Arc<AtomicU64>)]) -> u64 {
+    counters.iter().fold(0, |acc, (_, checksum)| {
+        acc ^ checksum.load(Ordering::Relaxed)
+    })
+}

--- a/user/std-bin/src/task_manager.rs
+++ b/user/std-bin/src/task_manager.rs
@@ -70,6 +70,11 @@ struct RawTaskInfo {
     name: [u8; 64],
     cpu_time_ns: u64,
     sched_util_avg: u32,
+    sched_util_min: u32,
+    sched_required_capacity: u32,
+    core_preference: u8,
+    _reserved2: [u8; 3],
+    sched_migration_count: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -621,6 +626,11 @@ fn task_info() -> Vec<TaskInfo> {
             name: [0; 64],
             cpu_time_ns: 0,
             sched_util_avg: 0,
+            sched_util_min: 0,
+            sched_required_capacity: 0,
+            core_preference: 0,
+            _reserved2: [0; 3],
+            sched_migration_count: 0,
         };
         total
     ];

--- a/user/std-bin/src/task_manager.rs
+++ b/user/std-bin/src/task_manager.rs
@@ -1,0 +1,895 @@
+use std::fs;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use scarlet_sys::{Syscall, syscall0, syscall1, syscall2};
+use scarlet_ui::prelude::*;
+use scarlet_ui::{Color, ProgressView, ScrollView, hstack, vstack};
+use scarlet_ui_macros::View;
+
+const APP_ID: &str = "org.scarlet-os.desktop.task-manager";
+const APP_TITLE: &str = "Task Manager";
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+const WINDOW_WIDTH: f32 = 980.0;
+const WINDOW_HEIGHT: f32 = 660.0;
+const UTIL_SCALE: u32 = 1024;
+const MAX_VISIBLE_TASKS: usize = 10;
+const MAX_VISIBLE_CPUS: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TaskState {
+    NotInitialized,
+    Ready,
+    Running,
+    BlockedInterruptible,
+    BlockedUninterruptible,
+    Zombie,
+    Terminated,
+}
+
+impl TaskState {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Ready,
+            2 => Self::Running,
+            3 => Self::BlockedInterruptible,
+            4 => Self::BlockedUninterruptible,
+            5 => Self::Zombie,
+            6 => Self::Terminated,
+            _ => Self::NotInitialized,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TaskType {
+    Kernel,
+    User,
+}
+
+impl TaskType {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::User,
+            _ => Self::Kernel,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct RawTaskInfo {
+    pid: usize,
+    ppid: usize,
+    state: u8,
+    task_type: u8,
+    cpu_id: u8,
+    _reserved: u8,
+    exit_status: i32,
+    tgid: usize,
+    name: [u8; 64],
+    cpu_time_ns: u64,
+    sched_util_avg: u32,
+}
+
+#[derive(Debug, Clone)]
+struct TaskInfo {
+    pid: usize,
+    state: TaskState,
+    task_type: TaskType,
+    cpu: u8,
+    tgid: usize,
+    name: String,
+    cpu_time_ns: u64,
+    sched_util_avg: u32,
+}
+
+impl RawTaskInfo {
+    fn decode(&self) -> TaskInfo {
+        let end = self
+            .name
+            .iter()
+            .position(|&byte| byte == 0)
+            .unwrap_or(self.name.len());
+        let name = std::str::from_utf8(&self.name[..end])
+            .unwrap_or("<invalid>")
+            .to_string();
+
+        TaskInfo {
+            pid: self.pid,
+            state: TaskState::from_u8(self.state),
+            task_type: TaskType::from_u8(self.task_type),
+            cpu: self.cpu_id,
+            tgid: self.tgid,
+            name,
+            cpu_time_ns: self.cpu_time_ns,
+            sched_util_avg: self.sched_util_avg,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct RawCpuUsageInfo {
+    online_cpus: usize,
+    busy_time_ns: u64,
+    idle_time_ns: u64,
+    total_time_ns: u64,
+    usage_per_mille: u32,
+    _reserved: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CpuUsageInfo {
+    busy_time_ns: u64,
+    idle_time_ns: u64,
+    usage_per_mille: u32,
+}
+
+#[derive(Clone, Default)]
+struct SchedulerStats {
+    migrations: u64,
+    promotions: u64,
+    demotions: u64,
+    cooldown_skips: u64,
+    work_steals: u64,
+}
+
+#[derive(Clone)]
+struct CpuRow {
+    id: usize,
+    class_name: String,
+    capacity: u32,
+    util_avg: u32,
+    util_min: u32,
+    runnable: u32,
+    cur_freq_khz: u32,
+    target_freq_khz: u32,
+    max_freq_khz: u32,
+}
+
+impl Default for CpuRow {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            class_name: String::from("unknown"),
+            capacity: 0,
+            util_avg: 0,
+            util_min: 0,
+            runnable: 0,
+            cur_freq_khz: 0,
+            target_freq_khz: 0,
+            max_freq_khz: 0,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct TaskRow {
+    pid: usize,
+    tgid: usize,
+    cpu: u8,
+    state: TaskState,
+    task_type: TaskType,
+    name: String,
+    cpu_time_ns: u64,
+    cpu_per_mille: u64,
+    util_avg: u32,
+}
+
+#[derive(Clone, Default)]
+struct TaskCounts {
+    total: usize,
+    running: usize,
+    sleeping: usize,
+    stopped: usize,
+    zombie: usize,
+    user: usize,
+    kernel: usize,
+}
+
+#[derive(Clone)]
+struct Snapshot {
+    counts: TaskCounts,
+    busy_per_mille: u64,
+    idle_per_mille: u64,
+    cpus: Vec<CpuRow>,
+    tasks: Vec<TaskRow>,
+    scheduler: SchedulerStats,
+    status: String,
+}
+
+impl Default for Snapshot {
+    fn default() -> Self {
+        Self {
+            counts: TaskCounts::default(),
+            busy_per_mille: 0,
+            idle_per_mille: 1000,
+            cpus: Vec::new(),
+            tasks: Vec::new(),
+            scheduler: SchedulerStats::default(),
+            status: String::from("Collecting scheduler samples..."),
+        }
+    }
+}
+
+#[derive(View, Clone)]
+struct TaskManagerApp {
+    snapshot: State<Snapshot>,
+}
+
+impl TaskManagerApp {
+    fn new() -> Self {
+        Self {
+            snapshot: State::new(StateId::new(1), Snapshot::default()),
+        }
+    }
+}
+
+impl Application for TaskManagerApp {
+    fn scenes(&self) -> impl Scene {
+        let snapshot = self.snapshot.get();
+        WindowGroup::new(
+            "main",
+            Window::new(
+                APP_TITLE,
+                app_content(snapshot).frame(f32::INFINITY, f32::INFINITY),
+            )
+            .app_id(APP_ID)
+            .background_color(bg())
+            .size(Size::new(WINDOW_WIDTH, WINDOW_HEIGHT)),
+        )
+    }
+
+    fn init(&mut self) {
+        start_sampler(self.snapshot.clone());
+    }
+
+    fn debug_logging(&self) -> bool {
+        false
+    }
+}
+
+fn app_content(snapshot: Snapshot) -> impl View + Clone {
+    vstack! {
+        header_view(&snapshot),
+        Spacer::new().frame_height(12.0),
+        hstack! {
+            section_title("CPU Cores"),
+            Spacer::new(),
+            body_text(format!(
+                "migrations {}  promotions {}  demotions {}  skips {}  steals {}",
+                snapshot.scheduler.migrations,
+                snapshot.scheduler.promotions,
+                snapshot.scheduler.demotions,
+                snapshot.scheduler.cooldown_skips,
+                snapshot.scheduler.work_steals,
+            )),
+        },
+        Spacer::new().frame_height(8.0),
+        hstack! {
+            cpu_tile(&snapshot, 0),
+            cpu_tile(&snapshot, 1),
+            cpu_tile(&snapshot, 2),
+            cpu_tile(&snapshot, 3),
+        },
+        hstack! {
+            cpu_tile(&snapshot, 4),
+            cpu_tile(&snapshot, 5),
+            cpu_tile(&snapshot, 6),
+            cpu_tile(&snapshot, 7),
+        },
+        Spacer::new().frame_height(14.0),
+        hstack! {
+            section_title("Tasks"),
+            Spacer::new(),
+            body_text(format!(
+                "showing top {} of {}",
+                snapshot.tasks.len().min(MAX_VISIBLE_TASKS),
+                snapshot.counts.total,
+            )),
+        },
+        table_header(),
+        ScrollView::new(vstack! {
+            task_row(&snapshot, 0),
+            task_row(&snapshot, 1),
+            task_row(&snapshot, 2),
+            task_row(&snapshot, 3),
+            task_row(&snapshot, 4),
+            task_row(&snapshot, 5),
+            task_row(&snapshot, 6),
+            task_row(&snapshot, 7),
+            task_row(&snapshot, 8),
+            task_row(&snapshot, 9),
+        })
+        .frame_height(250.0),
+    }
+    .padding(16.0)
+}
+
+fn header_view(snapshot: &Snapshot) -> impl View + Clone + use<> {
+    vstack! {
+        hstack! {
+            vstack! {
+                Text::new(APP_TITLE)
+                    .font_size(28.0)
+                    .color(text_primary()),
+                Text::new(snapshot.status.clone())
+                    .font_size(12.0)
+                    .color(text_secondary()),
+            },
+            Spacer::new(),
+            vstack! {
+                Text::new(format!(
+                    "CPU {}% busy / {}% idle",
+                    format_percent(snapshot.busy_per_mille),
+                    format_percent(snapshot.idle_per_mille),
+                ))
+                .font_size(14.0)
+                .color(text_primary()),
+                ProgressView::new(progress(snapshot.busy_per_mille, 1000))
+                    .frame_width(220.0),
+            },
+        },
+        Spacer::new().frame_height(10.0),
+        hstack! {
+            summary_cell("total", snapshot.counts.total),
+            summary_cell("running", snapshot.counts.running),
+            summary_cell("sleeping", snapshot.counts.sleeping),
+            summary_cell("stopped", snapshot.counts.stopped),
+            summary_cell("zombie", snapshot.counts.zombie),
+            summary_cell("user", snapshot.counts.user),
+            summary_cell("kernel", snapshot.counts.kernel),
+        },
+    }
+    .padding(14.0)
+    .background(surface())
+}
+
+fn summary_cell(label: &'static str, value: usize) -> impl View + Clone {
+    vstack! {
+        Text::new(value.to_string())
+            .font_size(18.0)
+            .color(text_primary()),
+        Text::new(label)
+            .font_size(11.0)
+            .color(text_secondary()),
+    }
+    .frame_width(92.0)
+}
+
+fn section_title(title: &'static str) -> impl View + Clone {
+    Text::new(title).font_size(18.0).color(text_primary())
+}
+
+fn body_text(text: String) -> impl View + Clone {
+    Text::new(text).font_size(12.0).color(text_secondary())
+}
+
+fn cpu_tile(snapshot: &Snapshot, index: usize) -> impl View + Clone + use<> {
+    let cpu = snapshot.cpus.get(index);
+    let id = cpu.map(|cpu| cpu.id).unwrap_or(index);
+    let class_name = cpu
+        .map(|cpu| cpu.class_name.clone())
+        .unwrap_or_else(|| String::from("offline"));
+    let capacity = cpu.map(|cpu| cpu.capacity).unwrap_or(0);
+    let util_avg = cpu.map(|cpu| cpu.util_avg).unwrap_or(0);
+    let util_min = cpu.map(|cpu| cpu.util_min).unwrap_or(0);
+    let runnable = cpu.map(|cpu| cpu.runnable).unwrap_or(0);
+    let cur_freq = cpu.map(|cpu| cpu.cur_freq_khz).unwrap_or(0);
+    let target_freq = cpu.map(|cpu| cpu.target_freq_khz).unwrap_or(0);
+    let max_freq = cpu.map(|cpu| cpu.max_freq_khz).unwrap_or(0);
+    let title_color = if index < snapshot.cpus.len() {
+        text_primary()
+    } else {
+        muted_text()
+    };
+
+    vstack! {
+        hstack! {
+            Text::new(format!("CPU{}", id))
+                .font_size(15.0)
+                .color(title_color),
+            Spacer::new(),
+            Text::new(class_name)
+                .font_size(11.0)
+                .color(text_secondary()),
+        },
+        ProgressView::new(progress(util_avg as u64, UTIL_SCALE as u64))
+            .frame_width(205.0),
+        hstack! {
+            metric_text(format!("util {}", util_avg)),
+            Spacer::new(),
+            metric_text(format!("min {}", util_min)),
+            Spacer::new(),
+            metric_text(format!("run {}", runnable)),
+        },
+        hstack! {
+            metric_text(format!("cap {}", capacity)),
+            Spacer::new(),
+            metric_text(freq_text(cur_freq, target_freq, max_freq)),
+        },
+    }
+    .padding(10.0)
+    .background(surface())
+    .frame_width(224.0)
+}
+
+fn metric_text(text: String) -> impl View + Clone {
+    Text::new(text).font_size(11.0).color(text_secondary())
+}
+
+fn table_header() -> impl View + Clone {
+    hstack! {
+        header_cell("PID", 54.0),
+        header_cell("CPU", 48.0),
+        header_cell("%CPU", 54.0),
+        header_cell("UTIL", 52.0),
+        header_cell("STAT", 48.0),
+        header_cell("TYPE", 52.0),
+        header_cell("TIME", 82.0),
+        header_cell("TGID", 54.0),
+        header_cell("COMMAND", 300.0),
+    }
+    .padding(8.0)
+    .background(header_bg())
+}
+
+fn header_cell(text: &'static str, width: f32) -> impl View + Clone {
+    Text::new(text)
+        .font_size(11.0)
+        .color(text_secondary())
+        .frame_width(width)
+}
+
+fn task_row(snapshot: &Snapshot, index: usize) -> impl View + Clone + use<> {
+    let task = snapshot.tasks.get(index);
+    let is_visible = task.is_some();
+    let row_bg = if index % 2 == 0 { surface() } else { row_alt() };
+    let text_color = if is_visible {
+        text_primary()
+    } else {
+        muted_text()
+    };
+    let pid = task.map(|task| task.pid.to_string()).unwrap_or_default();
+    let cpu = task
+        .map(|task| format!("CPU{}", task.cpu))
+        .unwrap_or_default();
+    let percent = task
+        .map(|task| format_percent(task.cpu_per_mille))
+        .unwrap_or_default();
+    let util = task
+        .map(|task| task.util_avg.to_string())
+        .unwrap_or_default();
+    let state = task
+        .map(|task| format_stat(task.state).to_string())
+        .unwrap_or_default();
+    let task_type = task
+        .map(|task| format_type(task.task_type).to_string())
+        .unwrap_or_default();
+    let time = task
+        .map(|task| format_time_ns(task.cpu_time_ns))
+        .unwrap_or_default();
+    let tgid = task.map(|task| task.tgid.to_string()).unwrap_or_default();
+    let name = task
+        .map(|task| truncate(&task.name, 34))
+        .unwrap_or_default();
+
+    hstack! {
+        row_cell(pid, 54.0, text_color),
+        row_cell(cpu, 48.0, text_color),
+        row_cell(percent, 54.0, text_color),
+        row_cell(util, 52.0, text_color),
+        row_cell(state, 48.0, text_color),
+        row_cell(task_type, 52.0, text_color),
+        row_cell(time, 82.0, text_color),
+        row_cell(tgid, 54.0, text_color),
+        row_cell(name, 300.0, text_color),
+    }
+    .padding(7.0)
+    .background(row_bg)
+}
+
+fn row_cell(text: String, width: f32, color: Color) -> impl View + Clone {
+    Text::new(text)
+        .font_size(12.0)
+        .color(color)
+        .frame_width(width)
+}
+
+fn start_sampler(snapshot: State<Snapshot>) {
+    thread::spawn(move || {
+        let mut previous_tasks = task_info();
+        let mut previous_cpu = cpu_usage();
+
+        loop {
+            let started_at = Instant::now();
+            thread::sleep(SAMPLE_INTERVAL);
+            let elapsed = started_at.elapsed();
+
+            let current_tasks = task_info();
+            let current_cpu = cpu_usage();
+            let sampled = collect_snapshot(
+                &previous_tasks,
+                &current_tasks,
+                previous_cpu,
+                current_cpu,
+                elapsed,
+            );
+            snapshot.set(sampled);
+
+            previous_tasks = current_tasks;
+            previous_cpu = current_cpu;
+        }
+    });
+}
+
+fn collect_snapshot(
+    previous_tasks: &[TaskInfo],
+    current_tasks: &[TaskInfo],
+    previous_cpu: Option<CpuUsageInfo>,
+    current_cpu: Option<CpuUsageInfo>,
+    elapsed: Duration,
+) -> Snapshot {
+    let (cpus, scheduler, cpuinfo_status) = read_cpuinfo();
+    let (busy_per_mille, idle_per_mille) = cpu_per_mille(previous_cpu, current_cpu);
+    let elapsed_ns = elapsed.as_nanos().max(1);
+
+    let mut rows = Vec::new();
+    let mut counts = TaskCounts::default();
+    for task in current_tasks {
+        if is_idle_task(task) {
+            continue;
+        }
+
+        counts.total += 1;
+        match task.state {
+            TaskState::Running | TaskState::Ready => counts.running += 1,
+            TaskState::BlockedInterruptible | TaskState::BlockedUninterruptible => {
+                counts.sleeping += 1;
+            }
+            TaskState::Terminated => counts.stopped += 1,
+            TaskState::Zombie => counts.zombie += 1,
+            TaskState::NotInitialized => {}
+        }
+        match task.task_type {
+            TaskType::Kernel => counts.kernel += 1,
+            TaskType::User => counts.user += 1,
+        }
+
+        let previous = previous_cpu_time(previous_tasks, task).unwrap_or(task.cpu_time_ns);
+        let delta = task.cpu_time_ns.saturating_sub(previous);
+        let cpu_per_mille = ((delta as u128 * 1000) / elapsed_ns) as u64;
+
+        rows.push(TaskRow {
+            pid: task.pid,
+            tgid: task.tgid,
+            cpu: task.cpu,
+            state: task.state,
+            task_type: task.task_type,
+            name: task.name.clone(),
+            cpu_time_ns: task.cpu_time_ns,
+            cpu_per_mille,
+            util_avg: task.sched_util_avg,
+        });
+    }
+
+    rows.sort_by(|a, b| {
+        b.cpu_per_mille
+            .cmp(&a.cpu_per_mille)
+            .then_with(|| b.util_avg.cmp(&a.util_avg))
+            .then_with(|| a.pid.cmp(&b.pid))
+    });
+
+    if rows.len() > MAX_VISIBLE_TASKS {
+        rows.truncate(MAX_VISIBLE_TASKS);
+    }
+
+    let status = cpuinfo_status.unwrap_or_else(|| {
+        format!(
+            "{} tasks, {} running, {} CPUs visible, {} cooldown skips",
+            counts.total,
+            counts.running,
+            cpus.len().min(MAX_VISIBLE_CPUS),
+            scheduler.cooldown_skips,
+        )
+    });
+
+    Snapshot {
+        counts,
+        busy_per_mille,
+        idle_per_mille,
+        cpus,
+        tasks: rows,
+        scheduler,
+        status,
+    }
+}
+
+fn task_info() -> Vec<TaskInfo> {
+    let total = syscall0(Syscall::GetTaskInfoCount);
+    let mut raw = vec![
+        RawTaskInfo {
+            pid: 0,
+            ppid: 0,
+            state: 0,
+            task_type: 0,
+            cpu_id: 0,
+            _reserved: 0,
+            exit_status: 0,
+            tgid: 0,
+            name: [0; 64],
+            cpu_time_ns: 0,
+            sched_util_avg: 0,
+        };
+        total
+    ];
+    let written = syscall2(
+        Syscall::GetTaskInfoList,
+        raw.as_mut_ptr() as usize,
+        raw.len(),
+    );
+    if written == usize::MAX {
+        return Vec::new();
+    }
+    raw.truncate(written.min(raw.len()));
+    raw.iter().map(RawTaskInfo::decode).collect()
+}
+
+fn cpu_usage() -> Option<CpuUsageInfo> {
+    let mut raw = RawCpuUsageInfo {
+        online_cpus: 0,
+        busy_time_ns: 0,
+        idle_time_ns: 0,
+        total_time_ns: 0,
+        usage_per_mille: 0,
+        _reserved: 0,
+    };
+    let result = syscall1(
+        Syscall::GetCpuUsageInfo,
+        &mut raw as *mut RawCpuUsageInfo as usize,
+    );
+    if result == usize::MAX {
+        None
+    } else {
+        Some(CpuUsageInfo {
+            busy_time_ns: raw.busy_time_ns,
+            idle_time_ns: raw.idle_time_ns,
+            usage_per_mille: raw.usage_per_mille,
+        })
+    }
+}
+
+fn previous_cpu_time(tasks: &[TaskInfo], task: &TaskInfo) -> Option<u64> {
+    tasks
+        .iter()
+        .find(|previous| {
+            previous.pid == task.pid && previous.tgid == task.tgid && previous.name == task.name
+        })
+        .map(|previous| previous.cpu_time_ns)
+}
+
+fn is_idle_task(task: &TaskInfo) -> bool {
+    task.task_type == TaskType::Kernel && task.name.starts_with("idle")
+}
+
+fn cpu_per_mille(before: Option<CpuUsageInfo>, after: Option<CpuUsageInfo>) -> (u64, u64) {
+    let Some(after) = after else {
+        return (0, 1000);
+    };
+    let Some(before) = before else {
+        let busy = after.usage_per_mille as u64;
+        return (busy, 1000u64.saturating_sub(busy));
+    };
+
+    let busy_delta = after.busy_time_ns.saturating_sub(before.busy_time_ns);
+    let idle_delta = after.idle_time_ns.saturating_sub(before.idle_time_ns);
+    let total_delta = busy_delta.saturating_add(idle_delta);
+    if total_delta == 0 {
+        let busy = after.usage_per_mille as u64;
+        return (busy, 1000u64.saturating_sub(busy));
+    }
+
+    let busy = ((busy_delta as u128 * 1000) / total_delta as u128) as u64;
+    (busy, 1000u64.saturating_sub(busy))
+}
+
+fn read_cpuinfo() -> (Vec<CpuRow>, SchedulerStats, Option<String>) {
+    let Ok(content) = fs::read_to_string("/dev/cpuinfo") else {
+        return (
+            Vec::new(),
+            SchedulerStats::default(),
+            Some(String::from("/dev/cpuinfo unavailable")),
+        );
+    };
+
+    let mut cpus = Vec::new();
+    let mut stats = SchedulerStats::default();
+    let mut current: Option<CpuRow> = None;
+
+    for line in content.lines() {
+        if let Some(value) = field(line, "scheduler migrations") {
+            stats.migrations = parse_u64(value);
+            continue;
+        }
+        if let Some(value) = field(line, "scheduler promotions") {
+            stats.promotions = parse_u64(value);
+            continue;
+        }
+        if let Some(value) = field(line, "scheduler demotions") {
+            stats.demotions = parse_u64(value);
+            continue;
+        }
+        if let Some(value) = field(line, "scheduler cooldown skips") {
+            stats.cooldown_skips = parse_u64(value);
+            continue;
+        }
+        if let Some(value) = field(line, "scheduler work steals") {
+            stats.work_steals = parse_u64(value);
+            continue;
+        }
+
+        if let Some(value) = field(line, "processor") {
+            if let Some(cpu) = current.take() {
+                cpus.push(cpu);
+            }
+            current = Some(CpuRow {
+                id: parse_usize(value),
+                ..CpuRow::default()
+            });
+            continue;
+        }
+
+        let Some(cpu) = current.as_mut() else {
+            continue;
+        };
+        if let Some(value) = field(line, "core class") {
+            cpu.class_name = value.to_string();
+        } else if let Some(value) = field(line, "cpu capacity") {
+            cpu.capacity = parse_u32(value);
+        } else if let Some(value) = field(line, "util avg") {
+            cpu.util_avg = parse_u32(value);
+        } else if let Some(value) = field(line, "util min") {
+            cpu.util_min = parse_u32(value);
+        } else if let Some(value) = field(line, "runnable") {
+            cpu.runnable = parse_u32(value);
+        } else if let Some(value) = field(line, "cur freq kHz") {
+            cpu.cur_freq_khz = parse_u32(value);
+        } else if let Some(value) = field(line, "target freq kHz") {
+            cpu.target_freq_khz = parse_u32(value);
+        } else if let Some(value) = field(line, "policy target kHz") {
+            cpu.target_freq_khz = parse_u32(value);
+        } else if let Some(value) = field(line, "max freq kHz") {
+            cpu.max_freq_khz = parse_u32(value);
+        }
+    }
+
+    if let Some(cpu) = current {
+        cpus.push(cpu);
+    }
+    cpus.sort_by(|a, b| a.id.cmp(&b.id));
+
+    (cpus, stats, None)
+}
+
+fn field<'a>(line: &'a str, expected: &str) -> Option<&'a str> {
+    let (key, value) = line.split_once(':')?;
+    if key.trim() == expected {
+        Some(value.trim())
+    } else {
+        None
+    }
+}
+
+fn parse_u32(value: &str) -> u32 {
+    value.parse::<u32>().unwrap_or(0)
+}
+
+fn parse_u64(value: &str) -> u64 {
+    value.parse::<u64>().unwrap_or(0)
+}
+
+fn parse_usize(value: &str) -> usize {
+    value.parse::<usize>().unwrap_or(0)
+}
+
+fn progress(value: u64, max: u64) -> f32 {
+    if max == 0 {
+        return 0.0;
+    }
+    ((value.min(max) as f32) / max as f32).clamp(0.0, 1.0)
+}
+
+fn format_stat(state: TaskState) -> &'static str {
+    match state {
+        TaskState::Running => "R",
+        TaskState::Ready => "R<",
+        TaskState::BlockedInterruptible => "S",
+        TaskState::BlockedUninterruptible => "D",
+        TaskState::Zombie => "Z",
+        TaskState::Terminated => "T",
+        TaskState::NotInitialized => "?",
+    }
+}
+
+fn format_type(task_type: TaskType) -> &'static str {
+    match task_type {
+        TaskType::Kernel => "K",
+        TaskType::User => "U",
+    }
+}
+
+fn format_percent(per_mille: u64) -> String {
+    format!("{}.{:01}", per_mille / 10, per_mille % 10)
+}
+
+fn format_time_ns(ns: u64) -> String {
+    let total_ms = ns / 1_000_000;
+    let ms = total_ms % 1000;
+    let total_secs = total_ms / 1000;
+    let secs = total_secs % 60;
+    let mins = (total_secs / 60) % 60;
+    let hours = total_secs / 3600;
+
+    if hours > 0 {
+        format!("{}:{:02}:{:02}", hours, mins, secs)
+    } else {
+        format!("{:02}:{:02}.{:03}", mins, secs, ms)
+    }
+}
+
+fn freq_text(cur: u32, target: u32, max: u32) -> String {
+    if max == 0 {
+        return String::from("freq n/a");
+    }
+    format!("{} -> {} MHz", cur / 1000, target / 1000)
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+
+    let mut output = String::new();
+    for ch in value.chars().take(max_chars.saturating_sub(1)) {
+        output.push(ch);
+    }
+    output.push_str("...");
+    output
+}
+
+fn bg() -> Color {
+    Color::rgb(244, 246, 248)
+}
+
+fn surface() -> Color {
+    Color::rgb(255, 255, 255)
+}
+
+fn row_alt() -> Color {
+    Color::rgb(249, 251, 253)
+}
+
+fn header_bg() -> Color {
+    Color::rgb(235, 239, 244)
+}
+
+fn text_primary() -> Color {
+    Color::rgb(28, 34, 42)
+}
+
+fn text_secondary() -> Color {
+    Color::rgb(96, 106, 118)
+}
+
+fn muted_text() -> Color {
+    Color::rgb(156, 164, 174)
+}
+
+fn main() {
+    println!("[task_manager] starting");
+    let mut app = TaskManagerApp::new();
+    if let Err(error) = app.run() {
+        println!("[task_manager] error: {}", error);
+    }
+}

--- a/user/std-bin/src/top.rs
+++ b/user/std-bin/src/top.rs
@@ -61,6 +61,11 @@ struct RawTaskInfo {
     name: [u8; 64],
     cpu_time_ns: u64,
     sched_util_avg: u32,
+    sched_util_min: u32,
+    sched_required_capacity: u32,
+    core_preference: u8,
+    _reserved2: [u8; 3],
+    sched_migration_count: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -73,6 +78,10 @@ struct TaskInfo {
     name: String,
     cpu_time_ns: u64,
     sched_util_avg: u32,
+    sched_util_min: u32,
+    sched_required_capacity: u32,
+    core_preference: u8,
+    sched_migration_count: u64,
 }
 
 impl RawTaskInfo {
@@ -95,6 +104,10 @@ impl RawTaskInfo {
             name,
             cpu_time_ns: self.cpu_time_ns,
             sched_util_avg: self.sched_util_avg,
+            sched_util_min: self.sched_util_min,
+            sched_required_capacity: self.sched_required_capacity,
+            core_preference: self.core_preference,
+            sched_migration_count: self.sched_migration_count,
         }
     }
 }
@@ -273,6 +286,11 @@ fn task_info() -> Vec<TaskInfo> {
             name: [0; 64],
             cpu_time_ns: 0,
             sched_util_avg: 0,
+            sched_util_min: 0,
+            sched_required_capacity: 0,
+            core_preference: 0,
+            _reserved2: [0; 3],
+            sched_migration_count: 0,
         };
         total
     ];
@@ -353,7 +371,7 @@ fn print_table(samples: &[TaskSample]) {
     }
 
     println!(
-        "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:>5} {:>4} {:>w_time$} {:<w_cmd$} {}",
+        "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:>5} {:>4} {:>4} {:>4} {:<4} {:>5} {:>w_time$} {:<w_cmd$} {}",
         "PID",
         "USER",
         "PR",
@@ -361,6 +379,10 @@ fn print_table(samples: &[TaskSample]) {
         "CPU",
         "%CPU",
         "UTIL",
+        "MIN",
+        "REQ",
+        "PREF",
+        "MIG",
         "TIME+",
         "COMMAND",
         "TGID",
@@ -377,7 +399,7 @@ fn print_table(samples: &[TaskSample]) {
             TaskType::User => "U",
         };
         println!(
-            "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:>5} {:>4} {:>w_time$} {:<w_cmd$} {}",
+            "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:>5} {:>4} {:>4} {:>4} {:<4} {:>5} {:>w_time$} {:<w_cmd$} {}",
             task.pid,
             user,
             "-",
@@ -385,6 +407,10 @@ fn print_table(samples: &[TaskSample]) {
             format!("CPU{}", task.cpu),
             format_percent_per_mille(sample.cpu_per_mille),
             task.sched_util_avg,
+            task.sched_util_min,
+            task.sched_required_capacity,
+            format_core_preference(task.core_preference),
+            task.sched_migration_count,
             format_time_ns(task.cpu_time_ns),
             task.name,
             task.tgid,
@@ -431,6 +457,14 @@ fn format_stat(state: TaskState) -> &'static str {
         TaskState::Zombie => "Z",
         TaskState::Terminated => "T",
         TaskState::NotInitialized => "?",
+    }
+}
+
+fn format_core_preference(preference: u8) -> &'static str {
+    match preference {
+        1 => "E",
+        2 => "P",
+        _ => "-",
     }
 }
 

--- a/user/std-bin/src/top.rs
+++ b/user/std-bin/src/top.rs
@@ -1,4 +1,6 @@
+use std::cmp::Ordering;
 use std::env;
+use std::fmt;
 use std::process::ExitCode;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -6,6 +8,7 @@ use std::time::{Duration, Instant};
 use scarlet_sys::{Syscall, syscall0, syscall1, syscall2};
 
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+const TASK_NAME_CAP: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TaskState {
@@ -75,7 +78,7 @@ struct TaskInfo {
     task_type: TaskType,
     cpu: u8,
     tgid: usize,
-    name: String,
+    name: TaskName,
     cpu_time_ns: u64,
     sched_util_avg: u32,
     sched_util_min: u32,
@@ -84,24 +87,60 @@ struct TaskInfo {
     sched_migration_count: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TaskName {
+    bytes: [u8; TASK_NAME_CAP],
+    len: usize,
+}
+
+impl TaskName {
+    fn from_raw(raw: &[u8; TASK_NAME_CAP]) -> Self {
+        let len = raw.iter().position(|&byte| byte == 0).unwrap_or(raw.len());
+        let mut bytes = [0; TASK_NAME_CAP];
+        bytes[..len].copy_from_slice(&raw[..len]);
+        Self { bytes, len }
+    }
+
+    fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.bytes[..self.len]).unwrap_or("<invalid>")
+    }
+
+    fn len(&self) -> usize {
+        self.as_str().len()
+    }
+
+    fn starts_with(&self, prefix: &str) -> bool {
+        self.as_str().starts_with(prefix)
+    }
+}
+
+impl Ord for TaskName {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialOrd for TaskName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for TaskName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl RawTaskInfo {
     fn decode(&self) -> TaskInfo {
-        let end = self
-            .name
-            .iter()
-            .position(|&byte| byte == 0)
-            .unwrap_or(self.name.len());
-        let name = std::str::from_utf8(&self.name[..end])
-            .unwrap_or("<invalid>")
-            .to_string();
-
         TaskInfo {
             pid: self.pid,
             state: TaskState::from_u8(self.state),
             task_type: TaskType::from_u8(self.task_type),
             cpu: self.cpu_id,
             tgid: self.tgid,
-            name,
+            name: TaskName::from_raw(&self.name),
             cpu_time_ns: self.cpu_time_ns,
             sched_util_avg: self.sched_util_avg,
             sched_util_min: self.sched_util_min,
@@ -225,8 +264,8 @@ fn main() -> ExitCode {
     println!("       {:>3} user,  {:>3} kernel", user_tasks, kernel_tasks);
     println!(
         "%Cpu(s): {:>5} busy, {:>5} idle",
-        format_percent_per_mille(busy_per_mille),
-        format_percent_per_mille(idle_per_mille),
+        Percent(busy_per_mille),
+        Percent(idle_per_mille),
     );
     println!();
 
@@ -364,10 +403,10 @@ fn print_table(samples: &[TaskSample]) {
 
     for sample in samples {
         let task = &sample.task;
-        max_pid = max_pid.max(task.pid.to_string().len());
+        max_pid = max_pid.max(decimal_digits_usize(task.pid));
         max_cmd = max_cmd.max(task.name.len());
-        max_cpu = max_cpu.max(format!("CPU{}", task.cpu).len());
-        max_time = max_time.max(format_time_ns(task.cpu_time_ns).len());
+        max_cpu = max_cpu.max(cpu_label_width(task.cpu));
+        max_time = max_time.max(time_width_ns(task.cpu_time_ns));
     }
 
     println!(
@@ -404,14 +443,14 @@ fn print_table(samples: &[TaskSample]) {
             user,
             "-",
             format_stat(task.state),
-            format!("CPU{}", task.cpu),
-            format_percent_per_mille(sample.cpu_per_mille),
+            CpuLabel(task.cpu),
+            Percent(sample.cpu_per_mille),
             task.sched_util_avg,
             task.sched_util_min,
             task.sched_required_capacity,
             format_core_preference(task.core_preference),
             task.sched_migration_count,
-            format_time_ns(task.cpu_time_ns),
+            TimeNs(task.cpu_time_ns),
             task.name,
             task.tgid,
             w_pid = max_pid,
@@ -491,11 +530,36 @@ fn is_idle_task(task: &TaskInfo) -> bool {
     task.task_type == TaskType::Kernel && task.name.starts_with("idle")
 }
 
-fn format_percent_per_mille(per_mille: u64) -> String {
-    format!("{}.{:01}", per_mille / 10, per_mille % 10)
+struct Percent(u64);
+
+impl fmt::Display for Percent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{:01}", self.0 / 10, self.0 % 10)
+    }
 }
 
-fn format_time_ns(ns: u64) -> String {
+struct CpuLabel(u8);
+
+impl fmt::Display for CpuLabel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CPU{}", self.0)
+    }
+}
+
+struct TimeNs(u64);
+
+impl fmt::Display for TimeNs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (hours, mins, secs, ms) = split_time_ns(self.0);
+        if hours > 0 {
+            write!(f, "{}:{:02}:{:02}.{:03}", hours, mins, secs, ms)
+        } else {
+            write!(f, "{:02}:{:02}.{:03}", mins, secs, ms)
+        }
+    }
+}
+
+fn split_time_ns(ns: u64) -> (u64, u64, u64, u64) {
     let total_ms = ns / 1_000_000;
     let ms = total_ms % 1000;
     let total_secs = total_ms / 1000;
@@ -503,9 +567,36 @@ fn format_time_ns(ns: u64) -> String {
     let mins = (total_secs / 60) % 60;
     let hours = total_secs / 3600;
 
+    (hours, mins, secs, ms)
+}
+
+fn time_width_ns(ns: u64) -> usize {
+    let (hours, _, _, _) = split_time_ns(ns);
     if hours > 0 {
-        format!("{}:{:02}:{:02}.{:03}", hours, mins, secs, ms)
+        decimal_digits_u64(hours) + 10
     } else {
-        format!("{:02}:{:02}.{:03}", mins, secs, ms)
+        9
     }
+}
+
+fn cpu_label_width(cpu: u8) -> usize {
+    3 + decimal_digits_usize(usize::from(cpu))
+}
+
+fn decimal_digits_usize(mut value: usize) -> usize {
+    let mut digits = 1;
+    while value >= 10 {
+        value /= 10;
+        digits += 1;
+    }
+    digits
+}
+
+fn decimal_digits_u64(mut value: u64) -> usize {
+    let mut digits = 1;
+    while value >= 10 {
+        value /= 10;
+        digits += 1;
+    }
+    digits
 }

--- a/user/std-bin/src/top.rs
+++ b/user/std-bin/src/top.rs
@@ -60,6 +60,7 @@ struct RawTaskInfo {
     tgid: usize,
     name: [u8; 64],
     cpu_time_ns: u64,
+    sched_util_avg: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -71,6 +72,7 @@ struct TaskInfo {
     tgid: usize,
     name: String,
     cpu_time_ns: u64,
+    sched_util_avg: u32,
 }
 
 impl RawTaskInfo {
@@ -92,6 +94,7 @@ impl RawTaskInfo {
             tgid: self.tgid,
             name,
             cpu_time_ns: self.cpu_time_ns,
+            sched_util_avg: self.sched_util_avg,
         }
     }
 }
@@ -269,6 +272,7 @@ fn task_info() -> Vec<TaskInfo> {
             tgid: 0,
             name: [0; 64],
             cpu_time_ns: 0,
+            sched_util_avg: 0,
         };
         total
     ];
@@ -349,13 +353,14 @@ fn print_table(samples: &[TaskSample]) {
     }
 
     println!(
-        "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:>5} {:>w_time$} {:<w_cmd$} {}",
+        "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:>5} {:>4} {:>w_time$} {:<w_cmd$} {}",
         "PID",
         "USER",
         "PR",
         "STAT",
         "CPU",
         "%CPU",
+        "UTIL",
         "TIME+",
         "COMMAND",
         "TGID",
@@ -372,13 +377,14 @@ fn print_table(samples: &[TaskSample]) {
             TaskType::User => "U",
         };
         println!(
-            "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:>5} {:>w_time$} {:<w_cmd$} {}",
+            "{:>w_pid$} {:<4} {:<2} {:<5} {:<w_cpu$} {:>5} {:>4} {:>w_time$} {:<w_cmd$} {}",
             task.pid,
             user,
             "-",
             format_stat(task.state),
             format!("CPU{}", task.cpu),
             format_percent_per_mille(sample.cpu_per_mille),
+            task.sched_util_avg,
             format_time_ns(task.cpu_time_ns),
             task.name,
             task.tgid,


### PR DESCRIPTION
## Summary

This PR expands scheduler placement and observability work across the kernel and user tools.

- Adds per-task utilization accounting, topology domain modeling, capacity-aware migration, idle work stealing, and deferred terminated-task reaping.
- Exposes task placement diagnostics and adds user-facing tools, including a desktop task manager, `top` updates, and a scheduler benchmark binary.
- Documents scheduler placement policy and benchmark scenarios.
- Includes related architecture/task fixes for TLS trapframe access, user exception termination via `exit_group`, AArch64 executable page cache sync, and tty-backed `putchar` routing.
- Restricts owner-backed VMA extension to owners that explicitly support growth, preventing anonymous mappings from expanding to invalid high fault addresses such as `0xfffffffffffffff8`.

## Impact

The branch should make scheduler behavior more topology-aware and easier to inspect from user space, while giving benchmark and desktop tooling a clearer view of task state. The architecture and syscall fixes support the scheduler/user-tool work by improving task termination behavior, instruction-cache coherency on AArch64, and console output routing.

The VMA extension fix preserves shared-memory resize behavior while keeping fixed-size anonymous mappings from treating out-of-range faults as valid growth.

## Validation

- `git diff --check`
- `cargo make fmt-check`
- `cargo test --target targets/riscv64gc-unknown-none-elf.json --no-run test_anonymous_owner_fault_past_vma_does_not_extend_mapping`
- `cargo test --target targets/aarch64-unknown-none-elf.json --no-run test_anonymous_owner_fault_past_vma_does_not_extend_mapping`

Note: running the RISC-V test without `--no-run` built successfully, then failed to launch QEMU because `kernel/.run/limine-riscv64-boot.img` is missing in this checkout.
