### PR TITLE
Feature/sgfx ir

### DIFF
--- a/bundles/desktop/bundle.toml
+++ b/bundles/desktop/bundle.toml
@@ -154,6 +154,12 @@ to = "/system/scarlet/bin/sgfx_texture"
 [[layers]]
 kind = "cargo"
 source = "../../user/std-bin"
+bin = "sgfx_showcase"
+to = "/system/scarlet/bin/sgfx_showcase"
+
+[[layers]]
+kind = "cargo"
+source = "../../user/std-bin"
 bin = "httpd"
 to = "/system/scarlet/bin/httpd"
 

--- a/projects/aarch64-limine-full/bsp/Cargo.lock
+++ b/projects/aarch64-limine-full/bsp/Cargo.lock
@@ -106,3 +106,39 @@ checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
 ]
+
+[[patch.unused]]
+name = "scarlet-abi"
+version = "0.16.0"
+
+[[patch.unused]]
+name = "scarlet-os"
+version = "0.16.0"
+
+[[patch.unused]]
+name = "scarlet-rt"
+version = "0.16.0"
+
+[[patch.unused]]
+name = "scarlet-std"
+version = "0.16.0"
+
+[[patch.unused]]
+name = "scarlet-sys"
+version = "0.16.0"
+
+[[patch.unused]]
+name = "sws-client"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "sws-protocol"
+version = "0.16.0"
+
+[[patch.unused]]
+name = "scarlet-ui"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "scarlet-ui-macros"
+version = "0.1.0"

--- a/projects/aarch64-limine-full/bsp/Cargo.lock
+++ b/projects/aarch64-limine-full/bsp/Cargo.lock
@@ -108,6 +108,14 @@ dependencies = [
 ]
 
 [[patch.unused]]
+name = "scarlet-ui"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "scarlet-ui-macros"
+version = "0.1.0"
+
+[[patch.unused]]
 name = "scarlet-abi"
 version = "0.16.0"
 
@@ -134,11 +142,3 @@ version = "0.1.0"
 [[patch.unused]]
 name = "sws-protocol"
 version = "0.16.0"
-
-[[patch.unused]]
-name = "scarlet-ui"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "scarlet-ui-macros"
-version = "0.1.0"

--- a/user/bin/Cargo.lock
+++ b/user/bin/Cargo.lock
@@ -280,7 +280,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "scarlet-ui-core",
  "scarlet-ui-platform-sws",
@@ -289,7 +288,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-core"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "ab_glyph",
  "bitflags",
@@ -303,7 +301,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-macros"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -313,7 +310,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-platform-sws"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "scarlet-std",
  "scarlet-ui-core",

--- a/user/lib/sgfx/src/driver.rs
+++ b/user/lib/sgfx/src/driver.rs
@@ -44,6 +44,31 @@ pub(crate) enum Context {
 }
 
 impl Context {
+    pub(crate) fn context_id(&self) -> i32 {
+        match self {
+            Self::Virgl(context) => context.context_id(),
+        }
+    }
+
+    pub(crate) fn create_ir_resources(&self) -> HandleResult<IrResources> {
+        match self {
+            Self::Virgl(context) => Ok(IrResources::Virgl(context.create_ir_resources()?)),
+        }
+    }
+
+    pub(crate) fn map_ir_image(
+        &self,
+        resources: &mut IrResources,
+        texture: IrTextureSpec,
+        image: &Image,
+    ) -> HandleResult<()> {
+        match (self, resources, image) {
+            (Self::Virgl(context), IrResources::Virgl(resources), Image::Virgl(image)) => {
+                context.map_ir_image(resources, texture, image)
+            }
+        }
+    }
+
     pub(crate) fn create_image(&self, width: u32, height: u32) -> HandleResult<Image> {
         match self {
             Self::Virgl(context) => Ok(Image::Virgl(context.create_image(width, height)?)),
@@ -143,6 +168,70 @@ pub(crate) enum Queue {
 }
 
 impl Queue {
+    pub(crate) fn context_id(&self) -> i32 {
+        match self {
+            Self::Virgl(queue) => queue.context_id(),
+        }
+    }
+
+    pub(crate) fn submit_ir(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        image: &Image,
+        submission: &IrSubmission,
+    ) -> HandleResult<()> {
+        match (self, context, resources, image) {
+            (
+                Self::Virgl(queue),
+                Context::Virgl(context),
+                IrResources::Virgl(resources),
+                Image::Virgl(image),
+            ) => queue.submit_ir(context, resources, image, submission),
+        }
+    }
+
+    pub(crate) fn submit_ir_internal(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        target: IrTextureSpec,
+        submission: &IrSubmission,
+    ) -> HandleResult<()> {
+        match (self, context, resources) {
+            (Self::Virgl(queue), Context::Virgl(context), IrResources::Virgl(resources)) => {
+                queue.submit_ir_internal(context, resources, target, submission)
+            }
+        }
+    }
+
+    pub(crate) fn upload_ir_texture(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        texture: IrTextureSpec,
+        upload: &IrTextureUpload,
+    ) -> HandleResult<()> {
+        match (self, context, resources) {
+            (Self::Virgl(queue), Context::Virgl(context), IrResources::Virgl(resources)) => {
+                queue.upload_ir_texture(context, resources, texture, upload)
+            }
+        }
+    }
+
+    pub(crate) fn copy_ir_texture(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        copy: IrTextureCopy,
+    ) -> HandleResult<()> {
+        match (self, context, resources) {
+            (Self::Virgl(queue), Context::Virgl(context), IrResources::Virgl(resources)) => {
+                queue.copy_ir_texture(context, resources, copy)
+            }
+        }
+    }
+
     pub(crate) fn submit(
         &self,
         image: &Image,
@@ -206,6 +295,196 @@ impl Queue {
 
 pub(crate) enum Image {
     Virgl(virgl::Image),
+}
+
+impl Image {
+    pub(crate) fn context_id(&self) -> i32 {
+        match self {
+            Self::Virgl(image) => image.context_id(),
+        }
+    }
+}
+
+/// Maximum canonical vertices accepted in one persistent IR submission.
+pub(crate) const MAX_IR_VERTICES: usize = 1_024;
+
+/// Canonical vertex representation shared by portable IR lowering and drivers.
+#[derive(Clone, Copy)]
+pub(crate) struct IrVertex {
+    pub(crate) position: [f32; 4],
+    pub(crate) color: [f32; 4],
+    pub(crate) uv: [f32; 2],
+}
+
+/// Backend-neutral rectangle used by the private IR execution plan.
+#[derive(Clone, Copy)]
+pub(crate) struct IrRect {
+    pub(crate) x: u32,
+    pub(crate) y: u32,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+}
+
+/// Portable fragment operation lowered by the IR executor.
+#[derive(Clone, Copy)]
+pub(crate) enum IrFragmentProgram {
+    Solid,
+    VertexColor,
+    TextureRgba,
+    TextureRgbIgnoreAlpha,
+    TextureAlphaMask,
+}
+
+/// Portable blend factor carried without backend protocol constants.
+#[derive(Clone, Copy)]
+pub(crate) enum IrBlendFactor {
+    Zero,
+    One,
+    SourceAlpha,
+    OneMinusSourceAlpha,
+    DestinationAlpha,
+    OneMinusDestinationAlpha,
+}
+
+/// Portable blend arithmetic operation carried without backend protocol constants.
+#[derive(Clone, Copy)]
+pub(crate) enum IrBlendOp {
+    Add,
+    Subtract,
+    ReverseSubtract,
+}
+
+/// Independent portable blend component.
+#[derive(Clone, Copy)]
+pub(crate) struct IrBlendComponent {
+    pub(crate) source_factor: IrBlendFactor,
+    pub(crate) destination_factor: IrBlendFactor,
+    pub(crate) operation: IrBlendOp,
+}
+
+/// Exact independent color and alpha blending state.
+#[derive(Clone, Copy)]
+pub(crate) struct IrBlendState {
+    pub(crate) color: IrBlendComponent,
+    pub(crate) alpha: IrBlendComponent,
+}
+
+/// Portable culling selection used by the IR executor.
+#[derive(Clone, Copy)]
+pub(crate) enum IrCullMode {
+    None,
+    Front,
+    Back,
+}
+
+/// Portable front-face selection used by the IR executor.
+#[derive(Clone, Copy)]
+pub(crate) enum IrFrontFace {
+    Clockwise,
+    CounterClockwise,
+}
+
+/// Persistent pipeline slot and its immutable portable state.
+#[derive(Clone, Copy)]
+pub(crate) struct IrPipelineState {
+    pub(crate) slot: usize,
+    pub(crate) fragment: IrFragmentProgram,
+    pub(crate) blend: IrBlendState,
+    pub(crate) cull_mode: IrCullMode,
+    pub(crate) front_face: IrFrontFace,
+}
+
+/// Portable sampler filtering mode.
+#[derive(Clone, Copy)]
+pub(crate) enum IrFilterMode {
+    Nearest,
+    Linear,
+}
+
+/// Portable sampler coordinate addressing mode.
+#[derive(Clone, Copy)]
+pub(crate) enum IrAddressMode {
+    ClampToEdge,
+    Repeat,
+    MirrorRepeat,
+}
+
+/// Persistent sampler slot and its immutable portable state.
+#[derive(Clone, Copy)]
+pub(crate) struct IrSamplerState {
+    pub(crate) slot: usize,
+    pub(crate) min_filter: IrFilterMode,
+    pub(crate) mag_filter: IrFilterMode,
+    pub(crate) address_u: IrAddressMode,
+    pub(crate) address_v: IrAddressMode,
+}
+
+/// Draw-uniform constants sent to the GPU without CPU vertex transformation.
+#[derive(Clone, Copy)]
+pub(crate) struct IrUniforms {
+    pub(crate) transform: [f32; 16],
+    pub(crate) color: [f32; 4],
+}
+
+/// One private non-indexed draw in an ordered IR submission.
+pub(crate) struct IrDraw {
+    pub(crate) start_vertex: usize,
+    pub(crate) vertex_count: usize,
+    pub(crate) pipeline: IrPipelineState,
+    pub(crate) texture: Option<IrTextureSpec>,
+    pub(crate) sampler: Option<IrSamplerState>,
+    pub(crate) uniforms: IrUniforms,
+    pub(crate) scissor: IrRect,
+}
+
+/// Converted BGRA texture upload retained until all stream validation succeeds.
+pub(crate) struct IrTextureUpload {
+    pub(crate) texture: IrTextureSpec,
+    pub(crate) destination: IrRect,
+    pub(crate) pixels: Vec<u8>,
+}
+
+/// Logical texture materialization requirements without backend identifiers.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IrTextureSpec {
+    pub(crate) slot: usize,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) sampled: bool,
+    pub(crate) render_attachment: bool,
+    pub(crate) copy_destination: bool,
+    pub(crate) present: bool,
+    pub(crate) format: IrTextureFormat,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IrTextureFormat {
+    Bgra8,
+    Rgba8,
+    R8,
+}
+
+/// One validated texture copy request without backend identifiers.
+#[derive(Clone, Copy)]
+pub(crate) struct IrTextureCopy {
+    pub(crate) source: IrTextureSpec,
+    pub(crate) source_rect: IrRect,
+    pub(crate) destination: IrTextureSpec,
+    pub(crate) destination_rect: IrRect,
+}
+
+/// Complete backend-neutral render submission for one mapped presentation target.
+pub(crate) struct IrSubmission {
+    pub(crate) clear_color: Option<[f32; 4]>,
+    pub(crate) render_area: IrRect,
+    pub(crate) vertices: Vec<IrVertex>,
+    pub(crate) draws: Vec<IrDraw>,
+    pub(crate) texture_uploads: Vec<IrTextureUpload>,
+}
+
+/// Private persistent materialization cache owned by the creating context.
+pub(crate) enum IrResources {
+    Virgl(virgl::IrResources),
 }
 
 pub(crate) enum Texture {

--- a/user/lib/sgfx/src/ir/command.rs
+++ b/user/lib/sgfx/src/ir/command.rs
@@ -1,0 +1,753 @@
+//! Validated logical upload, copy, and render commands.
+
+use alloc::vec::Vec;
+
+use super::{
+    BufferRef, BufferUsage, Color, DrawUniforms, Error, FragmentProgram, IndexFormat, PixelRect,
+    RenderPipelineRef, ResourceTable, Result, SamplerRef, TextureRef, TextureUsage, TextureWrite,
+};
+
+/// Maximum commands retained by one logical command buffer.
+pub const MAX_COMMANDS: usize = 4_096;
+
+/// Color attachment initialization operation for a render pass.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LoadOp {
+    /// Preserve the attachment contents in the render area.
+    Load,
+    /// Clear the render area to a finite color before drawing.
+    Clear(Color),
+    /// Permit a backend to discard prior attachment contents.
+    DontCare,
+}
+
+/// Color attachment finalization operation for a render pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreOp {
+    /// Preserve attachment contents after the pass.
+    Store,
+    /// Permit a backend to discard attachment contents after the pass.
+    DontCare,
+}
+
+/// Validated configuration for one logical color render pass.
+#[derive(Clone, Copy)]
+pub struct RenderPassDesc<'r> {
+    pub(crate) target: TextureRef<'r>,
+    pub(crate) area: PixelRect,
+    pub(crate) load: LoadOp,
+    pub(crate) store: StoreOp,
+}
+
+impl<'r> RenderPassDesc<'r> {
+    /// Construct a validated color render-pass descriptor.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Table that owns `target`.
+    /// * `target` - `RENDER_ATTACHMENT` texture.
+    /// * `area` - Non-empty render area inside `target`.
+    /// * `load` - Attachment initialization operation.
+    /// * `store` - Attachment finalization operation.
+    ///
+    /// # Returns
+    /// A validated pass descriptor, or an error for table mismatch, usage, or bounds.
+    pub fn new(
+        resources: &'r ResourceTable,
+        target: TextureRef<'r>,
+        area: PixelRect,
+        load: LoadOp,
+        store: StoreOp,
+    ) -> Result<Self> {
+        let texture = resources.texture(target)?;
+        if !texture.usage().contains(TextureUsage::RENDER_ATTACHMENT) {
+            return Err(Error::InvalidUsage);
+        }
+        if !area.is_within(texture.extent()) {
+            return Err(Error::OutOfBounds);
+        }
+        Ok(Self {
+            target,
+            area,
+            load,
+            store,
+        })
+    }
+
+    /// Return the color attachment reference.
+    ///
+    /// # Returns
+    /// The lifetime-branded target texture reference.
+    pub const fn target(self) -> TextureRef<'r> {
+        self.target
+    }
+
+    /// Return the render area.
+    ///
+    /// # Returns
+    /// The validated non-empty target rectangle.
+    pub const fn area(self) -> PixelRect {
+        self.area
+    }
+
+    /// Return the attachment initialization operation.
+    ///
+    /// # Returns
+    /// The configured load operation.
+    pub const fn load(self) -> LoadOp {
+        self.load
+    }
+
+    /// Return the attachment finalization operation.
+    ///
+    /// # Returns
+    /// The configured store operation.
+    pub const fn store(self) -> StoreOp {
+        self.store
+    }
+}
+
+/// One validated logical graphics command.
+///
+/// Commands are exposed only through [`CommandBuffer::commands`]. Resource
+/// references remain lifetime-branded and cannot be constructed from raw IDs.
+pub enum Command<'r, 'data> {
+    /// Upload borrowed bytes into a logical buffer.
+    WriteBuffer {
+        /// Destination buffer reference.
+        buffer: BufferRef<'r>,
+        /// Destination byte offset.
+        offset: u64,
+        /// Borrowed source bytes.
+        data: &'data [u8],
+    },
+    /// Upload borrowed pixel data into a logical texture.
+    WriteTexture {
+        /// Destination texture reference.
+        texture: TextureRef<'r>,
+        /// Validated pixel source layout and destination rectangle.
+        write: TextureWrite<'data>,
+    },
+    /// Copy an equal-sized rectangle between compatible logical textures.
+    CopyTextureToTexture {
+        /// Source texture reference.
+        source: TextureRef<'r>,
+        /// Source rectangle.
+        source_rect: PixelRect,
+        /// Destination texture reference.
+        destination: TextureRef<'r>,
+        /// Destination rectangle.
+        destination_rect: PixelRect,
+    },
+    /// Begin a render pass with explicit attachment operations.
+    BeginRenderPass(RenderPassDesc<'r>),
+    /// End the current render pass.
+    EndRenderPass,
+    /// Bind a render pipeline for subsequent draws.
+    SetPipeline(RenderPipelineRef<'r>),
+    /// Bind a vertex buffer for subsequent draws.
+    SetVertexBuffer {
+        /// Vertex buffer reference.
+        buffer: BufferRef<'r>,
+        /// Byte offset of vertex zero.
+        offset: u64,
+    },
+    /// Bind an index buffer for subsequent indexed draws.
+    SetIndexBuffer {
+        /// Index buffer reference.
+        buffer: BufferRef<'r>,
+        /// Byte offset of index zero.
+        offset: u64,
+        /// Width of each encoded index.
+        format: IndexFormat,
+    },
+    /// Bind a sampled texture for subsequent draws.
+    SetTexture(TextureRef<'r>),
+    /// Bind a sampler for subsequent draws.
+    SetSampler(SamplerRef<'r>),
+    /// Bind transform and color uniforms for subsequent draws.
+    SetUniforms(DrawUniforms),
+    /// Set or reset the scissor for subsequent draws.
+    SetScissor(Option<PixelRect>),
+    /// Issue a non-indexed draw.
+    Draw {
+        /// Number of vertices to draw.
+        vertex_count: u32,
+        /// First vertex relative to the bound vertex buffer.
+        first_vertex: u32,
+    },
+    /// Issue an indexed draw.
+    DrawIndexed {
+        /// Number of indices to draw.
+        index_count: u32,
+        /// First index relative to the bound index buffer.
+        first_index: u32,
+        /// Signed base vertex applied by a backend.
+        base_vertex: i32,
+    },
+}
+
+/// Encoder that records validated logical graphics commands.
+pub struct CommandEncoder<'r, 'data> {
+    resources: &'r ResourceTable,
+    commands: Vec<Command<'r, 'data>>,
+    pass_open: bool,
+}
+
+impl<'r, 'data> CommandEncoder<'r, 'data> {
+    /// Start an empty command encoder for one resource table.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Table whose branded references may be recorded.
+    ///
+    /// # Returns
+    /// An empty encoder with the fixed [`MAX_COMMANDS`] bound.
+    pub const fn new(resources: &'r ResourceTable) -> Self {
+        Self {
+            resources,
+            commands: Vec::new(),
+            pass_open: false,
+        }
+    }
+
+    /// Record a buffer upload outside a render pass.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - `COPY_DST` buffer in this encoder's table.
+    /// * `offset` - Destination byte offset.
+    /// * `data` - Non-empty borrowed source bytes.
+    ///
+    /// # Returns
+    /// Success, or an error for table mismatch, usage, range, pass state, or capacity.
+    pub fn write_buffer(
+        &mut self,
+        buffer: BufferRef<'r>,
+        offset: u64,
+        data: &'data [u8],
+    ) -> Result<()> {
+        self.ensure_outside_pass()?;
+        let desc = self.resources.buffer(buffer)?;
+        Self::require_buffer_usage(desc.usage(), BufferUsage::COPY_DST)?;
+        if data.is_empty() {
+            return Err(Error::InvalidValue);
+        }
+        Self::validate_byte_range(
+            offset,
+            u64::try_from(data.len()).map_err(|_| Error::Overflow)?,
+            desc.size(),
+        )?;
+        self.push(Command::WriteBuffer {
+            buffer,
+            offset,
+            data,
+        })
+    }
+
+    /// Record a texture upload outside a render pass.
+    ///
+    /// # Arguments
+    ///
+    /// * `texture` - `COPY_DST` texture in this encoder's table.
+    /// * `write` - Borrowed pixel data and destination layout.
+    ///
+    /// # Returns
+    /// Success, or an error for table mismatch, usage, bounds, source layout, pass state, or capacity.
+    pub fn write_texture(
+        &mut self,
+        texture: TextureRef<'r>,
+        write: TextureWrite<'data>,
+    ) -> Result<()> {
+        self.ensure_outside_pass()?;
+        let desc = self.resources.texture(texture)?;
+        Self::require_texture_usage(desc.usage(), TextureUsage::COPY_DST)?;
+        if !write.destination().is_within(desc.extent()) {
+            return Err(Error::OutOfBounds);
+        }
+        let tight = write
+            .destination()
+            .width()
+            .checked_mul(desc.format().bytes_per_pixel())
+            .ok_or(Error::Overflow)?;
+        if write.bytes_per_row() < tight {
+            return Err(Error::InvalidValue);
+        }
+        let rows_before_last = u64::from(write.destination().height() - 1);
+        let required = u64::from(write.bytes_per_row())
+            .checked_mul(rows_before_last)
+            .and_then(|value| value.checked_add(u64::from(tight)))
+            .ok_or(Error::Overflow)?;
+        if u64::try_from(write.data().len()).map_err(|_| Error::Overflow)? < required {
+            return Err(Error::OutOfBounds);
+        }
+        self.push(Command::WriteTexture { texture, write })
+    }
+
+    /// Record a format-preserving texture-to-texture copy outside a render pass.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - `COPY_SRC` source texture.
+    /// * `source_rect` - Source rectangle.
+    /// * `destination` - `COPY_DST` destination texture.
+    /// * `destination_rect` - Equal-sized destination rectangle.
+    ///
+    /// # Returns
+    /// Success, or an error for mismatched tables, usage, format, bounds, overlapping self-copy, pass state, or capacity.
+    pub fn copy_texture_to_texture(
+        &mut self,
+        source: TextureRef<'r>,
+        source_rect: PixelRect,
+        destination: TextureRef<'r>,
+        destination_rect: PixelRect,
+    ) -> Result<()> {
+        self.ensure_outside_pass()?;
+        let source_desc = self.resources.texture(source)?;
+        let destination_desc = self.resources.texture(destination)?;
+        Self::require_texture_usage(source_desc.usage(), TextureUsage::COPY_SRC)?;
+        Self::require_texture_usage(destination_desc.usage(), TextureUsage::COPY_DST)?;
+        if source_desc.format() != destination_desc.format()
+            || !source_rect.same_extent(destination_rect)
+        {
+            return Err(Error::InvalidDescriptor);
+        }
+        if !source_rect.is_within(source_desc.extent())
+            || !destination_rect.is_within(destination_desc.extent())
+        {
+            return Err(Error::OutOfBounds);
+        }
+        if self.resources.same_texture(source, destination)?
+            && Self::rectangles_overlap(source_rect, destination_rect)
+        {
+            return Err(Error::InvalidValue);
+        }
+        self.push(Command::CopyTextureToTexture {
+            source,
+            source_rect,
+            destination,
+            destination_rect,
+        })
+    }
+
+    /// Begin a render pass described by explicit load and store operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `desc` - Validated pass descriptor from this encoder's resource table.
+    ///
+    /// # Returns
+    /// A pass encoder, or an error for usage, bounds, nested-pass state, or capacity.
+    pub fn begin_render_pass<'encoder>(
+        &'encoder mut self,
+        desc: RenderPassDesc<'r>,
+    ) -> Result<RenderPassEncoder<'encoder, 'r, 'data>> {
+        self.ensure_outside_pass()?;
+        let target_desc = self.resources.texture(desc.target)?;
+        Self::require_texture_usage(target_desc.usage(), TextureUsage::RENDER_ATTACHMENT)?;
+        if !desc.area.is_within(target_desc.extent()) {
+            return Err(Error::OutOfBounds);
+        }
+        self.reserve_pass_begin()?;
+        self.push(Command::BeginRenderPass(desc))?;
+        self.pass_open = true;
+        Ok(RenderPassEncoder {
+            encoder: self,
+            target: desc.target,
+            target_format: target_desc.format(),
+            area: desc.area,
+            pipeline: None,
+            vertex_buffer: None,
+            index_buffer: None,
+            texture: None,
+            sampler: None,
+            uniforms: None,
+        })
+    }
+
+    /// Finish this encoder into an immutable logical command buffer.
+    ///
+    /// # Returns
+    /// The finished command buffer, or [`Error::RenderPassStillActive`] when a pass was not ended.
+    pub fn finish(self) -> Result<CommandBuffer<'r, 'data>> {
+        if self.pass_open {
+            Err(Error::RenderPassStillActive)
+        } else {
+            Ok(CommandBuffer {
+                resources: self.resources,
+                commands: self.commands,
+            })
+        }
+    }
+
+    fn ensure_outside_pass(&self) -> Result<()> {
+        if self.pass_open {
+            Err(Error::RenderPassActive)
+        } else {
+            Ok(())
+        }
+    }
+    fn push(&mut self, command: Command<'r, 'data>) -> Result<()> {
+        let reserved_end_slot = usize::from(self.pass_open);
+        if self.commands.len() >= MAX_COMMANDS - reserved_end_slot {
+            return Err(Error::CommandLimitExceeded);
+        }
+        self.commands
+            .try_reserve(1)
+            .map_err(|_| Error::OutOfMemory)?;
+        self.commands.push(command);
+        Ok(())
+    }
+    fn reserve_pass_begin(&self) -> Result<()> {
+        if self.commands.len() > MAX_COMMANDS - 2 {
+            Err(Error::CommandLimitExceeded)
+        } else {
+            Ok(())
+        }
+    }
+    fn push_end_render_pass(&mut self) -> Result<()> {
+        if self.commands.len() >= MAX_COMMANDS {
+            return Err(Error::CommandLimitExceeded);
+        }
+        self.commands
+            .try_reserve(1)
+            .map_err(|_| Error::OutOfMemory)?;
+        self.commands.push(Command::EndRenderPass);
+        Ok(())
+    }
+    fn require_texture_usage(usage: TextureUsage, required: TextureUsage) -> Result<()> {
+        if usage.contains(required) {
+            Ok(())
+        } else {
+            Err(Error::InvalidUsage)
+        }
+    }
+    fn require_buffer_usage(usage: BufferUsage, required: BufferUsage) -> Result<()> {
+        if usage.contains(required) {
+            Ok(())
+        } else {
+            Err(Error::InvalidUsage)
+        }
+    }
+    fn validate_byte_range(offset: u64, length: u64, limit: u64) -> Result<()> {
+        match offset.checked_add(length) {
+            Some(end) if end <= limit => Ok(()),
+            Some(_) => Err(Error::OutOfBounds),
+            None => Err(Error::Overflow),
+        }
+    }
+    fn rectangles_overlap(left: PixelRect, right: PixelRect) -> bool {
+        left.x() < right.x() + right.width()
+            && right.x() < left.x() + left.width()
+            && left.y() < right.y() + right.height()
+            && right.y() < left.y() + left.height()
+    }
+}
+
+/// Encoder for commands within one active render pass.
+pub struct RenderPassEncoder<'encoder, 'r, 'data> {
+    encoder: &'encoder mut CommandEncoder<'r, 'data>,
+    target: TextureRef<'r>,
+    target_format: super::TextureFormat,
+    area: PixelRect,
+    pipeline: Option<RenderPipelineRef<'r>>,
+    vertex_buffer: Option<(BufferRef<'r>, u64)>,
+    index_buffer: Option<(BufferRef<'r>, u64, IndexFormat)>,
+    texture: Option<TextureRef<'r>>,
+    sampler: Option<SamplerRef<'r>>,
+    uniforms: Option<DrawUniforms>,
+}
+
+impl<'encoder, 'r, 'data> RenderPassEncoder<'encoder, 'r, 'data> {
+    /// Set the render pipeline for subsequent draws.
+    ///
+    /// # Arguments
+    ///
+    /// * `pipeline` - Pipeline from this encoder's resource table.
+    ///
+    /// # Returns
+    /// Success, or an error when the table or target format differs.
+    pub fn set_pipeline(&mut self, pipeline: RenderPipelineRef<'r>) -> Result<()> {
+        let target_format = self
+            .encoder
+            .resources
+            .with_pipeline(pipeline, |descriptor| descriptor.target_format())?;
+        if target_format != self.target_format {
+            return Err(Error::PipelineTargetMismatch);
+        }
+        self.encoder.push(Command::SetPipeline(pipeline))?;
+        self.pipeline = Some(pipeline);
+        Ok(())
+    }
+
+    /// Set the vertex buffer and first vertex byte offset.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - `VERTEX` buffer from this encoder's resource table.
+    /// * `offset` - Byte offset of vertex zero.
+    ///
+    /// # Returns
+    /// Success, or an error for table mismatch, usage, range, or capacity.
+    pub fn set_vertex_buffer(&mut self, buffer: BufferRef<'r>, offset: u64) -> Result<()> {
+        let desc = self.encoder.resources.buffer(buffer)?;
+        CommandEncoder::require_buffer_usage(desc.usage(), BufferUsage::VERTEX)?;
+        if offset > desc.size() {
+            return Err(Error::OutOfBounds);
+        }
+        self.encoder
+            .push(Command::SetVertexBuffer { buffer, offset })?;
+        self.vertex_buffer = Some((buffer, offset));
+        Ok(())
+    }
+
+    /// Set the index buffer, byte offset, and encoded index format.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - `INDEX` buffer from this encoder's resource table.
+    /// * `offset` - Aligned byte offset of index zero.
+    /// * `format` - Width of each encoded index.
+    ///
+    /// # Returns
+    /// Success, or an error for table mismatch, usage, alignment, range, or capacity.
+    pub fn set_index_buffer(
+        &mut self,
+        buffer: BufferRef<'r>,
+        offset: u64,
+        format: IndexFormat,
+    ) -> Result<()> {
+        let desc = self.encoder.resources.buffer(buffer)?;
+        CommandEncoder::require_buffer_usage(desc.usage(), BufferUsage::INDEX)?;
+        if offset > desc.size() {
+            return Err(Error::OutOfBounds);
+        }
+        if offset % format.byte_size() != 0 {
+            return Err(Error::InvalidValue);
+        }
+        self.encoder.push(Command::SetIndexBuffer {
+            buffer,
+            offset,
+            format,
+        })?;
+        self.index_buffer = Some((buffer, offset, format));
+        Ok(())
+    }
+
+    /// Set the sampled texture for a textured pipeline.
+    ///
+    /// # Arguments
+    ///
+    /// * `texture` - `SAMPLED` texture from this encoder's resource table.
+    ///
+    /// # Returns
+    /// Success, or an error for usage, table mismatch, attachment feedback, or capacity.
+    pub fn set_texture(&mut self, texture: TextureRef<'r>) -> Result<()> {
+        let desc = self.encoder.resources.texture(texture)?;
+        CommandEncoder::require_texture_usage(desc.usage(), TextureUsage::SAMPLED)?;
+        if self.encoder.resources.same_texture(texture, self.target)? {
+            return Err(Error::AttachmentFeedback);
+        }
+        self.encoder.push(Command::SetTexture(texture))?;
+        self.texture = Some(texture);
+        Ok(())
+    }
+
+    /// Set the sampler for a textured pipeline.
+    ///
+    /// # Arguments
+    ///
+    /// * `sampler` - Sampler from this encoder's resource table.
+    ///
+    /// # Returns
+    /// Success, or an error for table mismatch or capacity.
+    pub fn set_sampler(&mut self, sampler: SamplerRef<'r>) -> Result<()> {
+        self.encoder.resources.sampler(sampler)?;
+        self.encoder.push(Command::SetSampler(sampler))?;
+        self.sampler = Some(sampler);
+        Ok(())
+    }
+
+    /// Set finite transform and color uniforms for subsequent draws.
+    ///
+    /// # Arguments
+    ///
+    /// * `uniforms` - General transform and finite color values.
+    ///
+    /// # Returns
+    /// Success, or an allocation/capacity error.
+    pub fn set_uniforms(&mut self, uniforms: DrawUniforms) -> Result<()> {
+        self.encoder.push(Command::SetUniforms(uniforms))?;
+        self.uniforms = Some(uniforms);
+        Ok(())
+    }
+
+    /// Set or disable the scissor for subsequent draws.
+    ///
+    /// # Arguments
+    ///
+    /// * `scissor` - A rectangle wholly inside the pass area, or `None` to reset clipping to the pass render area.
+    ///
+    /// # Returns
+    /// Success, or [`Error::OutOfBounds`] for a scissor outside the render area. `None` never permits drawing outside that area.
+    pub fn set_scissor(&mut self, scissor: Option<PixelRect>) -> Result<()> {
+        if let Some(scissor) = scissor {
+            if scissor.x() < self.area.x()
+                || scissor.y() < self.area.y()
+                || scissor.x() + scissor.width() > self.area.x() + self.area.width()
+                || scissor.y() + scissor.height() > self.area.y() + self.area.height()
+            {
+                return Err(Error::OutOfBounds);
+            }
+        }
+        self.encoder.push(Command::SetScissor(scissor))
+    }
+
+    /// Record a non-indexed triangle-list draw.
+    ///
+    /// # Arguments
+    ///
+    /// * `vertex_count` - Positive multiple of three vertices.
+    /// * `first_vertex` - First vertex relative to the bound vertex buffer.
+    ///
+    /// # Returns
+    /// Success, or an error for missing state, vertex range, texture bindings, or capacity.
+    pub fn draw(&mut self, vertex_count: u32, first_vertex: u32) -> Result<()> {
+        self.validate_draw(vertex_count)?;
+        let pipeline = self.pipeline.ok_or(Error::PipelineNotSet)?;
+        let stride = self
+            .encoder
+            .resources
+            .with_pipeline(pipeline, |descriptor| descriptor.vertex_buffer().stride())?;
+        let (buffer, offset) = self.vertex_buffer.ok_or(Error::VertexBufferNotSet)?;
+        let desc = self.encoder.resources.buffer(buffer)?;
+        if offset % u64::from(stride) != 0 {
+            return Err(Error::InvalidValue);
+        }
+        let vertices = u64::from(first_vertex)
+            .checked_add(u64::from(vertex_count))
+            .ok_or(Error::Overflow)?;
+        let bytes = vertices
+            .checked_mul(u64::from(stride))
+            .ok_or(Error::Overflow)?;
+        CommandEncoder::validate_byte_range(offset, bytes, desc.size())?;
+        self.encoder.push(Command::Draw {
+            vertex_count,
+            first_vertex,
+        })
+    }
+
+    /// Record an indexed triangle-list draw.
+    ///
+    /// # Arguments
+    ///
+    /// * `index_count` - Positive multiple of three indices.
+    /// * `first_index` - First index relative to the bound index buffer.
+    /// * `base_vertex` - Signed base vertex added by a future backend.
+    ///
+    /// # Returns
+    /// Success, or an error for missing pipeline, vertex/index buffers, index range, bindings, or capacity. A future backend validates the maximum vertex addressed by opaque index data.
+    pub fn draw_indexed(
+        &mut self,
+        index_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+    ) -> Result<()> {
+        self.validate_draw(index_count)?;
+        let pipeline = self.pipeline.ok_or(Error::PipelineNotSet)?;
+        let stride = self
+            .encoder
+            .resources
+            .with_pipeline(pipeline, |descriptor| descriptor.vertex_buffer().stride())?;
+        let (vertex_buffer, vertex_offset) = self.vertex_buffer.ok_or(Error::VertexBufferNotSet)?;
+        let vertex_desc = self.encoder.resources.buffer(vertex_buffer)?;
+        if vertex_offset % u64::from(stride) != 0 {
+            return Err(Error::InvalidValue);
+        }
+        CommandEncoder::validate_byte_range(vertex_offset, u64::from(stride), vertex_desc.size())?;
+        let (buffer, offset, format) = self.index_buffer.ok_or(Error::IndexBufferNotSet)?;
+        let desc = self.encoder.resources.buffer(buffer)?;
+        let indices = u64::from(first_index)
+            .checked_add(u64::from(index_count))
+            .ok_or(Error::Overflow)?;
+        let bytes = indices
+            .checked_mul(format.byte_size())
+            .ok_or(Error::Overflow)?;
+        CommandEncoder::validate_byte_range(offset, bytes, desc.size())?;
+        self.encoder.push(Command::DrawIndexed {
+            index_count,
+            first_index,
+            base_vertex,
+        })
+    }
+
+    /// End this render pass.
+    ///
+    /// # Returns
+    /// Success, or an allocation/capacity error while recording the end command.
+    pub fn end(self) -> Result<()> {
+        self.encoder.push_end_render_pass()?;
+        self.encoder.pass_open = false;
+        Ok(())
+    }
+
+    fn validate_draw(&self, count: u32) -> Result<()> {
+        if count == 0 || count % 3 != 0 {
+            return Err(Error::InvalidValue);
+        }
+        let pipeline = self.pipeline.ok_or(Error::PipelineNotSet)?;
+        let fragment = self
+            .encoder
+            .resources
+            .with_pipeline(pipeline, |descriptor| descriptor.fragment())?;
+        self.uniforms.ok_or(Error::UniformsNotSet)?;
+        if matches!(fragment, FragmentProgram::Texture(_))
+            && (self.texture.is_none() || self.sampler.is_none())
+        {
+            return Err(Error::TextureBindingNotSet);
+        }
+        Ok(())
+    }
+}
+
+/// Finished, immutable logical command buffer with separate resource and data lifetimes.
+pub struct CommandBuffer<'r, 'data> {
+    pub(crate) resources: &'r ResourceTable,
+    pub(crate) commands: Vec<Command<'r, 'data>>,
+}
+
+impl<'r, 'data> CommandBuffer<'r, 'data> {
+    /// Return the resource table that owns this buffer's references.
+    ///
+    /// # Returns
+    ///
+    /// The lifetime-branded resource table retained at finish time.
+    pub const fn resources(&self) -> &'r ResourceTable {
+        self.resources
+    }
+
+    /// Return the immutable ordered command stream.
+    ///
+    /// # Returns
+    ///
+    /// The validated command slice. Its resource references cannot be forged
+    /// because their owner and index fields are not public.
+    pub fn commands(&self) -> &[Command<'r, 'data>] {
+        &self.commands
+    }
+
+    /// Return the number of recorded commands.
+    ///
+    /// # Returns
+    /// The immutable command count without exposing resource identities.
+    pub const fn command_count(&self) -> usize {
+        self.commands.len()
+    }
+    /// Return whether no commands were recorded.
+    ///
+    /// # Returns
+    /// `true` when the command buffer is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+}

--- a/user/lib/sgfx/src/ir/mod.rs
+++ b/user/lib/sgfx/src/ir/mod.rs
@@ -1,0 +1,27 @@
+//! Validated, backend-neutral logical graphics intermediate representation.
+//!
+//! Resources are descriptors held by [`ResourceTable`]. Commands recorded by
+//! [`CommandEncoder`] borrow both that table and upload data, so a future
+//! backend can lower the finished [`CommandBuffer`] without accepting forged
+//! resource identities.
+
+pub(crate) mod command;
+mod pipeline;
+pub(crate) mod resource;
+mod types;
+
+pub use command::{
+    Command, CommandBuffer, CommandEncoder, LoadOp, MAX_COMMANDS, RenderPassDesc,
+    RenderPassEncoder, StoreOp,
+};
+pub use pipeline::{
+    BlendComponent, BlendFactor, BlendOp, BlendState, CullMode, DrawUniforms, FragmentProgram,
+    FrontFace, IndexFormat, MAX_VERTEX_ATTRIBUTES, PrimitiveTopology, RasterState,
+    RenderPipelineDesc, TextureSampleMode, VertexAttribute, VertexBufferLayout, VertexFormat,
+};
+pub use resource::{
+    AddressMode, BufferDesc, BufferRef, BufferUsage, FilterMode, MAX_BUFFERS, MAX_RENDER_PIPELINES,
+    MAX_SAMPLERS, MAX_TEXTURES, RenderPipelineRef, ResourceTable, SamplerDesc, SamplerRef,
+    TextureDesc, TextureFormat, TextureRef, TextureUsage, TextureWrite,
+};
+pub use types::{Color, Error, Extent2D, PixelRect, Result, Transform};

--- a/user/lib/sgfx/src/ir/pipeline.rs
+++ b/user/lib/sgfx/src/ir/pipeline.rs
@@ -1,0 +1,544 @@
+//! Portable render-pipeline descriptors and draw state.
+
+use alloc::vec::Vec;
+
+use super::{Color, Error, Result, TextureFormat, Transform};
+
+/// Maximum attributes accepted by one portable vertex-buffer layout.
+pub const MAX_VERTEX_ATTRIBUTES: usize = 16;
+
+/// Format of one vertex attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexFormat {
+    /// Two 32-bit floating-point components.
+    Float32x2,
+    /// Three 32-bit floating-point components.
+    Float32x3,
+    /// Four 32-bit floating-point components.
+    Float32x4,
+    /// Four normalized unsigned 8-bit components.
+    Unorm8x4,
+}
+
+impl VertexFormat {
+    /// Return the byte size of one attribute value.
+    ///
+    /// # Returns
+    ///
+    /// The packed format size in bytes.
+    pub const fn byte_size(self) -> u32 {
+        match self {
+            Self::Float32x2 => 8,
+            Self::Float32x3 => 12,
+            Self::Float32x4 => 16,
+            Self::Unorm8x4 => 4,
+        }
+    }
+}
+
+/// One attribute within an interleaved vertex buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VertexAttribute {
+    location: u32,
+    format: VertexFormat,
+    offset: u32,
+}
+
+impl VertexAttribute {
+    /// Construct a vertex attribute.
+    ///
+    /// # Arguments
+    ///
+    /// * `location` - Shader-visible attribute location.
+    /// * `format` - Packed attribute format.
+    /// * `offset` - Byte offset within one vertex.
+    ///
+    /// # Returns
+    /// The attribute; layout construction validates its range.
+    pub const fn new(location: u32, format: VertexFormat, offset: u32) -> Self {
+        Self {
+            location,
+            format,
+            offset,
+        }
+    }
+    /// Return the shader-visible location.
+    ///
+    /// # Returns
+    /// The location number.
+    pub const fn location(self) -> u32 {
+        self.location
+    }
+    /// Return the packed format.
+    ///
+    /// # Returns
+    /// The attribute format.
+    pub const fn format(self) -> VertexFormat {
+        self.format
+    }
+    /// Return the byte offset within each vertex.
+    ///
+    /// # Returns
+    /// The byte offset.
+    pub const fn offset(self) -> u32 {
+        self.offset
+    }
+}
+
+/// Owned validated description of one interleaved vertex buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VertexBufferLayout {
+    stride: u32,
+    attributes: Vec<VertexAttribute>,
+}
+
+impl VertexBufferLayout {
+    /// Construct a validated interleaved vertex-buffer layout.
+    ///
+    /// # Arguments
+    ///
+    /// * `stride` - Non-zero bytes between consecutive vertices.
+    /// * `attributes` - Owned attributes contained in every vertex.
+    ///
+    /// # Returns
+    /// The layout, or [`Error::InvalidDescriptor`] for empty or over-limit
+    /// attributes, duplicate locations, overflowing offsets, or attributes
+    /// beyond `stride`.
+    pub fn new(stride: u32, attributes: Vec<VertexAttribute>) -> Result<Self> {
+        if stride == 0 || attributes.is_empty() || attributes.len() > MAX_VERTEX_ATTRIBUTES {
+            return Err(Error::InvalidDescriptor);
+        }
+        for (index, attribute) in attributes.iter().enumerate() {
+            if attribute
+                .offset
+                .checked_add(attribute.format.byte_size())
+                .is_none_or(|end| end > stride)
+                || attributes[..index]
+                    .iter()
+                    .any(|other| other.location == attribute.location)
+            {
+                return Err(Error::InvalidDescriptor);
+            }
+        }
+        Ok(Self { stride, attributes })
+    }
+
+    /// Return the interleaved byte stride.
+    ///
+    /// # Returns
+    /// The non-zero stride.
+    pub const fn stride(&self) -> u32 {
+        self.stride
+    }
+    /// Return the owned-layout attributes.
+    ///
+    /// # Returns
+    /// Attributes in their declared order.
+    pub fn attributes(&self) -> &[VertexAttribute] {
+        &self.attributes
+    }
+}
+
+/// Primitive assembly topology.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrimitiveTopology {
+    /// Assemble independent triangles.
+    TriangleList,
+}
+
+/// Format of indices in an index buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexFormat {
+    /// Unsigned 16-bit indices.
+    Uint16,
+    /// Unsigned 32-bit indices.
+    Uint32,
+}
+
+impl IndexFormat {
+    /// Return the byte size of one index.
+    ///
+    /// # Returns
+    /// The encoded index size in bytes.
+    pub const fn byte_size(self) -> u64 {
+        match self {
+            Self::Uint16 => 2,
+            Self::Uint32 => 4,
+        }
+    }
+}
+
+/// Portable fragment operation supported by the logical IR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FragmentProgram {
+    /// Emit the draw uniform color.
+    Solid,
+    /// Emit interpolated vertex color modulated by the draw uniform color.
+    VertexColor,
+    /// Sample one texture using the specified alpha interpretation.
+    Texture(TextureSampleMode),
+}
+
+/// Alpha interpretation for a sampled texture fragment program.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextureSampleMode {
+    /// Use sampled red, green, blue, and alpha components.
+    Rgba,
+    /// Use sampled RGB and treat alpha as one.
+    RgbIgnoreAlpha,
+    /// Use sampled alpha as a coverage mask for uniform color.
+    AlphaMask,
+}
+
+/// Per-draw uniforms shared by the portable fragment programs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DrawUniforms {
+    transform: Transform,
+    color: Color,
+}
+
+impl DrawUniforms {
+    /// Construct per-draw transform and color uniforms.
+    ///
+    /// # Arguments
+    ///
+    /// * `transform` - Finite general 4×4 transform.
+    /// * `color` - Finite color multiplier.
+    ///
+    /// # Returns
+    /// The requested uniforms.
+    pub const fn new(transform: Transform, color: Color) -> Self {
+        Self { transform, color }
+    }
+    /// Return the transform.
+    ///
+    /// # Returns
+    /// The general draw transform.
+    pub const fn transform(self) -> Transform {
+        self.transform
+    }
+    /// Return the color multiplier.
+    ///
+    /// # Returns
+    /// The finite draw color.
+    pub const fn color(self) -> Color {
+        self.color
+    }
+}
+
+/// Source or destination factor in a blend component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendFactor {
+    /// Factor zero.
+    Zero,
+    /// Factor one.
+    One,
+    /// Source alpha factor.
+    SourceAlpha,
+    /// One minus source alpha factor.
+    OneMinusSourceAlpha,
+    /// Destination alpha factor.
+    DestinationAlpha,
+    /// One minus destination alpha factor.
+    OneMinusDestinationAlpha,
+}
+
+/// Arithmetic operation for a blend component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendOp {
+    /// Add source and destination terms.
+    Add,
+    /// Subtract destination from source.
+    Subtract,
+    /// Subtract source from destination.
+    ReverseSubtract,
+}
+
+/// Blend factors and operation for color or alpha.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlendComponent {
+    source_factor: BlendFactor,
+    destination_factor: BlendFactor,
+    operation: BlendOp,
+}
+
+impl BlendComponent {
+    /// Construct one blend component.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_factor` - Multiplier for source output.
+    /// * `destination_factor` - Multiplier for destination output.
+    /// * `operation` - Arithmetic operation.
+    ///
+    /// # Returns
+    /// The requested blend component.
+    pub const fn new(
+        source_factor: BlendFactor,
+        destination_factor: BlendFactor,
+        operation: BlendOp,
+    ) -> Self {
+        Self {
+            source_factor,
+            destination_factor,
+            operation,
+        }
+    }
+    /// Return the source multiplier.
+    ///
+    /// # Returns
+    /// The configured source factor.
+    pub const fn source_factor(self) -> BlendFactor {
+        self.source_factor
+    }
+    /// Return the destination multiplier.
+    ///
+    /// # Returns
+    /// The configured destination factor.
+    pub const fn destination_factor(self) -> BlendFactor {
+        self.destination_factor
+    }
+    /// Return the blend arithmetic operation.
+    ///
+    /// # Returns
+    /// The configured operation.
+    pub const fn operation(self) -> BlendOp {
+        self.operation
+    }
+}
+
+/// Complete independent color and alpha blend configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlendState {
+    color: BlendComponent,
+    alpha: BlendComponent,
+}
+
+impl BlendState {
+    /// Replace destination color and alpha with source output.
+    pub const REPLACE: Self = Self {
+        color: BlendComponent::new(BlendFactor::One, BlendFactor::Zero, BlendOp::Add),
+        alpha: BlendComponent::new(BlendFactor::One, BlendFactor::Zero, BlendOp::Add),
+    };
+    /// Source-over blending for straight-alpha source RGB.
+    pub const SOURCE_OVER_STRAIGHT_ALPHA: Self = Self {
+        color: BlendComponent::new(
+            BlendFactor::SourceAlpha,
+            BlendFactor::OneMinusSourceAlpha,
+            BlendOp::Add,
+        ),
+        alpha: BlendComponent::new(
+            BlendFactor::One,
+            BlendFactor::OneMinusSourceAlpha,
+            BlendOp::Add,
+        ),
+    };
+    /// Destination-in masking by source alpha.
+    pub const DESTINATION_IN: Self = Self {
+        color: BlendComponent::new(BlendFactor::Zero, BlendFactor::SourceAlpha, BlendOp::Add),
+        alpha: BlendComponent::new(BlendFactor::Zero, BlendFactor::SourceAlpha, BlendOp::Add),
+    };
+
+    /// Construct a blend state from independent color and alpha components.
+    ///
+    /// # Arguments
+    ///
+    /// * `color` - RGB blend component.
+    /// * `alpha` - Alpha blend component.
+    ///
+    /// # Returns
+    /// The requested blend state.
+    pub const fn new(color: BlendComponent, alpha: BlendComponent) -> Self {
+        Self { color, alpha }
+    }
+    /// Return the RGB blend component.
+    ///
+    /// # Returns
+    /// The color component.
+    pub const fn color(self) -> BlendComponent {
+        self.color
+    }
+    /// Return the alpha blend component.
+    ///
+    /// # Returns
+    /// The alpha component.
+    pub const fn alpha(self) -> BlendComponent {
+        self.alpha
+    }
+}
+
+/// Triangle faces discarded by rasterization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CullMode {
+    /// Rasterize both faces.
+    None,
+    /// Discard front-facing triangles.
+    Front,
+    /// Discard back-facing triangles.
+    Back,
+}
+
+/// Winding direction treated as front-facing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontFace {
+    /// Clockwise winding is front-facing.
+    Clockwise,
+    /// Counter-clockwise winding is front-facing.
+    CounterClockwise,
+}
+
+/// Rasterization state for one render pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RasterState {
+    cull_mode: CullMode,
+    front_face: FrontFace,
+}
+
+impl RasterState {
+    /// Construct rasterization state.
+    ///
+    /// # Arguments
+    ///
+    /// * `cull_mode` - Faces to discard.
+    /// * `front_face` - Winding treated as front-facing.
+    ///
+    /// # Returns
+    /// The requested raster state.
+    pub const fn new(cull_mode: CullMode, front_face: FrontFace) -> Self {
+        Self {
+            cull_mode,
+            front_face,
+        }
+    }
+    /// Return the face-culling mode.
+    ///
+    /// # Returns
+    /// The configured culling mode.
+    pub const fn cull_mode(self) -> CullMode {
+        self.cull_mode
+    }
+    /// Return the front-face winding.
+    ///
+    /// # Returns
+    /// The configured front-face winding.
+    pub const fn front_face(self) -> FrontFace {
+        self.front_face
+    }
+}
+
+/// Owned portable descriptor for a render pipeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderPipelineDesc {
+    target_format: TextureFormat,
+    topology: PrimitiveTopology,
+    vertex_buffer: VertexBufferLayout,
+    fragment: FragmentProgram,
+    blend: BlendState,
+    raster: RasterState,
+}
+
+impl RenderPipelineDesc {
+    /// Construct an owned render-pipeline descriptor.
+    ///
+    /// # Arguments
+    ///
+    /// * `target_format` - Required color attachment format.
+    /// * `topology` - Primitive topology.
+    /// * `vertex_buffer` - Owned interleaved vertex layout.
+    /// * `fragment` - Portable fragment program.
+    /// * `blend` - Color and alpha blend state.
+    /// * `raster` - Face and winding state.
+    ///
+    /// # Returns
+    /// The requested owned descriptor, or [`Error::InvalidDescriptor`] when
+    /// portable vertex conventions are absent. Location `0` is position and
+    /// must use `Float32x2`, `Float32x3`, or `Float32x4`. `VertexColor`
+    /// requires location `1` as `Float32x3`, `Float32x4`, or `Unorm8x4`; `Texture` requires
+    /// location `1` as `Float32x2` texture coordinates.
+    pub fn new(
+        target_format: TextureFormat,
+        topology: PrimitiveTopology,
+        vertex_buffer: VertexBufferLayout,
+        fragment: FragmentProgram,
+        blend: BlendState,
+        raster: RasterState,
+    ) -> Result<Self> {
+        let position = vertex_buffer
+            .attributes()
+            .iter()
+            .find(|attribute| attribute.location() == 0)
+            .map(|attribute| attribute.format());
+        if !matches!(
+            position,
+            Some(VertexFormat::Float32x2 | VertexFormat::Float32x3 | VertexFormat::Float32x4)
+        ) {
+            return Err(Error::InvalidDescriptor);
+        }
+        let location_one = vertex_buffer
+            .attributes()
+            .iter()
+            .find(|attribute| attribute.location() == 1)
+            .map(|attribute| attribute.format());
+        let fragment_attributes_are_valid = match fragment {
+            FragmentProgram::Solid => true,
+            FragmentProgram::VertexColor => matches!(
+                location_one,
+                Some(VertexFormat::Float32x3 | VertexFormat::Float32x4 | VertexFormat::Unorm8x4)
+            ),
+            FragmentProgram::Texture(_) => matches!(location_one, Some(VertexFormat::Float32x2)),
+        };
+        if !fragment_attributes_are_valid {
+            return Err(Error::InvalidDescriptor);
+        }
+        Ok(Self {
+            target_format,
+            topology,
+            vertex_buffer,
+            fragment,
+            blend,
+            raster,
+        })
+    }
+    /// Return the required color attachment format.
+    ///
+    /// # Returns
+    /// The target texture format.
+    pub const fn target_format(&self) -> TextureFormat {
+        self.target_format
+    }
+    /// Return primitive assembly topology.
+    ///
+    /// # Returns
+    /// The configured topology.
+    pub const fn topology(&self) -> PrimitiveTopology {
+        self.topology
+    }
+    /// Return the vertex-buffer layout.
+    ///
+    /// # Returns
+    /// The owned layout by shared reference.
+    pub const fn vertex_buffer(&self) -> &VertexBufferLayout {
+        &self.vertex_buffer
+    }
+    /// Return the fragment program.
+    ///
+    /// # Returns
+    /// The portable fragment operation.
+    pub const fn fragment(&self) -> FragmentProgram {
+        self.fragment
+    }
+    /// Return blend state.
+    ///
+    /// # Returns
+    /// The configured blend state.
+    pub const fn blend(&self) -> BlendState {
+        self.blend
+    }
+    /// Return rasterization state.
+    ///
+    /// # Returns
+    /// The configured raster state.
+    pub const fn raster(&self) -> RasterState {
+        self.raster
+    }
+}

--- a/user/lib/sgfx/src/ir/resource.rs
+++ b/user/lib/sgfx/src/ir/resource.rs
@@ -1,0 +1,589 @@
+//! Logical resource descriptors, validated resource tables, and branded references.
+
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::fmt;
+use core::ops::{BitOr, BitOrAssign};
+
+use super::pipeline::RenderPipelineDesc;
+use super::{Error, Extent2D, PixelRect, Result};
+
+/// Maximum textures held by one [`ResourceTable`].
+pub const MAX_TEXTURES: usize = 1_024;
+/// Maximum buffers held by one [`ResourceTable`].
+pub const MAX_BUFFERS: usize = 1_024;
+/// Maximum samplers held by one [`ResourceTable`].
+pub const MAX_SAMPLERS: usize = 256;
+/// Maximum render pipelines held by one [`ResourceTable`].
+pub const MAX_RENDER_PIPELINES: usize = 256;
+
+/// Portable texture pixel format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextureFormat {
+    /// Eight-bit blue, green, red, and alpha channels.
+    Bgra8Unorm,
+    /// Eight-bit red, green, blue, and alpha channels.
+    Rgba8Unorm,
+    /// One eight-bit normalized red channel.
+    R8Unorm,
+}
+
+impl TextureFormat {
+    /// Return the number of bytes per tightly packed pixel.
+    ///
+    /// # Returns
+    ///
+    /// The portable byte size for this format.
+    pub const fn bytes_per_pixel(self) -> u32 {
+        match self {
+            Self::Bgra8Unorm | Self::Rgba8Unorm => 4,
+            Self::R8Unorm => 1,
+        }
+    }
+}
+
+/// Bitflag-like allowed operations for a texture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextureUsage(u8);
+
+impl TextureUsage {
+    /// Allow shader sampling.
+    pub const SAMPLED: Self = Self(1 << 0);
+    /// Allow use as a render-pass color attachment.
+    pub const RENDER_ATTACHMENT: Self = Self(1 << 1);
+    /// Allow use as a texture copy source.
+    pub const COPY_SRC: Self = Self(1 << 2);
+    /// Allow use as a texture upload or copy destination.
+    pub const COPY_DST: Self = Self(1 << 3);
+    /// Allow eventual presentation by a backend.
+    pub const PRESENT: Self = Self(1 << 4);
+
+    /// Return no usage flags.
+    ///
+    /// # Returns
+    ///
+    /// An empty usage set.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Return whether all flags in `other` are present.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - Flags to test.
+    ///
+    /// # Returns
+    ///
+    /// `true` when every requested flag is set.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Combine this usage set with another.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - Flags to add.
+    ///
+    /// # Returns
+    ///
+    /// The union of both usage sets.
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+
+impl BitOr for TextureUsage {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        self.union(rhs)
+    }
+}
+impl BitOrAssign for TextureUsage {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = self.union(rhs);
+    }
+}
+
+/// Validated descriptor for a logical texture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextureDesc {
+    format: TextureFormat,
+    extent: Extent2D,
+    usage: TextureUsage,
+}
+
+impl TextureDesc {
+    /// Construct a texture descriptor.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - Pixel format.
+    /// * `extent` - Non-zero texture dimensions.
+    /// * `usage` - Allowed texture operations.
+    ///
+    /// # Returns
+    ///
+    /// A descriptor, or [`Error::InvalidDescriptor`] for empty usage.
+    pub const fn new(format: TextureFormat, extent: Extent2D, usage: TextureUsage) -> Result<Self> {
+        if usage.0 == 0 {
+            Err(Error::InvalidDescriptor)
+        } else {
+            Ok(Self {
+                format,
+                extent,
+                usage,
+            })
+        }
+    }
+
+    /// Return the pixel format.
+    ///
+    /// # Returns
+    /// The texture format.
+    pub const fn format(self) -> TextureFormat {
+        self.format
+    }
+    /// Return the dimensions.
+    ///
+    /// # Returns
+    /// The non-zero texture extent.
+    pub const fn extent(self) -> Extent2D {
+        self.extent
+    }
+    /// Return allowed operations.
+    ///
+    /// # Returns
+    /// The texture usage flags.
+    pub const fn usage(self) -> TextureUsage {
+        self.usage
+    }
+}
+
+/// Bitflag-like allowed operations for a buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BufferUsage(u8);
+
+impl BufferUsage {
+    /// Allow use as a vertex buffer.
+    pub const VERTEX: Self = Self(1 << 0);
+    /// Allow use as an index buffer.
+    pub const INDEX: Self = Self(1 << 1);
+    /// Allow use as a copy source.
+    pub const COPY_SRC: Self = Self(1 << 2);
+    /// Allow writes through upload commands.
+    pub const COPY_DST: Self = Self(1 << 3);
+    /// Return no usage flags.
+    ///
+    /// # Returns
+    /// An empty usage set.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+    /// Return whether all flags in `other` are present.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - Flags to test.
+    ///
+    /// # Returns
+    /// `true` when every requested flag is set.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+    /// Combine this usage set with another.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - Flags to add.
+    ///
+    /// # Returns
+    /// The union of both usage sets.
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+
+impl BitOr for BufferUsage {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        self.union(rhs)
+    }
+}
+impl BitOrAssign for BufferUsage {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = self.union(rhs);
+    }
+}
+
+/// Validated descriptor for a logical buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BufferDesc {
+    size: u64,
+    usage: BufferUsage,
+}
+
+impl BufferDesc {
+    /// Construct a buffer descriptor.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Non-zero size in bytes.
+    /// * `usage` - Allowed buffer operations.
+    ///
+    /// # Returns
+    /// A descriptor, or [`Error::InvalidDescriptor`] for empty size or usage.
+    pub const fn new(size: u64, usage: BufferUsage) -> Result<Self> {
+        if size == 0 || usage.0 == 0 {
+            Err(Error::InvalidDescriptor)
+        } else {
+            Ok(Self { size, usage })
+        }
+    }
+    /// Return the size in bytes.
+    ///
+    /// # Returns
+    /// The non-zero buffer size.
+    pub const fn size(self) -> u64 {
+        self.size
+    }
+    /// Return allowed operations.
+    ///
+    /// # Returns
+    /// The buffer usage flags.
+    pub const fn usage(self) -> BufferUsage {
+        self.usage
+    }
+}
+
+/// Texture filtering mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilterMode {
+    /// Select the nearest texel.
+    Nearest,
+    /// Linearly filter neighboring texels.
+    Linear,
+}
+
+/// Texture coordinate addressing mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddressMode {
+    /// Clamp coordinates to the edge texel.
+    ClampToEdge,
+    /// Repeat the texture.
+    Repeat,
+    /// Repeat while mirroring every other copy.
+    MirrorRepeat,
+}
+
+/// Portable logical sampler descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SamplerDesc {
+    min_filter: FilterMode,
+    mag_filter: FilterMode,
+    address_u: AddressMode,
+    address_v: AddressMode,
+}
+
+impl SamplerDesc {
+    /// Construct a sampler descriptor.
+    ///
+    /// # Arguments
+    ///
+    /// * `min_filter` - Minification filter.
+    /// * `mag_filter` - Magnification filter.
+    /// * `address_u` - Horizontal addressing.
+    /// * `address_v` - Vertical addressing.
+    ///
+    /// # Returns
+    /// A portable sampler descriptor.
+    pub const fn new(
+        min_filter: FilterMode,
+        mag_filter: FilterMode,
+        address_u: AddressMode,
+        address_v: AddressMode,
+    ) -> Self {
+        Self {
+            min_filter,
+            mag_filter,
+            address_u,
+            address_v,
+        }
+    }
+    /// Return the minification filter.
+    ///
+    /// # Returns
+    /// The configured filter.
+    pub const fn min_filter(self) -> FilterMode {
+        self.min_filter
+    }
+    /// Return the magnification filter.
+    ///
+    /// # Returns
+    /// The configured filter.
+    pub const fn mag_filter(self) -> FilterMode {
+        self.mag_filter
+    }
+    /// Return horizontal addressing.
+    ///
+    /// # Returns
+    /// The configured U-coordinate mode.
+    pub const fn address_u(self) -> AddressMode {
+        self.address_u
+    }
+    /// Return vertical addressing.
+    ///
+    /// # Returns
+    /// The configured V-coordinate mode.
+    pub const fn address_v(self) -> AddressMode {
+        self.address_v
+    }
+}
+
+/// Borrowed pixel data and layout for one texture upload.
+#[derive(Debug, Clone, Copy)]
+pub struct TextureWrite<'data> {
+    destination: PixelRect,
+    bytes_per_row: u32,
+    data: &'data [u8],
+}
+
+impl<'data> TextureWrite<'data> {
+    /// Construct a texture upload description.
+    ///
+    /// # Arguments
+    ///
+    /// * `destination` - Non-empty destination rectangle.
+    /// * `bytes_per_row` - Source byte stride, validated against the texture format when recorded.
+    /// * `data` - Borrowed source bytes.
+    ///
+    /// # Returns
+    /// The upload description, or [`Error::InvalidValue`] for a zero stride.
+    pub const fn new(
+        destination: PixelRect,
+        bytes_per_row: u32,
+        data: &'data [u8],
+    ) -> Result<Self> {
+        if bytes_per_row == 0 {
+            Err(Error::InvalidValue)
+        } else {
+            Ok(Self {
+                destination,
+                bytes_per_row,
+                data,
+            })
+        }
+    }
+    /// Return the destination rectangle.
+    ///
+    /// # Returns
+    /// The upload destination.
+    pub const fn destination(self) -> PixelRect {
+        self.destination
+    }
+    /// Return the source row stride.
+    ///
+    /// # Returns
+    /// Bytes between source row starts.
+    pub const fn bytes_per_row(self) -> u32 {
+        self.bytes_per_row
+    }
+    /// Return the borrowed source bytes.
+    ///
+    /// # Returns
+    /// The source byte slice.
+    pub const fn data(self) -> &'data [u8] {
+        self.data
+    }
+}
+
+/// Table that owns validated logical resource descriptors.
+pub struct ResourceTable {
+    textures: RefCell<Vec<TextureDesc>>,
+    buffers: RefCell<Vec<BufferDesc>>,
+    samplers: RefCell<Vec<SamplerDesc>>,
+    pipelines: RefCell<Vec<RenderPipelineDesc>>,
+}
+
+impl ResourceTable {
+    /// Construct an empty resource table.
+    ///
+    /// # Returns
+    /// An empty table with bounded resource categories.
+    pub const fn new() -> Self {
+        Self {
+            textures: RefCell::new(Vec::new()),
+            buffers: RefCell::new(Vec::new()),
+            samplers: RefCell::new(Vec::new()),
+            pipelines: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Define a texture descriptor and return its table-branded reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `desc` - Validated texture descriptor.
+    ///
+    /// # Returns
+    /// A texture reference, or a bounded-allocation error.
+    pub fn define_texture(&self, desc: TextureDesc) -> Result<TextureRef<'_>> {
+        let index = Self::push(&self.textures, desc, MAX_TEXTURES)?;
+        Ok(TextureRef { owner: self, index })
+    }
+    /// Define a buffer descriptor and return its table-branded reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `desc` - Validated buffer descriptor.
+    ///
+    /// # Returns
+    /// A buffer reference, or a bounded-allocation error.
+    pub fn define_buffer(&self, desc: BufferDesc) -> Result<BufferRef<'_>> {
+        let index = Self::push(&self.buffers, desc, MAX_BUFFERS)?;
+        Ok(BufferRef { owner: self, index })
+    }
+    /// Define a sampler descriptor and return its table-branded reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `desc` - Sampler descriptor.
+    ///
+    /// # Returns
+    /// A sampler reference, or a bounded-allocation error.
+    pub fn define_sampler(&self, desc: SamplerDesc) -> Result<SamplerRef<'_>> {
+        let index = Self::push(&self.samplers, desc, MAX_SAMPLERS)?;
+        Ok(SamplerRef { owner: self, index })
+    }
+    /// Define a render-pipeline descriptor and return its table-branded reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `desc` - Validated owned pipeline descriptor.
+    ///
+    /// # Returns
+    /// A pipeline reference, or a bounded-allocation error.
+    pub fn define_render_pipeline(
+        &self,
+        desc: RenderPipelineDesc,
+    ) -> Result<RenderPipelineRef<'_>> {
+        let index = Self::push(&self.pipelines, desc, MAX_RENDER_PIPELINES)?;
+        Ok(RenderPipelineRef { owner: self, index })
+    }
+
+    fn push<T>(items: &RefCell<Vec<T>>, value: T, maximum: usize) -> Result<usize> {
+        let mut items = items.borrow_mut();
+        if items.len() >= maximum {
+            return Err(Error::ResourceLimitExceeded);
+        }
+        items.try_reserve(1).map_err(|_| Error::OutOfMemory)?;
+        let index = items.len();
+        items.push(value);
+        Ok(index)
+    }
+    pub(crate) fn texture(&self, reference: TextureRef<'_>) -> Result<TextureDesc> {
+        if !core::ptr::eq(reference.owner, self) {
+            return Err(Error::ResourceTableMismatch);
+        }
+        self.textures
+            .borrow()
+            .get(reference.index)
+            .copied()
+            .ok_or(Error::InvalidDescriptor)
+    }
+    pub(crate) fn buffer(&self, reference: BufferRef<'_>) -> Result<BufferDesc> {
+        if !core::ptr::eq(reference.owner, self) {
+            return Err(Error::ResourceTableMismatch);
+        }
+        self.buffers
+            .borrow()
+            .get(reference.index)
+            .copied()
+            .ok_or(Error::InvalidDescriptor)
+    }
+    pub(crate) fn sampler(&self, reference: SamplerRef<'_>) -> Result<SamplerDesc> {
+        if !core::ptr::eq(reference.owner, self) {
+            return Err(Error::ResourceTableMismatch);
+        }
+        self.samplers
+            .borrow()
+            .get(reference.index)
+            .copied()
+            .ok_or(Error::InvalidDescriptor)
+    }
+    /// Borrow a validated pipeline descriptor without cloning its owned layout.
+    pub(crate) fn with_pipeline<T>(
+        &self,
+        reference: RenderPipelineRef<'_>,
+        access: impl FnOnce(&RenderPipelineDesc) -> T,
+    ) -> Result<T> {
+        if !core::ptr::eq(reference.owner, self) {
+            return Err(Error::ResourceTableMismatch);
+        }
+        let pipelines = self.pipelines.borrow();
+        let descriptor = pipelines
+            .get(reference.index)
+            .ok_or(Error::InvalidDescriptor)?;
+        Ok(access(descriptor))
+    }
+    pub(crate) fn same_texture(&self, left: TextureRef<'_>, right: TextureRef<'_>) -> Result<bool> {
+        self.texture(left)?;
+        self.texture(right)?;
+        Ok(left.index == right.index)
+    }
+}
+
+impl Default for ResourceTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Reference to a texture retained by one [`ResourceTable`].
+#[derive(Clone, Copy)]
+pub struct TextureRef<'r> {
+    pub(crate) owner: &'r ResourceTable,
+    pub(crate) index: usize,
+}
+/// Reference to a buffer retained by one [`ResourceTable`].
+#[derive(Clone, Copy)]
+pub struct BufferRef<'r> {
+    pub(crate) owner: &'r ResourceTable,
+    pub(crate) index: usize,
+}
+/// Reference to a sampler retained by one [`ResourceTable`].
+#[derive(Clone, Copy)]
+pub struct SamplerRef<'r> {
+    pub(crate) owner: &'r ResourceTable,
+    pub(crate) index: usize,
+}
+/// Reference to a render pipeline retained by one [`ResourceTable`].
+#[derive(Clone, Copy)]
+pub struct RenderPipelineRef<'r> {
+    pub(crate) owner: &'r ResourceTable,
+    pub(crate) index: usize,
+}
+
+macro_rules! impl_resource_ref_traits {
+    ($reference:ident) => {
+        impl fmt::Debug for $reference<'_> {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(concat!(stringify!($reference), "(..)"))
+            }
+        }
+
+        impl PartialEq for $reference<'_> {
+            fn eq(&self, other: &Self) -> bool {
+                core::ptr::eq(self.owner, other.owner) && self.index == other.index
+            }
+        }
+
+        impl Eq for $reference<'_> {}
+    };
+}
+
+impl_resource_ref_traits!(TextureRef);
+impl_resource_ref_traits!(BufferRef);
+impl_resource_ref_traits!(SamplerRef);
+impl_resource_ref_traits!(RenderPipelineRef);

--- a/user/lib/sgfx/src/ir/types.rs
+++ b/user/lib/sgfx/src/ir/types.rs
@@ -1,0 +1,280 @@
+//! Value types and validation errors used by the graphics IR.
+
+/// Result type returned by graphics IR operations.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Reason a graphics IR descriptor or command was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    /// A value was non-finite, zero where non-zero is required, or otherwise malformed.
+    InvalidValue,
+    /// A descriptor does not describe a portable logical graphics object.
+    InvalidDescriptor,
+    /// A resource's required usage flag is absent.
+    InvalidUsage,
+    /// A rectangle, byte range, or index range exceeds its resource.
+    OutOfBounds,
+    /// Arithmetic needed to validate a range overflowed.
+    Overflow,
+    /// A resource reference belongs to a different resource table.
+    ResourceTableMismatch,
+    /// A render pass command was used outside an active render pass.
+    RenderPassNotActive,
+    /// A copy or upload command was used while a render pass is active.
+    RenderPassActive,
+    /// A command requires a render pipeline that has not been set.
+    PipelineNotSet,
+    /// A command requires a vertex buffer that has not been set.
+    VertexBufferNotSet,
+    /// A command requires an index buffer that has not been set.
+    IndexBufferNotSet,
+    /// A draw requires uniforms that have not been set.
+    UniformsNotSet,
+    /// A textured pipeline requires both a texture and sampler binding.
+    TextureBindingNotSet,
+    /// A render pipeline's target format differs from the active attachment.
+    PipelineTargetMismatch,
+    /// Sampling the active render attachment would create feedback.
+    AttachmentFeedback,
+    /// A bounded resource table is full.
+    ResourceLimitExceeded,
+    /// A bounded command buffer is full.
+    CommandLimitExceeded,
+    /// Allocation for IR-owned storage failed.
+    OutOfMemory,
+    /// A command buffer was finished while a render pass remained open.
+    RenderPassStillActive,
+}
+
+/// A finite RGBA color represented with floating-point components.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Color {
+    red: f32,
+    green: f32,
+    blue: f32,
+    alpha: f32,
+}
+
+impl Color {
+    /// Construct a finite RGBA color.
+    ///
+    /// # Arguments
+    ///
+    /// * `red` - Red component.
+    /// * `green` - Green component.
+    /// * `blue` - Blue component.
+    /// * `alpha` - Alpha component.
+    ///
+    /// # Returns
+    ///
+    /// The color, or [`Error::InvalidValue`] when any component is non-finite.
+    pub fn rgba(red: f32, green: f32, blue: f32, alpha: f32) -> Result<Self> {
+        if [red, green, blue, alpha]
+            .iter()
+            .all(|value| value.is_finite())
+        {
+            Ok(Self {
+                red,
+                green,
+                blue,
+                alpha,
+            })
+        } else {
+            Err(Error::InvalidValue)
+        }
+    }
+
+    /// Return the RGBA components in order.
+    ///
+    /// # Returns
+    ///
+    /// `[red, green, blue, alpha]`.
+    pub const fn components(self) -> [f32; 4] {
+        [self.red, self.green, self.blue, self.alpha]
+    }
+}
+
+/// Non-zero two-dimensional pixel extent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Extent2D {
+    width: u32,
+    height: u32,
+}
+
+impl Extent2D {
+    /// Construct a non-zero pixel extent.
+    ///
+    /// # Arguments
+    ///
+    /// * `width` - Width in pixels.
+    /// * `height` - Height in pixels.
+    ///
+    /// # Returns
+    ///
+    /// The extent, or [`Error::InvalidValue`] for a zero dimension.
+    pub const fn new(width: u32, height: u32) -> Result<Self> {
+        if width == 0 || height == 0 {
+            Err(Error::InvalidValue)
+        } else {
+            Ok(Self { width, height })
+        }
+    }
+
+    /// Return the width in pixels.
+    ///
+    /// # Returns
+    ///
+    /// The non-zero width.
+    pub const fn width(self) -> u32 {
+        self.width
+    }
+
+    /// Return the height in pixels.
+    ///
+    /// # Returns
+    ///
+    /// The non-zero height.
+    pub const fn height(self) -> u32 {
+        self.height
+    }
+}
+
+/// A non-empty top-left pixel rectangle with overflow-safe bounds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PixelRect {
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
+
+impl PixelRect {
+    /// Construct a non-empty pixel rectangle.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - Left pixel coordinate.
+    /// * `y` - Top pixel coordinate.
+    /// * `width` - Non-zero width in pixels.
+    /// * `height` - Non-zero height in pixels.
+    ///
+    /// # Returns
+    ///
+    /// The rectangle, or [`Error::InvalidValue`] when it is empty or overflows.
+    pub const fn new(x: u32, y: u32, width: u32, height: u32) -> Result<Self> {
+        if width == 0
+            || height == 0
+            || x.checked_add(width).is_none()
+            || y.checked_add(height).is_none()
+        {
+            Err(Error::InvalidValue)
+        } else {
+            Ok(Self {
+                x,
+                y,
+                width,
+                height,
+            })
+        }
+    }
+
+    /// Return the left coordinate.
+    ///
+    /// # Returns
+    ///
+    /// The left pixel coordinate.
+    pub const fn x(self) -> u32 {
+        self.x
+    }
+
+    /// Return the top coordinate.
+    ///
+    /// # Returns
+    ///
+    /// The top pixel coordinate.
+    pub const fn y(self) -> u32 {
+        self.y
+    }
+
+    /// Return the width in pixels.
+    ///
+    /// # Returns
+    ///
+    /// The non-zero rectangle width.
+    pub const fn width(self) -> u32 {
+        self.width
+    }
+
+    /// Return the height in pixels.
+    ///
+    /// # Returns
+    ///
+    /// The non-zero rectangle height.
+    pub const fn height(self) -> u32 {
+        self.height
+    }
+
+    /// Return whether this rectangle lies wholly within an extent.
+    ///
+    /// # Arguments
+    ///
+    /// * `extent` - Bounds to test.
+    ///
+    /// # Returns
+    ///
+    /// `true` when all pixels are inside `extent`.
+    pub const fn is_within(self, extent: Extent2D) -> bool {
+        self.x + self.width <= extent.width && self.y + self.height <= extent.height
+    }
+
+    pub(crate) const fn same_extent(self, other: Self) -> bool {
+        self.width == other.width && self.height == other.height
+    }
+}
+
+/// A finite general 4×4 transform matrix in column-major order.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Transform {
+    columns: [f32; 16],
+}
+
+impl Transform {
+    /// Construct a finite column-major 4×4 transform.
+    ///
+    /// # Arguments
+    ///
+    /// * `columns` - Sixteen matrix elements in column-major order.
+    ///
+    /// # Returns
+    ///
+    /// The transform, or [`Error::InvalidValue`] for a non-finite element.
+    pub fn from_columns(columns: [f32; 16]) -> Result<Self> {
+        if columns.iter().all(|value| value.is_finite()) {
+            Ok(Self { columns })
+        } else {
+            Err(Error::InvalidValue)
+        }
+    }
+
+    /// Construct the identity transform.
+    ///
+    /// # Returns
+    ///
+    /// A finite identity matrix.
+    pub const fn identity() -> Self {
+        Self {
+            columns: [
+                1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+            ],
+        }
+    }
+
+    /// Return the column-major matrix elements.
+    ///
+    /// # Returns
+    ///
+    /// The sixteen finite matrix elements.
+    pub const fn columns(self) -> [f32; 16] {
+        self.columns
+    }
+}

--- a/user/lib/sgfx/src/ir_execute.rs
+++ b/user/lib/sgfx/src/ir_execute.rs
@@ -1,0 +1,540 @@
+//! Lowering of the currently supported logical IR subset to the active backend.
+
+use alloc::vec::Vec;
+use core::mem::size_of;
+
+use crate::ir::{
+    self, BlendState, BufferRef, BufferUsage, Command, CommandBuffer, DrawUniforms,
+    FragmentProgram, LoadOp, PrimitiveTopology, RenderPassDesc, RenderPipelineRef, ResourceTable,
+    StoreOp, TextureFormat, TextureRef, TextureUsage, VertexFormat,
+};
+use crate::{
+    Color, Context, CullMode, FrontFace, HandleError, Image, PipelineDesc, Queue, RenderPass,
+    VertexClip4Color3, Viewport,
+};
+
+/// An IR feature that the active backend facade cannot lower faithfully yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedIrFeature {
+    /// The command sequence is not the single-upload, single-pass shape currently supported.
+    CommandSequence,
+    /// More than one buffer upload was recorded.
+    MultipleBufferUploads,
+    /// More than one render pass was recorded.
+    MultipleRenderPasses,
+    /// More than one draw was recorded.
+    MultipleDraws,
+    /// Texture upload is not available through the initial IR lowering path.
+    TextureUpload,
+    /// Texture-to-texture copies are not available through the initial IR lowering path.
+    TextureCopy,
+    /// Index buffers and indexed draws are not available through the initial IR lowering path.
+    IndexedDrawing,
+    /// Sampled textures are not available through the initial IR lowering path.
+    TextureSampling,
+    /// Sampler objects are not available through the initial IR lowering path.
+    Sampler,
+    /// Scissor state is not available through the initial IR lowering path.
+    Scissor,
+    /// The presentation target format is unsupported.
+    TargetFormat,
+    /// The presentation target usage combination is unsupported.
+    TargetUsage,
+    /// Only a render pass covering the complete presentation target is supported.
+    RenderArea,
+    /// Only a clear attachment load operation is supported.
+    LoadOperation,
+    /// Only a store attachment operation is supported.
+    StoreOperation,
+    /// The clear color cannot be represented by the active backend facade.
+    ClearColor,
+    /// The pipeline target format is unsupported.
+    PipelineTargetFormat,
+    /// The pipeline primitive topology is unsupported.
+    PrimitiveTopology,
+    /// The pipeline vertex layout is unsupported.
+    VertexLayout,
+    /// The pipeline fragment program is unsupported.
+    FragmentProgram,
+    /// The pipeline blend state is unsupported.
+    BlendState,
+    /// The logical vertex buffer usage or upload layout is unsupported.
+    VertexBuffer,
+    /// Draw uniforms require backend functionality that is not implemented yet.
+    DrawUniforms,
+}
+
+/// Failure while mapping or submitting a logical IR command buffer.
+#[derive(Debug)]
+pub enum IrSubmitError {
+    /// A logical resource reference or descriptor failed validation.
+    InvalidIr(ir::Error),
+    /// The command buffer and presentation target use different resource tables.
+    ResourceTableMismatch,
+    /// The logical target extent differs from the physical presentation image.
+    TargetExtentMismatch,
+    /// A valid IR feature is not implemented by the active lowering path.
+    Unsupported(UnsupportedIrFeature),
+    /// Uploaded vertex bytes are malformed, non-finite, or outside the supported color range.
+    InvalidVertexData,
+    /// Allocation for decoded backend vertices failed.
+    OutOfMemory,
+    /// The active graphics backend rejected resource creation or submission.
+    Backend(HandleError),
+}
+
+impl From<ir::Error> for IrSubmitError {
+    fn from(error: ir::Error) -> Self {
+        Self::InvalidIr(error)
+    }
+}
+
+impl From<HandleError> for IrSubmitError {
+    fn from(error: HandleError) -> Self {
+        Self::Backend(error)
+    }
+}
+
+/// Typed association between one logical presentation texture and one real image.
+///
+/// The mapping retains only safe references. Backend resource identifiers and
+/// transport details remain private to `sgfx`.
+#[derive(Clone, Copy)]
+pub struct IrPresentTarget<'r, 'image> {
+    resources: &'r ResourceTable,
+    texture: TextureRef<'r>,
+    image: &'image Image,
+}
+
+impl Image {
+    /// Associate this image with one logical presentation texture.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Resource table that owns `texture`.
+    /// * `texture` - BGRA render attachment with presentation usage.
+    ///
+    /// # Returns
+    ///
+    /// A typed target accepted by [`Queue::submit_ir`], or an error when the
+    /// logical texture cannot be represented by this image.
+    pub fn map_ir_present_target<'r>(
+        &self,
+        resources: &'r ResourceTable,
+        texture: TextureRef<'r>,
+    ) -> Result<IrPresentTarget<'r, '_>, IrSubmitError> {
+        let descriptor = resources.texture(texture)?;
+        if descriptor.format() != TextureFormat::Bgra8Unorm {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::TargetFormat,
+            ));
+        }
+        let supported_usage = TextureUsage::RENDER_ATTACHMENT | TextureUsage::PRESENT;
+        if descriptor.usage() != supported_usage {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::TargetUsage,
+            ));
+        }
+        let extent = descriptor.extent();
+        if extent.width() != self.width || extent.height() != self.height {
+            return Err(IrSubmitError::TargetExtentMismatch);
+        }
+        Ok(IrPresentTarget {
+            resources,
+            texture,
+            image: self,
+        })
+    }
+}
+
+struct ExecutionPlan {
+    clear_color: Color,
+    pipeline: PipelineDesc,
+    vertices: Vec<VertexClip4Color3>,
+}
+
+struct VertexDecodeRequest<'r, 'data> {
+    resources: &'r ResourceTable,
+    upload_buffer: BufferRef<'r>,
+    upload_offset: u64,
+    upload_data: &'data [u8],
+    vertex_buffer: BufferRef<'r>,
+    vertex_offset: u64,
+    first_vertex: u32,
+    vertex_count: u32,
+}
+
+impl Queue {
+    /// Validate, lower, and synchronously submit one logical IR command buffer.
+    ///
+    /// The initial lowering path intentionally supports one explicit subset:
+    /// one complete-target clear/store render pass containing one non-indexed
+    /// vertex-color triangle-list draw. Unsupported valid IR features return an
+    /// explicit [`IrSubmitError::Unsupported`] error before backend submission.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - Context used to materialize backend pipeline state.
+    /// * `target` - Explicit mapping from the logical presentation texture to an image.
+    /// * `commands` - Finished logical command buffer to execute.
+    ///
+    /// # Returns
+    ///
+    /// Success after synchronous backend submission, or a validation,
+    /// unsupported-feature, allocation, or backend error.
+    pub fn submit_ir<'r, 'image, 'data>(
+        &self,
+        context: &Context,
+        target: IrPresentTarget<'r, 'image>,
+        commands: &CommandBuffer<'r, 'data>,
+    ) -> Result<(), IrSubmitError> {
+        if !core::ptr::eq(target.resources, commands.resources()) {
+            return Err(IrSubmitError::ResourceTableMismatch);
+        }
+
+        let plan = ExecutionPlan::from_commands(target, commands)?;
+        let pipeline = context.create_pipeline(target.image, plan.pipeline)?;
+        let viewport = Viewport::new(target.image.width, target.image.height);
+        let mut render_pass = RenderPass::new(target.image, viewport, plan.clear_color);
+        render_pass.draw_clip_space_vertex_color(&pipeline, &plan.vertices);
+        self.submit(&render_pass).map_err(IrSubmitError::Backend)
+    }
+}
+
+impl ExecutionPlan {
+    fn from_commands<'r, 'image, 'data>(
+        target: IrPresentTarget<'r, 'image>,
+        commands: &CommandBuffer<'r, 'data>,
+    ) -> Result<Self, IrSubmitError> {
+        let stream = commands.commands();
+        Self::reject_unimplemented_commands(stream)?;
+        Self::validate_command_counts(stream)?;
+        if stream.len() != 7 {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::CommandSequence,
+            ));
+        }
+
+        let (upload_buffer, upload_offset, upload_data) = match &stream[0] {
+            Command::WriteBuffer {
+                buffer,
+                offset,
+                data,
+            } => (*buffer, *offset, *data),
+            _ => return Err(Self::unsupported_sequence()),
+        };
+        let pass = match &stream[1] {
+            Command::BeginRenderPass(pass) => *pass,
+            _ => return Err(Self::unsupported_sequence()),
+        };
+        let pipeline = match &stream[2] {
+            Command::SetPipeline(pipeline) => *pipeline,
+            _ => return Err(Self::unsupported_sequence()),
+        };
+        let (vertex_buffer, vertex_offset) = match &stream[3] {
+            Command::SetVertexBuffer { buffer, offset } => (*buffer, *offset),
+            _ => return Err(Self::unsupported_sequence()),
+        };
+        let uniforms = match &stream[4] {
+            Command::SetUniforms(uniforms) => *uniforms,
+            _ => return Err(Self::unsupported_sequence()),
+        };
+        let (vertex_count, first_vertex) = match &stream[5] {
+            Command::Draw {
+                vertex_count,
+                first_vertex,
+            } => (*vertex_count, *first_vertex),
+            _ => return Err(Self::unsupported_sequence()),
+        };
+        if !matches!(stream[6], Command::EndRenderPass) {
+            return Err(Self::unsupported_sequence());
+        }
+
+        let clear_color = Self::validate_pass(target, pass)?;
+        let pipeline_description =
+            Self::validate_pipeline(target.resources, pipeline, vertex_count)?;
+        Self::validate_uniforms(uniforms)?;
+        let vertices = Self::decode_vertices(VertexDecodeRequest {
+            resources: target.resources,
+            upload_buffer,
+            upload_offset,
+            upload_data,
+            vertex_buffer,
+            vertex_offset,
+            first_vertex,
+            vertex_count,
+        })?;
+        Ok(Self {
+            clear_color,
+            pipeline: pipeline_description,
+            vertices,
+        })
+    }
+
+    fn reject_unimplemented_commands(stream: &[Command<'_, '_>]) -> Result<(), IrSubmitError> {
+        for command in stream {
+            let unsupported = match command {
+                Command::WriteTexture { .. } => Some(UnsupportedIrFeature::TextureUpload),
+                Command::CopyTextureToTexture { .. } => Some(UnsupportedIrFeature::TextureCopy),
+                Command::SetIndexBuffer { .. } | Command::DrawIndexed { .. } => {
+                    Some(UnsupportedIrFeature::IndexedDrawing)
+                }
+                Command::SetTexture(_) => Some(UnsupportedIrFeature::TextureSampling),
+                Command::SetSampler(_) => Some(UnsupportedIrFeature::Sampler),
+                Command::SetScissor(_) => Some(UnsupportedIrFeature::Scissor),
+                _ => None,
+            };
+            if let Some(feature) = unsupported {
+                return Err(IrSubmitError::Unsupported(feature));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_command_counts(stream: &[Command<'_, '_>]) -> Result<(), IrSubmitError> {
+        let uploads = stream
+            .iter()
+            .filter(|command| matches!(command, Command::WriteBuffer { .. }))
+            .count();
+        let passes = stream
+            .iter()
+            .filter(|command| matches!(command, Command::BeginRenderPass(_)))
+            .count();
+        let draws = stream
+            .iter()
+            .filter(|command| matches!(command, Command::Draw { .. }))
+            .count();
+        if uploads != 1 {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::MultipleBufferUploads,
+            ));
+        }
+        if passes != 1 {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::MultipleRenderPasses,
+            ));
+        }
+        if draws != 1 {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::MultipleDraws,
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_pass(
+        target: IrPresentTarget<'_, '_>,
+        pass: RenderPassDesc<'_>,
+    ) -> Result<Color, IrSubmitError> {
+        if pass.target() != target.texture {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::MultipleRenderPasses,
+            ));
+        }
+        let area = pass.area();
+        if area.x() != 0
+            || area.y() != 0
+            || area.width() != target.image.width
+            || area.height() != target.image.height
+        {
+            return Err(IrSubmitError::Unsupported(UnsupportedIrFeature::RenderArea));
+        }
+        let clear = match pass.load() {
+            LoadOp::Clear(color) => color,
+            LoadOp::Load | LoadOp::DontCare => {
+                return Err(IrSubmitError::Unsupported(
+                    UnsupportedIrFeature::LoadOperation,
+                ));
+            }
+        };
+        if pass.store() != StoreOp::Store {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::StoreOperation,
+            ));
+        }
+        let [red, green, blue, alpha] = clear.components();
+        if ![red, green, blue, alpha]
+            .iter()
+            .all(|component| (0.0..=1.0).contains(component))
+        {
+            return Err(IrSubmitError::Unsupported(UnsupportedIrFeature::ClearColor));
+        }
+        Ok(Color::rgba(red, green, blue, alpha))
+    }
+
+    fn validate_pipeline(
+        resources: &ResourceTable,
+        pipeline: RenderPipelineRef<'_>,
+        vertex_count: u32,
+    ) -> Result<PipelineDesc, IrSubmitError> {
+        let (target_format, topology, layout_valid, fragment, blend, raster) = resources
+            .with_pipeline(pipeline, |descriptor| {
+                let attributes = descriptor.vertex_buffer().attributes();
+                let layout_valid = usize::try_from(descriptor.vertex_buffer().stride()).ok()
+                    == Some(size_of::<VertexClip4Color3>())
+                    && attributes.len() == 2
+                    && attributes[0].location() == 0
+                    && attributes[0].format() == VertexFormat::Float32x4
+                    && attributes[0].offset() == 0
+                    && attributes[1].location() == 1
+                    && attributes[1].format() == VertexFormat::Float32x3
+                    && attributes[1].offset() == 16;
+                (
+                    descriptor.target_format(),
+                    descriptor.topology(),
+                    layout_valid,
+                    descriptor.fragment(),
+                    descriptor.blend(),
+                    descriptor.raster(),
+                )
+            })?;
+        if target_format != TextureFormat::Bgra8Unorm {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::PipelineTargetFormat,
+            ));
+        }
+        if topology != PrimitiveTopology::TriangleList {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::PrimitiveTopology,
+            ));
+        }
+        if !layout_valid {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::VertexLayout,
+            ));
+        }
+        if fragment != FragmentProgram::VertexColor {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::FragmentProgram,
+            ));
+        }
+        if blend != BlendState::REPLACE {
+            return Err(IrSubmitError::Unsupported(UnsupportedIrFeature::BlendState));
+        }
+        let max_vertices =
+            usize::try_from(vertex_count).map_err(|_| IrSubmitError::InvalidVertexData)?;
+        let cull_mode = match raster.cull_mode() {
+            ir::CullMode::None => CullMode::None,
+            ir::CullMode::Front => CullMode::Front,
+            ir::CullMode::Back => CullMode::Back,
+        };
+        let front_face = match raster.front_face() {
+            ir::FrontFace::Clockwise => FrontFace::Clockwise,
+            ir::FrontFace::CounterClockwise => FrontFace::CounterClockwise,
+        };
+        Ok(PipelineDesc::clip_space_vertex_color(max_vertices)
+            .with_cull_mode(cull_mode)
+            .with_front_face(front_face))
+    }
+
+    fn validate_uniforms(uniforms: DrawUniforms) -> Result<(), IrSubmitError> {
+        if uniforms.transform() != ir::Transform::identity()
+            || uniforms.color().components() != [1.0, 1.0, 1.0, 1.0]
+        {
+            Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::DrawUniforms,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn decode_vertices(
+        request: VertexDecodeRequest<'_, '_>,
+    ) -> Result<Vec<VertexClip4Color3>, IrSubmitError> {
+        let VertexDecodeRequest {
+            resources,
+            upload_buffer,
+            upload_offset,
+            upload_data,
+            vertex_buffer,
+            vertex_offset,
+            first_vertex,
+            vertex_count,
+        } = request;
+        if upload_buffer != vertex_buffer || upload_offset != 0 {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::VertexBuffer,
+            ));
+        }
+        let descriptor = resources.buffer(vertex_buffer)?;
+        let supported_usage = BufferUsage::VERTEX | BufferUsage::COPY_DST;
+        let upload_len =
+            u64::try_from(upload_data.len()).map_err(|_| IrSubmitError::InvalidVertexData)?;
+        if descriptor.usage() != supported_usage || descriptor.size() != upload_len {
+            return Err(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::VertexBuffer,
+            ));
+        }
+
+        let stride = size_of::<VertexClip4Color3>();
+        let first = usize::try_from(first_vertex).map_err(|_| IrSubmitError::InvalidVertexData)?;
+        let count = usize::try_from(vertex_count).map_err(|_| IrSubmitError::InvalidVertexData)?;
+        let base = usize::try_from(vertex_offset)
+            .ok()
+            .and_then(|offset| {
+                first
+                    .checked_mul(stride)
+                    .and_then(|first_bytes| offset.checked_add(first_bytes))
+            })
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        let byte_len = count
+            .checked_mul(stride)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        let end = base
+            .checked_add(byte_len)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        let selected = upload_data
+            .get(base..end)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+
+        let mut vertices = Vec::new();
+        vertices
+            .try_reserve_exact(count)
+            .map_err(|_| IrSubmitError::OutOfMemory)?;
+        for encoded in selected.chunks_exact(stride) {
+            let mut cursor = 0usize;
+            let clip_position = [
+                Self::read_f32(encoded, &mut cursor)?,
+                Self::read_f32(encoded, &mut cursor)?,
+                Self::read_f32(encoded, &mut cursor)?,
+                Self::read_f32(encoded, &mut cursor)?,
+            ];
+            let color = [
+                Self::read_f32(encoded, &mut cursor)?,
+                Self::read_f32(encoded, &mut cursor)?,
+                Self::read_f32(encoded, &mut cursor)?,
+            ];
+            if !clip_position.iter().all(|component| component.is_finite())
+                || !color
+                    .iter()
+                    .all(|component| component.is_finite() && (0.0..=1.0).contains(component))
+            {
+                return Err(IrSubmitError::InvalidVertexData);
+            }
+            vertices.push(VertexClip4Color3::new(clip_position, color));
+        }
+        if vertices.len() != count {
+            return Err(IrSubmitError::InvalidVertexData);
+        }
+        Ok(vertices)
+    }
+
+    fn read_f32(bytes: &[u8], cursor: &mut usize) -> Result<f32, IrSubmitError> {
+        let end = cursor
+            .checked_add(size_of::<f32>())
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        let encoded = bytes
+            .get(*cursor..end)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        let encoded: [u8; 4] = encoded
+            .try_into()
+            .map_err(|_| IrSubmitError::InvalidVertexData)?;
+        *cursor = end;
+        Ok(f32::from_le_bytes(encoded))
+    }
+
+    const fn unsupported_sequence() -> IrSubmitError {
+        IrSubmitError::Unsupported(UnsupportedIrFeature::CommandSequence)
+    }
+}

--- a/user/lib/sgfx/src/ir_execute.rs
+++ b/user/lib/sgfx/src/ir_execute.rs
@@ -1,22 +1,25 @@
-//! Lowering of the currently supported logical IR subset to the active backend.
+//! Ordered lowering of portable logical IR to the active backend.
 
 use alloc::vec::Vec;
-use core::mem::size_of;
 
+use crate::driver::{
+    self, IrAddressMode, IrBlendComponent, IrBlendFactor, IrBlendOp, IrBlendState, IrCullMode,
+    IrDraw, IrFilterMode, IrFragmentProgram, IrFrontFace, IrPipelineState, IrRect, IrSamplerState,
+    IrSubmission, IrTextureFormat, IrTextureUpload, IrUniforms, IrVertex, MAX_IR_VERTICES,
+};
 use crate::ir::{
-    self, BlendState, BufferRef, BufferUsage, Command, CommandBuffer, DrawUniforms,
-    FragmentProgram, LoadOp, PrimitiveTopology, RenderPassDesc, RenderPipelineRef, ResourceTable,
-    StoreOp, TextureFormat, TextureRef, TextureUsage, VertexFormat,
+    self, AddressMode, BlendComponent, BlendFactor, BlendOp, BlendState, BufferRef, BufferUsage,
+    Command, CommandBuffer, DrawUniforms, FilterMode, FragmentProgram, IndexFormat, LoadOp,
+    MAX_BUFFERS, PrimitiveTopology, RenderPipelineRef, ResourceTable, SamplerDesc, SamplerRef,
+    TextureDesc, TextureFormat, TextureRef, TextureSampleMode, TextureUsage, TextureWrite,
+    VertexAttribute, VertexFormat,
 };
-use crate::{
-    Color, Context, CullMode, FrontFace, HandleError, Image, PipelineDesc, Queue, RenderPass,
-    VertexClip4Color3, Viewport,
-};
+use crate::{Context, HandleError, Image, Queue};
 
 /// An IR feature that the active backend facade cannot lower faithfully yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedIrFeature {
-    /// The command sequence is not the single-upload, single-pass shape currently supported.
+    /// The command sequence is outside the one-upload-phase, one-pass subset.
     CommandSequence,
     /// More than one buffer upload was recorded.
     MultipleBufferUploads,
@@ -24,29 +27,29 @@ pub enum UnsupportedIrFeature {
     MultipleRenderPasses,
     /// More than one draw was recorded.
     MultipleDraws,
-    /// Texture upload is not available through the initial IR lowering path.
+    /// Texture upload is unavailable through an older lowering path.
     TextureUpload,
-    /// Texture-to-texture copies are not available through the initial IR lowering path.
+    /// Texture-to-texture copies are not available through this lowering path.
     TextureCopy,
-    /// Index buffers and indexed draws are not available through the initial IR lowering path.
+    /// Index buffers and indexed draws are not available through this lowering path.
     IndexedDrawing,
-    /// Sampled textures are not available through the initial IR lowering path.
+    /// Texture sampling is unavailable through an older lowering path.
     TextureSampling,
-    /// Sampler objects are not available through the initial IR lowering path.
+    /// Sampler objects are unavailable through an older lowering path.
     Sampler,
-    /// Scissor state is not available through the initial IR lowering path.
+    /// Scissor state is unavailable through an older lowering path.
     Scissor,
     /// The presentation target format is unsupported.
     TargetFormat,
     /// The presentation target usage combination is unsupported.
     TargetUsage,
-    /// Only a render pass covering the complete presentation target is supported.
+    /// The render area is unsupported.
     RenderArea,
-    /// Only a clear attachment load operation is supported.
+    /// The attachment load operation is unsupported.
     LoadOperation,
-    /// Only a store attachment operation is supported.
+    /// The attachment store operation is unsupported.
     StoreOperation,
-    /// The clear color cannot be represented by the active backend facade.
+    /// The clear color is unsupported.
     ClearColor,
     /// The pipeline target format is unsupported.
     PipelineTargetFormat,
@@ -60,8 +63,10 @@ pub enum UnsupportedIrFeature {
     BlendState,
     /// The logical vertex buffer usage or upload layout is unsupported.
     VertexBuffer,
-    /// Draw uniforms require backend functionality that is not implemented yet.
+    /// Draw uniforms are unsupported.
     DrawUniforms,
+    /// The backend command stream would exceed its fixed 64 KiB transport limit.
+    CommandStream,
 }
 
 /// Failure while mapping or submitting a logical IR command buffer.
@@ -69,17 +74,25 @@ pub enum UnsupportedIrFeature {
 pub enum IrSubmitError {
     /// A logical resource reference or descriptor failed validation.
     InvalidIr(ir::Error),
-    /// The command buffer and presentation target use different resource tables.
+    /// The command buffer and resource cache use different resource tables.
     ResourceTableMismatch,
+    /// A context or queue differs from the context that created the resource cache.
+    ContextMismatch,
     /// The logical target extent differs from the physical presentation image.
     TargetExtentMismatch,
+    /// The active render-pass texture has no mapped physical image.
+    ImageNotMapped,
+    /// A logical texture was already mapped to an image.
+    TextureAlreadyMapped,
+    /// A physical image was already mapped to a different logical texture.
+    ImageAlreadyMapped,
     /// A valid IR feature is not implemented by the active lowering path.
     Unsupported(UnsupportedIrFeature),
     /// Uploaded vertex bytes are malformed, non-finite, or outside the supported color range.
     InvalidVertexData,
-    /// Allocation for decoded backend vertices failed.
+    /// Allocation for persistent shadow data or decoded backend data failed.
     OutOfMemory,
-    /// The active graphics backend rejected resource creation or submission.
+    /// The active graphics backend rejected resource creation, upload, or submission.
     Backend(HandleError),
 }
 
@@ -95,446 +108,1366 @@ impl From<HandleError> for IrSubmitError {
     }
 }
 
-/// Typed association between one logical presentation texture and one real image.
-///
-/// The mapping retains only safe references. Backend resource identifiers and
-/// transport details remain private to `sgfx`.
-#[derive(Clone, Copy)]
-pub struct IrPresentTarget<'r, 'image> {
+/// Persistent association between one resource table, CPU buffer shadows, and
+/// private backend materialization owned by one creating context.
+pub struct IrResources<'r, 'image> {
     resources: &'r ResourceTable,
-    texture: TextureRef<'r>,
-    image: &'image Image,
+    context_id: i32,
+    backend: driver::IrResources,
+    images: Vec<ImageMapping<'r, 'image>>,
+    buffer_shadows: Vec<Option<Vec<u8>>>,
 }
 
-impl Image {
-    /// Associate this image with one logical presentation texture.
-    ///
-    /// # Arguments
-    ///
-    /// * `resources` - Resource table that owns `texture`.
-    /// * `texture` - BGRA render attachment with presentation usage.
+struct ImageMapping<'r, 'image> {
+    texture: TextureRef<'r>,
+    image: &'image Image,
+    backend_registered: bool,
+}
+
+impl<'r, 'image> IrResources<'r, 'image> {
+    pub(crate) fn new(
+        resources: &'r ResourceTable,
+        context: &driver::Context,
+    ) -> Result<Self, IrSubmitError> {
+        let mut images = Vec::new();
+        images
+            .try_reserve_exact(1_024)
+            .map_err(|_| IrSubmitError::OutOfMemory)?;
+        let mut buffer_shadows = Vec::new();
+        buffer_shadows
+            .try_reserve_exact(MAX_BUFFERS)
+            .map_err(|_| IrSubmitError::OutOfMemory)?;
+        for _ in 0..MAX_BUFFERS {
+            buffer_shadows.push(None);
+        }
+        Ok(Self {
+            resources,
+            context_id: context.context_id(),
+            backend: context.create_ir_resources()?,
+            images,
+            buffer_shadows,
+        })
+    }
+
+    /// Return the resource table that owns this cache's logical references.
     ///
     /// # Returns
     ///
-    /// A typed target accepted by [`Queue::submit_ir`], or an error when the
-    /// logical texture cannot be represented by this image.
-    pub fn map_ir_present_target<'r>(
-        &self,
-        resources: &'r ResourceTable,
+    /// The lifetime-branded table supplied to [`Context::create_ir_resources`].
+    pub const fn resources(&self) -> &'r ResourceTable {
+        self.resources
+    }
+
+    /// Map a logical presentation texture to a physical render-target image.
+    ///
+    /// # Arguments
+    ///
+    /// * `texture` - Texture owned by this cache's resource table.
+    /// * `image` - Physical image created by this cache's creating context.
+    ///
+    /// # Returns
+    ///
+    /// Success after retaining the safe image reference, or an error for a
+    /// table/context mismatch, an unsupported target descriptor, extent
+    /// mismatch, or a conflicting mapping.
+    pub fn map_image(
+        &mut self,
         texture: TextureRef<'r>,
-    ) -> Result<IrPresentTarget<'r, '_>, IrSubmitError> {
-        let descriptor = resources.texture(texture)?;
+        image: &'image Image,
+    ) -> Result<(), IrSubmitError> {
+        if image.backend.context_id() != self.context_id {
+            return Err(IrSubmitError::ContextMismatch);
+        }
+        if !core::ptr::eq(texture.owner, self.resources) {
+            return Err(IrSubmitError::ResourceTableMismatch);
+        }
+        let descriptor = self.resources.texture(texture)?;
         if descriptor.format() != TextureFormat::Bgra8Unorm {
             return Err(IrSubmitError::Unsupported(
                 UnsupportedIrFeature::TargetFormat,
             ));
         }
-        let supported_usage = TextureUsage::RENDER_ATTACHMENT | TextureUsage::PRESENT;
-        if descriptor.usage() != supported_usage {
+        let required_usage = TextureUsage::RENDER_ATTACHMENT | TextureUsage::PRESENT;
+        let allowed_usage = required_usage | TextureUsage::SAMPLED | TextureUsage::COPY_DST;
+        if !descriptor.usage().contains(required_usage)
+            || !allowed_usage.contains(descriptor.usage())
+        {
             return Err(IrSubmitError::Unsupported(
                 UnsupportedIrFeature::TargetUsage,
             ));
         }
         let extent = descriptor.extent();
-        if extent.width() != self.width || extent.height() != self.height {
+        if extent.width() != image.width || extent.height() != image.height {
             return Err(IrSubmitError::TargetExtentMismatch);
         }
-        Ok(IrPresentTarget {
-            resources,
+        if self.images.iter().any(|mapping| mapping.texture == texture) {
+            return Err(IrSubmitError::TextureAlreadyMapped);
+        }
+        if self
+            .images
+            .iter()
+            .any(|mapping| core::ptr::eq(mapping.image, image))
+        {
+            return Err(IrSubmitError::ImageAlreadyMapped);
+        }
+        self.images.push(ImageMapping {
             texture,
-            image: self,
-        })
+            image,
+            backend_registered: false,
+        });
+        Ok(())
+    }
+
+    fn mapped_image(&self, texture: TextureRef<'r>) -> Result<&'image Image, IrSubmitError> {
+        if !core::ptr::eq(texture.owner, self.resources) {
+            return Err(IrSubmitError::ResourceTableMismatch);
+        }
+        self.resources.texture(texture)?;
+        self.images
+            .iter()
+            .find(|mapping| mapping.texture == texture)
+            .map(|mapping| mapping.image)
+            .ok_or(IrSubmitError::ImageNotMapped)
+    }
+
+    fn shadow(&self, buffer: BufferRef<'r>) -> Result<Option<&[u8]>, IrSubmitError> {
+        self.resources.buffer(buffer)?;
+        Ok(self
+            .buffer_shadows
+            .get(buffer.index)
+            .and_then(Option::as_deref))
+    }
+
+    fn commit_buffer_updates(&mut self, updates: Vec<BufferShadowUpdate>) {
+        for update in updates {
+            if let Some(slot) = self.buffer_shadows.get_mut(update.slot) {
+                *slot = Some(update.bytes);
+            }
+        }
     }
 }
 
-struct ExecutionPlan {
-    clear_color: Color,
-    pipeline: PipelineDesc,
-    vertices: Vec<VertexClip4Color3>,
+struct BufferShadowUpdate {
+    slot: usize,
+    bytes: Vec<u8>,
 }
 
-struct VertexDecodeRequest<'r, 'data> {
-    resources: &'r ResourceTable,
-    upload_buffer: BufferRef<'r>,
-    upload_offset: u64,
-    upload_data: &'data [u8],
-    vertex_buffer: BufferRef<'r>,
-    vertex_offset: u64,
-    first_vertex: u32,
-    vertex_count: u32,
+struct PendingBuffers {
+    updates: Vec<BufferShadowUpdate>,
+}
+
+enum BufferBytes<'pending, 'resource> {
+    Pending(&'pending [u8]),
+    Persistent(&'resource [u8]),
+}
+
+impl BufferBytes<'_, '_> {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Pending(bytes) => bytes,
+            Self::Persistent(bytes) => bytes,
+        }
+    }
+}
+
+impl PendingBuffers {
+    fn new() -> Self {
+        Self {
+            updates: Vec::new(),
+        }
+    }
+
+    fn write(
+        &mut self,
+        resources: &IrResources<'_, '_>,
+        buffer: BufferRef<'_>,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<(), IrSubmitError> {
+        let descriptor = resources.resources.buffer(buffer)?;
+        if !descriptor.usage().contains(BufferUsage::COPY_DST) {
+            return Err(IrSubmitError::InvalidIr(ir::Error::InvalidUsage));
+        }
+        let length = u64::try_from(data.len()).map_err(|_| IrSubmitError::InvalidVertexData)?;
+        let end = offset
+            .checked_add(length)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        if end > descriptor.size() {
+            return Err(IrSubmitError::InvalidVertexData);
+        }
+        let slot = buffer.index;
+        let bytes = if let Some(update) = self.updates.iter_mut().find(|update| update.slot == slot)
+        {
+            &mut update.bytes
+        } else {
+            let size =
+                usize::try_from(descriptor.size()).map_err(|_| IrSubmitError::OutOfMemory)?;
+            let bytes = if let Some(previous) = resources.shadow(buffer)? {
+                Vec::from(previous)
+            } else {
+                let mut initial = Vec::new();
+                initial
+                    .try_reserve_exact(size)
+                    .map_err(|_| IrSubmitError::OutOfMemory)?;
+                initial.resize(size, 0);
+                initial
+            };
+            if bytes.len() != size {
+                return Err(IrSubmitError::InvalidVertexData);
+            }
+            self.updates
+                .try_reserve(1)
+                .map_err(|_| IrSubmitError::OutOfMemory)?;
+            self.updates.push(BufferShadowUpdate { slot, bytes });
+            &mut self
+                .updates
+                .last_mut()
+                .ok_or(IrSubmitError::OutOfMemory)?
+                .bytes
+        };
+        let start = usize::try_from(offset).map_err(|_| IrSubmitError::InvalidVertexData)?;
+        let end = start
+            .checked_add(data.len())
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        let destination = bytes
+            .get_mut(start..end)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        destination.copy_from_slice(data);
+        Ok(())
+    }
+
+    fn bytes<'pending, 'resource, 'r, 'image>(
+        &'pending self,
+        resources: &'resource IrResources<'r, 'image>,
+        buffer: BufferRef<'r>,
+    ) -> Result<BufferBytes<'pending, 'resource>, IrSubmitError> {
+        if let Some(update) = self
+            .updates
+            .iter()
+            .find(|update| update.slot == buffer.index)
+        {
+            return Ok(BufferBytes::Pending(&update.bytes));
+        }
+        resources
+            .shadow(buffer)?
+            .map(BufferBytes::Persistent)
+            .ok_or(IrSubmitError::InvalidVertexData)
+    }
+}
+
+struct ExecutionPlan<'image> {
+    events: Vec<ExecutionEvent<'image>>,
+    buffer_updates: Vec<BufferShadowUpdate>,
+}
+
+enum ExecutionEvent<'image> {
+    Upload(driver::IrTextureSpec, driver::IrTextureUpload),
+    Copy(driver::IrTextureCopy),
+    Pass(ExecutionPass<'image>),
+}
+
+struct ExecutionPass<'image> {
+    target: ExecutionTarget<'image>,
+    submission: IrSubmission,
+}
+
+enum ExecutionTarget<'image> {
+    Mapped(&'image Image),
+    Internal(driver::IrTextureSpec),
+}
+
+struct ActivePass<'r, 'image> {
+    attachment: TextureRef<'r>,
+    target: ExecutionTarget<'image>,
+    submission: IrSubmission,
+    pipeline: Option<RenderPipelineRef<'r>>,
+    vertex_buffer: Option<(BufferRef<'r>, u64)>,
+    index_buffer: Option<(BufferRef<'r>, u64, IndexFormat)>,
+    texture: Option<TextureRef<'r>>,
+    sampler: Option<SamplerRef<'r>>,
+    uniforms: Option<DrawUniforms>,
+    scissor: Option<ir::PixelRect>,
+}
+
+#[derive(Clone, Copy)]
+struct PipelineInfo {
+    state: IrPipelineState,
+    stride: u32,
+    position: VertexAttribute,
+    secondary: Option<VertexAttribute>,
 }
 
 impl Queue {
     /// Validate, lower, and synchronously submit one logical IR command buffer.
     ///
-    /// The initial lowering path intentionally supports one explicit subset:
-    /// one complete-target clear/store render pass containing one non-indexed
-    /// vertex-color triangle-list draw. Unsupported valid IR features return an
-    /// explicit [`IrSubmitError::Unsupported`] error before backend submission.
+    /// The supported subset contains any number of `WriteBuffer` and
+    /// `WriteTexture` commands before one or more mapped presentation render
+    /// passes. Each pass may contain ordered indexed and non-indexed triangle
+    /// draws. Texture copies and internally allocated offscreen targets remain
+    /// unsupported.
     ///
     /// # Arguments
     ///
-    /// * `context` - Context used to materialize backend pipeline state.
-    /// * `target` - Explicit mapping from the logical presentation texture to an image.
+    /// * `context` - Context that created `resources` and this queue.
+    /// * `resources` - Persistent logical-resource cache created by `context`.
     /// * `commands` - Finished logical command buffer to execute.
     ///
     /// # Returns
     ///
-    /// Success after synchronous backend submission, or a validation,
-    /// unsupported-feature, allocation, or backend error.
+    /// Success after synchronous texture upload and ordered backend queue
+    /// submissions, or a validation, unsupported-feature, allocation, or
+    /// backend error. The entire command stream, including every resolved index,
+    /// is validated before the first backend submission.
     pub fn submit_ir<'r, 'image, 'data>(
         &self,
         context: &Context,
-        target: IrPresentTarget<'r, 'image>,
+        resources: &mut IrResources<'r, 'image>,
         commands: &CommandBuffer<'r, 'data>,
     ) -> Result<(), IrSubmitError> {
-        if !core::ptr::eq(target.resources, commands.resources()) {
+        if !core::ptr::eq(resources.resources(), commands.resources()) {
             return Err(IrSubmitError::ResourceTableMismatch);
         }
-
-        let plan = ExecutionPlan::from_commands(target, commands)?;
-        let pipeline = context.create_pipeline(target.image, plan.pipeline)?;
-        let viewport = Viewport::new(target.image.width, target.image.height);
-        let mut render_pass = RenderPass::new(target.image, viewport, plan.clear_color);
-        render_pass.draw_clip_space_vertex_color(&pipeline, &plan.vertices);
-        self.submit(&render_pass).map_err(IrSubmitError::Backend)
+        if resources.context_id != context.backend.context_id()
+            || self.backend.context_id() != resources.context_id
+        {
+            return Err(IrSubmitError::ContextMismatch);
+        }
+        let plan = ExecutionPlan::from_commands(resources, commands)?;
+        register_mapped_images(context, resources)?;
+        for event in &plan.events {
+            match event {
+                ExecutionEvent::Upload(texture, upload) => self.backend.upload_ir_texture(
+                    &context.backend,
+                    &mut resources.backend,
+                    *texture,
+                    upload,
+                ),
+                ExecutionEvent::Copy(copy) => {
+                    self.backend
+                        .copy_ir_texture(&context.backend, &mut resources.backend, *copy)
+                }
+                ExecutionEvent::Pass(pass) => match pass.target {
+                    ExecutionTarget::Mapped(image) => self.backend.submit_ir(
+                        &context.backend,
+                        &mut resources.backend,
+                        &image.backend,
+                        &pass.submission,
+                    ),
+                    ExecutionTarget::Internal(target) => self.backend.submit_ir_internal(
+                        &context.backend,
+                        &mut resources.backend,
+                        target,
+                        &pass.submission,
+                    ),
+                },
+            }
+            .map_err(IrSubmitError::Backend)?;
+        }
+        resources.commit_buffer_updates(plan.buffer_updates);
+        Ok(())
     }
 }
 
-impl ExecutionPlan {
-    fn from_commands<'r, 'image, 'data>(
-        target: IrPresentTarget<'r, 'image>,
+fn register_mapped_images(
+    context: &Context,
+    resources: &mut IrResources<'_, '_>,
+) -> Result<(), IrSubmitError> {
+    for index in 0..resources.images.len() {
+        let (texture, image, registered) = {
+            let mapping = resources
+                .images
+                .get(index)
+                .ok_or(IrSubmitError::ImageNotMapped)?;
+            (mapping.texture, mapping.image, mapping.backend_registered)
+        };
+        if !registered {
+            let descriptor = resources.resources.texture(texture)?;
+            context.backend.map_ir_image(
+                &mut resources.backend,
+                texture_spec(texture, descriptor),
+                &image.backend,
+            )?;
+            if let Some(mapping) = resources.images.get_mut(index) {
+                mapping.backend_registered = true;
+            }
+        }
+    }
+    Ok(())
+}
+
+impl<'image> ExecutionPlan<'image> {
+    fn from_commands<'r, 'data>(
+        resources: &IrResources<'r, 'image>,
         commands: &CommandBuffer<'r, 'data>,
     ) -> Result<Self, IrSubmitError> {
-        let stream = commands.commands();
-        Self::reject_unimplemented_commands(stream)?;
-        Self::validate_command_counts(stream)?;
-        if stream.len() != 7 {
+        let mut pending_buffers = PendingBuffers::new();
+        let mut events = Vec::new();
+        let mut active = None;
+        let mut seen_pass = false;
+
+        for command in commands.commands() {
+            match command {
+                Command::CopyTextureToTexture {
+                    source,
+                    source_rect,
+                    destination,
+                    destination_rect,
+                } if active.is_none() => {
+                    let source_desc = resources.resources.texture(*source)?;
+                    let destination_desc = resources.resources.texture(*destination)?;
+                    if !source_desc.usage().contains(TextureUsage::COPY_SRC)
+                        || !destination_desc.usage().contains(TextureUsage::COPY_DST)
+                        || source_desc.format() != destination_desc.format()
+                        || !source_rect.same_extent(*destination_rect)
+                        || !source_rect.is_within(source_desc.extent())
+                        || !destination_rect.is_within(destination_desc.extent())
+                    {
+                        return Err(IrSubmitError::InvalidIr(ir::Error::InvalidUsage));
+                    }
+                    let source_spec = texture_spec(*source, source_desc);
+                    let destination_spec = texture_spec(*destination, destination_desc);
+                    if !materializable_texture(source_spec)
+                        || !materializable_texture(destination_spec)
+                    {
+                        return Err(IrSubmitError::Unsupported(
+                            UnsupportedIrFeature::TargetUsage,
+                        ));
+                    }
+                    events
+                        .try_reserve(1)
+                        .map_err(|_| IrSubmitError::OutOfMemory)?;
+                    events.push(ExecutionEvent::Copy(driver::IrTextureCopy {
+                        source: source_spec,
+                        source_rect: ir_rect(*source_rect),
+                        destination: destination_spec,
+                        destination_rect: ir_rect(*destination_rect),
+                    }));
+                }
+                Command::WriteBuffer {
+                    buffer,
+                    offset,
+                    data,
+                } if !seen_pass && active.is_none() => {
+                    pending_buffers.write(resources, *buffer, *offset, data)?;
+                }
+                Command::WriteTexture { texture, write } if active.is_none() => {
+                    let descriptor = resources.resources.texture(*texture)?;
+                    if !descriptor.usage().contains(TextureUsage::COPY_DST) {
+                        return Err(IrSubmitError::InvalidIr(ir::Error::InvalidUsage));
+                    }
+                    let spec = texture_spec(*texture, descriptor);
+                    if !materializable_texture(spec) {
+                        return Err(IrSubmitError::Unsupported(
+                            UnsupportedIrFeature::TargetUsage,
+                        ));
+                    }
+                    if resources
+                        .images
+                        .iter()
+                        .any(|mapping| mapping.texture == *texture)
+                    {
+                        return Err(IrSubmitError::Unsupported(
+                            UnsupportedIrFeature::TextureUpload,
+                        ));
+                    }
+                    events
+                        .try_reserve(1)
+                        .map_err(|_| IrSubmitError::OutOfMemory)?;
+                    events.push(ExecutionEvent::Upload(
+                        spec,
+                        convert_texture_upload(spec, *write)?,
+                    ));
+                }
+                Command::BeginRenderPass(desc) if active.is_none() => {
+                    let descriptor = resources.resources.texture(desc.target())?;
+                    if descriptor.format() != TextureFormat::Bgra8Unorm {
+                        return Err(IrSubmitError::Unsupported(
+                            UnsupportedIrFeature::TargetFormat,
+                        ));
+                    }
+                    let target = match resources.mapped_image(desc.target()) {
+                        Ok(image) => {
+                            if !area_within_image(desc.area(), image) {
+                                return Err(IrSubmitError::InvalidIr(ir::Error::OutOfBounds));
+                            }
+                            ExecutionTarget::Mapped(image)
+                        }
+                        Err(IrSubmitError::ImageNotMapped) => {
+                            let spec = texture_spec(desc.target(), descriptor);
+                            if spec.present || !spec.render_attachment {
+                                return Err(IrSubmitError::ImageNotMapped);
+                            }
+                            ExecutionTarget::Internal(spec)
+                        }
+                        Err(error) => return Err(error),
+                    };
+                    if !desc.area().is_within(descriptor.extent()) {
+                        return Err(IrSubmitError::InvalidIr(ir::Error::OutOfBounds));
+                    }
+                    active = Some(ActivePass {
+                        attachment: desc.target(),
+                        target,
+                        submission: IrSubmission {
+                            clear_color: match desc.load() {
+                                LoadOp::Clear(color) => Some(color.components()),
+                                LoadOp::Load | LoadOp::DontCare => None,
+                            },
+                            render_area: IrRect {
+                                x: desc.area().x(),
+                                y: desc.area().y(),
+                                width: desc.area().width(),
+                                height: desc.area().height(),
+                            },
+                            vertices: Vec::new(),
+                            draws: Vec::new(),
+                            texture_uploads: Vec::new(),
+                        },
+                        pipeline: None,
+                        vertex_buffer: None,
+                        index_buffer: None,
+                        texture: None,
+                        sampler: None,
+                        uniforms: None,
+                        scissor: None,
+                    });
+                    seen_pass = true;
+                }
+                Command::EndRenderPass => {
+                    let pass = active.take().ok_or(IrSubmitError::Unsupported(
+                        UnsupportedIrFeature::CommandSequence,
+                    ))?;
+                    if pass.submission.draws.is_empty() {
+                        return Err(IrSubmitError::Unsupported(
+                            UnsupportedIrFeature::CommandSequence,
+                        ));
+                    }
+                    events
+                        .try_reserve(1)
+                        .map_err(|_| IrSubmitError::OutOfMemory)?;
+                    events.push(ExecutionEvent::Pass(ExecutionPass {
+                        target: pass.target,
+                        submission: pass.submission,
+                    }));
+                }
+                Command::SetPipeline(reference) => {
+                    active_pass_mut(&mut active)?.pipeline = Some(*reference)
+                }
+                Command::SetVertexBuffer { buffer, offset } => {
+                    active_pass_mut(&mut active)?.vertex_buffer = Some((*buffer, *offset));
+                }
+                Command::SetIndexBuffer {
+                    buffer,
+                    offset,
+                    format,
+                } => {
+                    active_pass_mut(&mut active)?.index_buffer = Some((*buffer, *offset, *format));
+                }
+                Command::SetTexture(reference) => {
+                    active_pass_mut(&mut active)?.texture = Some(*reference)
+                }
+                Command::SetSampler(reference) => {
+                    active_pass_mut(&mut active)?.sampler = Some(*reference)
+                }
+                Command::SetUniforms(value) => {
+                    active_pass_mut(&mut active)?.uniforms = Some(*value)
+                }
+                Command::SetScissor(value) => {
+                    let pass = active_pass_mut(&mut active)?;
+                    if let Some(rectangle) = value {
+                        if !rect_within(*rectangle, pass.submission.render_area) {
+                            return Err(IrSubmitError::InvalidIr(ir::Error::OutOfBounds));
+                        }
+                    }
+                    pass.scissor = *value;
+                }
+                Command::Draw {
+                    vertex_count,
+                    first_vertex,
+                } => {
+                    let pass = active_pass_mut(&mut active)?;
+                    let decoded = decode_draw_vertices(
+                        resources,
+                        &pending_buffers,
+                        pass,
+                        *first_vertex,
+                        *vertex_count,
+                    )?;
+                    append_draw(pass, decoded)?;
+                }
+                Command::DrawIndexed {
+                    index_count,
+                    first_index,
+                    base_vertex,
+                } => {
+                    let pass = active_pass_mut(&mut active)?;
+                    let decoded = decode_indexed_draw_vertices(
+                        resources,
+                        &pending_buffers,
+                        pass,
+                        *first_index,
+                        *index_count,
+                        *base_vertex,
+                    )?;
+                    append_draw(pass, decoded)?;
+                }
+                _ => {
+                    return Err(IrSubmitError::Unsupported(
+                        UnsupportedIrFeature::CommandSequence,
+                    ));
+                }
+            }
+        }
+        if active.is_some() || events.is_empty() {
             return Err(IrSubmitError::Unsupported(
                 UnsupportedIrFeature::CommandSequence,
             ));
         }
-
-        let (upload_buffer, upload_offset, upload_data) = match &stream[0] {
-            Command::WriteBuffer {
-                buffer,
-                offset,
-                data,
-            } => (*buffer, *offset, *data),
-            _ => return Err(Self::unsupported_sequence()),
-        };
-        let pass = match &stream[1] {
-            Command::BeginRenderPass(pass) => *pass,
-            _ => return Err(Self::unsupported_sequence()),
-        };
-        let pipeline = match &stream[2] {
-            Command::SetPipeline(pipeline) => *pipeline,
-            _ => return Err(Self::unsupported_sequence()),
-        };
-        let (vertex_buffer, vertex_offset) = match &stream[3] {
-            Command::SetVertexBuffer { buffer, offset } => (*buffer, *offset),
-            _ => return Err(Self::unsupported_sequence()),
-        };
-        let uniforms = match &stream[4] {
-            Command::SetUniforms(uniforms) => *uniforms,
-            _ => return Err(Self::unsupported_sequence()),
-        };
-        let (vertex_count, first_vertex) = match &stream[5] {
-            Command::Draw {
-                vertex_count,
-                first_vertex,
-            } => (*vertex_count, *first_vertex),
-            _ => return Err(Self::unsupported_sequence()),
-        };
-        if !matches!(stream[6], Command::EndRenderPass) {
-            return Err(Self::unsupported_sequence());
-        }
-
-        let clear_color = Self::validate_pass(target, pass)?;
-        let pipeline_description =
-            Self::validate_pipeline(target.resources, pipeline, vertex_count)?;
-        Self::validate_uniforms(uniforms)?;
-        let vertices = Self::decode_vertices(VertexDecodeRequest {
-            resources: target.resources,
-            upload_buffer,
-            upload_offset,
-            upload_data,
-            vertex_buffer,
-            vertex_offset,
-            first_vertex,
-            vertex_count,
-        })?;
         Ok(Self {
-            clear_color,
-            pipeline: pipeline_description,
-            vertices,
+            events,
+            buffer_updates: pending_buffers.updates,
         })
     }
+}
 
-    fn reject_unimplemented_commands(stream: &[Command<'_, '_>]) -> Result<(), IrSubmitError> {
-        for command in stream {
-            let unsupported = match command {
-                Command::WriteTexture { .. } => Some(UnsupportedIrFeature::TextureUpload),
-                Command::CopyTextureToTexture { .. } => Some(UnsupportedIrFeature::TextureCopy),
-                Command::SetIndexBuffer { .. } | Command::DrawIndexed { .. } => {
-                    Some(UnsupportedIrFeature::IndexedDrawing)
-                }
-                Command::SetTexture(_) => Some(UnsupportedIrFeature::TextureSampling),
-                Command::SetSampler(_) => Some(UnsupportedIrFeature::Sampler),
-                Command::SetScissor(_) => Some(UnsupportedIrFeature::Scissor),
-                _ => None,
-            };
-            if let Some(feature) = unsupported {
-                return Err(IrSubmitError::Unsupported(feature));
-            }
-        }
-        Ok(())
+struct DecodedDraw {
+    vertices: Vec<IrVertex>,
+    pipeline: IrPipelineState,
+    texture: Option<driver::IrTextureSpec>,
+    sampler: Option<IrSamplerState>,
+    uniforms: IrUniforms,
+    scissor: IrRect,
+}
+
+fn active_pass_mut<'pass, 'r, 'image>(
+    active: &'pass mut Option<ActivePass<'r, 'image>>,
+) -> Result<&'pass mut ActivePass<'r, 'image>, IrSubmitError> {
+    active.as_mut().ok_or(IrSubmitError::Unsupported(
+        UnsupportedIrFeature::CommandSequence,
+    ))
+}
+
+fn area_within_image(area: ir::PixelRect, image: &Image) -> bool {
+    area.x()
+        .checked_add(area.width())
+        .is_some_and(|right| right <= image.width)
+        && area
+            .y()
+            .checked_add(area.height())
+            .is_some_and(|bottom| bottom <= image.height)
+}
+
+fn decode_draw_vertices(
+    resources: &IrResources<'_, '_>,
+    pending_buffers: &PendingBuffers,
+    pass: &ActivePass<'_, '_>,
+    first_vertex: u32,
+    vertex_count: u32,
+) -> Result<DecodedDraw, IrSubmitError> {
+    let (info, buffer, offset, uniforms, texture, sampler) = draw_state(resources, pass)?;
+    let bytes = pending_buffers.bytes(resources, buffer)?;
+    let vertices = decode_vertices(
+        resources.resources,
+        bytes.as_slice(),
+        buffer,
+        offset,
+        first_vertex,
+        vertex_count,
+        info,
+    )?;
+    Ok(DecodedDraw {
+        vertices,
+        pipeline: info.state,
+        texture,
+        sampler,
+        uniforms,
+        scissor: pass_scissor(pass),
+    })
+}
+
+fn decode_indexed_draw_vertices(
+    resources: &IrResources<'_, '_>,
+    pending_buffers: &PendingBuffers,
+    pass: &ActivePass<'_, '_>,
+    first_index: u32,
+    index_count: u32,
+    base_vertex: i32,
+) -> Result<DecodedDraw, IrSubmitError> {
+    if index_count == 0 || index_count % 3 != 0 {
+        return Err(IrSubmitError::InvalidVertexData);
     }
-
-    fn validate_command_counts(stream: &[Command<'_, '_>]) -> Result<(), IrSubmitError> {
-        let uploads = stream
-            .iter()
-            .filter(|command| matches!(command, Command::WriteBuffer { .. }))
-            .count();
-        let passes = stream
-            .iter()
-            .filter(|command| matches!(command, Command::BeginRenderPass(_)))
-            .count();
-        let draws = stream
-            .iter()
-            .filter(|command| matches!(command, Command::Draw { .. }))
-            .count();
-        if uploads != 1 {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::MultipleBufferUploads,
-            ));
-        }
-        if passes != 1 {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::MultipleRenderPasses,
-            ));
-        }
-        if draws != 1 {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::MultipleDraws,
-            ));
-        }
-        Ok(())
+    let (info, vertex_buffer, vertex_offset, uniforms, texture, sampler) =
+        draw_state(resources, pass)?;
+    let (index_buffer, index_offset, index_format) = pass
+        .index_buffer
+        .ok_or(IrSubmitError::InvalidIr(ir::Error::IndexBufferNotSet))?;
+    let index_descriptor = resources.resources.buffer(index_buffer)?;
+    if !index_descriptor.usage().contains(BufferUsage::INDEX) {
+        return Err(IrSubmitError::InvalidIr(ir::Error::InvalidUsage));
     }
-
-    fn validate_pass(
-        target: IrPresentTarget<'_, '_>,
-        pass: RenderPassDesc<'_>,
-    ) -> Result<Color, IrSubmitError> {
-        if pass.target() != target.texture {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::MultipleRenderPasses,
-            ));
-        }
-        let area = pass.area();
-        if area.x() != 0
-            || area.y() != 0
-            || area.width() != target.image.width
-            || area.height() != target.image.height
-        {
-            return Err(IrSubmitError::Unsupported(UnsupportedIrFeature::RenderArea));
-        }
-        let clear = match pass.load() {
-            LoadOp::Clear(color) => color,
-            LoadOp::Load | LoadOp::DontCare => {
-                return Err(IrSubmitError::Unsupported(
-                    UnsupportedIrFeature::LoadOperation,
-                ));
-            }
+    let index_bytes = pending_buffers.bytes(resources, index_buffer)?;
+    let vertex_bytes = pending_buffers.bytes(resources, vertex_buffer)?;
+    let index_size =
+        usize::try_from(index_format.byte_size()).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    let first = usize::try_from(first_index).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    let count = usize::try_from(index_count).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    let start = usize::try_from(index_offset)
+        .ok()
+        .and_then(|offset| {
+            first
+                .checked_mul(index_size)
+                .and_then(|value| offset.checked_add(value))
+        })
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let end = start
+        .checked_add(
+            count
+                .checked_mul(index_size)
+                .ok_or(IrSubmitError::InvalidVertexData)?,
+        )
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let encoded = index_bytes
+        .as_slice()
+        .get(start..end)
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let mut vertices = Vec::new();
+    vertices
+        .try_reserve_exact(count)
+        .map_err(|_| IrSubmitError::OutOfMemory)?;
+    for item in encoded.chunks_exact(index_size) {
+        let index = match index_format {
+            IndexFormat::Uint16 => u32::from(read_u16(item, 0)?),
+            IndexFormat::Uint32 => read_u32(item, 0)?,
         };
-        if pass.store() != StoreOp::Store {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::StoreOperation,
-            ));
+        let resolved = i64::from(index) + i64::from(base_vertex);
+        if resolved < 0 {
+            return Err(IrSubmitError::InvalidVertexData);
         }
-        let [red, green, blue, alpha] = clear.components();
-        if ![red, green, blue, alpha]
-            .iter()
-            .all(|component| (0.0..=1.0).contains(component))
-        {
-            return Err(IrSubmitError::Unsupported(UnsupportedIrFeature::ClearColor));
-        }
-        Ok(Color::rgba(red, green, blue, alpha))
-    }
-
-    fn validate_pipeline(
-        resources: &ResourceTable,
-        pipeline: RenderPipelineRef<'_>,
-        vertex_count: u32,
-    ) -> Result<PipelineDesc, IrSubmitError> {
-        let (target_format, topology, layout_valid, fragment, blend, raster) = resources
-            .with_pipeline(pipeline, |descriptor| {
-                let attributes = descriptor.vertex_buffer().attributes();
-                let layout_valid = usize::try_from(descriptor.vertex_buffer().stride()).ok()
-                    == Some(size_of::<VertexClip4Color3>())
-                    && attributes.len() == 2
-                    && attributes[0].location() == 0
-                    && attributes[0].format() == VertexFormat::Float32x4
-                    && attributes[0].offset() == 0
-                    && attributes[1].location() == 1
-                    && attributes[1].format() == VertexFormat::Float32x3
-                    && attributes[1].offset() == 16;
-                (
-                    descriptor.target_format(),
-                    descriptor.topology(),
-                    layout_valid,
-                    descriptor.fragment(),
-                    descriptor.blend(),
-                    descriptor.raster(),
-                )
-            })?;
-        if target_format != TextureFormat::Bgra8Unorm {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::PipelineTargetFormat,
-            ));
-        }
-        if topology != PrimitiveTopology::TriangleList {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::PrimitiveTopology,
-            ));
-        }
-        if !layout_valid {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::VertexLayout,
-            ));
-        }
-        if fragment != FragmentProgram::VertexColor {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::FragmentProgram,
-            ));
-        }
-        if blend != BlendState::REPLACE {
-            return Err(IrSubmitError::Unsupported(UnsupportedIrFeature::BlendState));
-        }
-        let max_vertices =
-            usize::try_from(vertex_count).map_err(|_| IrSubmitError::InvalidVertexData)?;
-        let cull_mode = match raster.cull_mode() {
-            ir::CullMode::None => CullMode::None,
-            ir::CullMode::Front => CullMode::Front,
-            ir::CullMode::Back => CullMode::Back,
-        };
-        let front_face = match raster.front_face() {
-            ir::FrontFace::Clockwise => FrontFace::Clockwise,
-            ir::FrontFace::CounterClockwise => FrontFace::CounterClockwise,
-        };
-        Ok(PipelineDesc::clip_space_vertex_color(max_vertices)
-            .with_cull_mode(cull_mode)
-            .with_front_face(front_face))
-    }
-
-    fn validate_uniforms(uniforms: DrawUniforms) -> Result<(), IrSubmitError> {
-        if uniforms.transform() != ir::Transform::identity()
-            || uniforms.color().components() != [1.0, 1.0, 1.0, 1.0]
-        {
-            Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::DrawUniforms,
-            ))
-        } else {
-            Ok(())
-        }
-    }
-
-    fn decode_vertices(
-        request: VertexDecodeRequest<'_, '_>,
-    ) -> Result<Vec<VertexClip4Color3>, IrSubmitError> {
-        let VertexDecodeRequest {
-            resources,
-            upload_buffer,
-            upload_offset,
-            upload_data,
+        let vertex_index =
+            usize::try_from(resolved).map_err(|_| IrSubmitError::InvalidVertexData)?;
+        vertices.push(decode_vertex(
+            resources.resources,
+            vertex_bytes.as_slice(),
             vertex_buffer,
             vertex_offset,
-            first_vertex,
-            vertex_count,
-        } = request;
-        if upload_buffer != vertex_buffer || upload_offset != 0 {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::VertexBuffer,
-            ));
-        }
-        let descriptor = resources.buffer(vertex_buffer)?;
-        let supported_usage = BufferUsage::VERTEX | BufferUsage::COPY_DST;
-        let upload_len =
-            u64::try_from(upload_data.len()).map_err(|_| IrSubmitError::InvalidVertexData)?;
-        if descriptor.usage() != supported_usage || descriptor.size() != upload_len {
-            return Err(IrSubmitError::Unsupported(
-                UnsupportedIrFeature::VertexBuffer,
-            ));
-        }
+            vertex_index,
+            info,
+        )?);
+    }
+    if vertices.len() != count {
+        return Err(IrSubmitError::InvalidVertexData);
+    }
+    Ok(DecodedDraw {
+        vertices,
+        pipeline: info.state,
+        texture,
+        sampler,
+        uniforms,
+        scissor: pass_scissor(pass),
+    })
+}
 
-        let stride = size_of::<VertexClip4Color3>();
-        let first = usize::try_from(first_vertex).map_err(|_| IrSubmitError::InvalidVertexData)?;
-        let count = usize::try_from(vertex_count).map_err(|_| IrSubmitError::InvalidVertexData)?;
-        let base = usize::try_from(vertex_offset)
-            .ok()
-            .and_then(|offset| {
-                first
-                    .checked_mul(stride)
-                    .and_then(|first_bytes| offset.checked_add(first_bytes))
-            })
-            .ok_or(IrSubmitError::InvalidVertexData)?;
-        let byte_len = count
-            .checked_mul(stride)
-            .ok_or(IrSubmitError::InvalidVertexData)?;
-        let end = base
-            .checked_add(byte_len)
-            .ok_or(IrSubmitError::InvalidVertexData)?;
-        let selected = upload_data
-            .get(base..end)
-            .ok_or(IrSubmitError::InvalidVertexData)?;
+fn draw_state<'r>(
+    resources: &IrResources<'r, '_>,
+    pass: &ActivePass<'r, '_>,
+) -> Result<
+    (
+        PipelineInfo,
+        BufferRef<'r>,
+        u64,
+        IrUniforms,
+        Option<driver::IrTextureSpec>,
+        Option<IrSamplerState>,
+    ),
+    IrSubmitError,
+> {
+    let pipeline = pass
+        .pipeline
+        .ok_or(IrSubmitError::InvalidIr(ir::Error::PipelineNotSet))?;
+    let info = pipeline_info(resources.resources, pipeline)?;
+    let (buffer, offset) = pass
+        .vertex_buffer
+        .ok_or(IrSubmitError::InvalidIr(ir::Error::VertexBufferNotSet))?;
+    let uniforms = pass
+        .uniforms
+        .ok_or(IrSubmitError::InvalidIr(ir::Error::UniformsNotSet))?;
+    let (texture, sampler) =
+        texture_binding(resources.resources, info, pass.texture, pass.sampler)?;
+    if pass
+        .texture
+        .is_some_and(|texture| texture == pass.attachment)
+    {
+        return Err(IrSubmitError::InvalidIr(ir::Error::AttachmentFeedback));
+    }
+    Ok((
+        info,
+        buffer,
+        offset,
+        uniform_state(uniforms),
+        texture,
+        sampler,
+    ))
+}
 
-        let mut vertices = Vec::new();
-        vertices
-            .try_reserve_exact(count)
-            .map_err(|_| IrSubmitError::OutOfMemory)?;
-        for encoded in selected.chunks_exact(stride) {
-            let mut cursor = 0usize;
-            let clip_position = [
-                Self::read_f32(encoded, &mut cursor)?,
-                Self::read_f32(encoded, &mut cursor)?,
-                Self::read_f32(encoded, &mut cursor)?,
-                Self::read_f32(encoded, &mut cursor)?,
-            ];
-            let color = [
-                Self::read_f32(encoded, &mut cursor)?,
-                Self::read_f32(encoded, &mut cursor)?,
-                Self::read_f32(encoded, &mut cursor)?,
-            ];
-            if !clip_position.iter().all(|component| component.is_finite())
-                || !color
-                    .iter()
-                    .all(|component| component.is_finite() && (0.0..=1.0).contains(component))
+fn pass_scissor(pass: &ActivePass<'_, '_>) -> IrRect {
+    match pass.scissor {
+        Some(value) => IrRect {
+            x: value.x(),
+            y: value.y(),
+            width: value.width(),
+            height: value.height(),
+        },
+        None => pass.submission.render_area,
+    }
+}
+
+fn append_draw(pass: &mut ActivePass<'_, '_>, draw: DecodedDraw) -> Result<(), IrSubmitError> {
+    let start_vertex = pass.submission.vertices.len();
+    let new_len =
+        start_vertex
+            .checked_add(draw.vertices.len())
+            .ok_or(IrSubmitError::Unsupported(
+                UnsupportedIrFeature::CommandStream,
+            ))?;
+    if new_len > MAX_IR_VERTICES {
+        return Err(IrSubmitError::Unsupported(
+            UnsupportedIrFeature::CommandStream,
+        ));
+    }
+    pass.submission
+        .vertices
+        .try_reserve(draw.vertices.len())
+        .map_err(|_| IrSubmitError::OutOfMemory)?;
+    pass.submission.vertices.extend(draw.vertices);
+    pass.submission
+        .draws
+        .try_reserve(1)
+        .map_err(|_| IrSubmitError::OutOfMemory)?;
+    pass.submission.draws.push(IrDraw {
+        start_vertex,
+        vertex_count: new_len - start_vertex,
+        pipeline: draw.pipeline,
+        texture: draw.texture,
+        sampler: draw.sampler,
+        uniforms: draw.uniforms,
+        scissor: draw.scissor,
+    });
+    Ok(())
+}
+
+fn pipeline_info(
+    resources: &ResourceTable,
+    reference: RenderPipelineRef<'_>,
+) -> Result<PipelineInfo, IrSubmitError> {
+    let (target, topology, fragment, blend, raster, stride, position, secondary) = resources
+        .with_pipeline(reference, |descriptor| {
+            let layout = descriptor.vertex_buffer();
+            let position = layout
+                .attributes()
+                .iter()
+                .find(|attribute| attribute.location() == 0)
+                .copied();
+            let secondary = layout
+                .attributes()
+                .iter()
+                .find(|attribute| attribute.location() == 1)
+                .copied();
+            (
+                descriptor.target_format(),
+                descriptor.topology(),
+                descriptor.fragment(),
+                descriptor.blend(),
+                descriptor.raster(),
+                layout.stride(),
+                position,
+                secondary,
+            )
+        })?;
+    if target != TextureFormat::Bgra8Unorm {
+        return Err(IrSubmitError::Unsupported(
+            UnsupportedIrFeature::PipelineTargetFormat,
+        ));
+    }
+    if topology != PrimitiveTopology::TriangleList {
+        return Err(IrSubmitError::Unsupported(
+            UnsupportedIrFeature::PrimitiveTopology,
+        ));
+    }
+    let position = position.ok_or(IrSubmitError::Unsupported(
+        UnsupportedIrFeature::VertexLayout,
+    ))?;
+    if !matches!(
+        position.format(),
+        VertexFormat::Float32x2 | VertexFormat::Float32x3 | VertexFormat::Float32x4
+    ) {
+        return Err(IrSubmitError::Unsupported(
+            UnsupportedIrFeature::VertexLayout,
+        ));
+    }
+    let secondary_valid = match fragment {
+        FragmentProgram::Solid => true,
+        FragmentProgram::VertexColor => matches!(
+            secondary.map(VertexAttribute::format),
+            Some(VertexFormat::Float32x3 | VertexFormat::Float32x4 | VertexFormat::Unorm8x4)
+        ),
+        FragmentProgram::Texture(_) => matches!(
+            secondary.map(VertexAttribute::format),
+            Some(VertexFormat::Float32x2)
+        ),
+    };
+    if !secondary_valid {
+        return Err(IrSubmitError::Unsupported(
+            UnsupportedIrFeature::VertexLayout,
+        ));
+    }
+    Ok(PipelineInfo {
+        state: IrPipelineState {
+            slot: reference.index,
+            fragment: fragment_program(fragment),
+            blend: blend_state(blend),
+            cull_mode: match raster.cull_mode() {
+                ir::CullMode::None => IrCullMode::None,
+                ir::CullMode::Front => IrCullMode::Front,
+                ir::CullMode::Back => IrCullMode::Back,
+            },
+            front_face: match raster.front_face() {
+                ir::FrontFace::Clockwise => IrFrontFace::Clockwise,
+                ir::FrontFace::CounterClockwise => IrFrontFace::CounterClockwise,
+            },
+        },
+        stride,
+        position,
+        secondary,
+    })
+}
+
+fn texture_binding(
+    resources: &ResourceTable,
+    pipeline: PipelineInfo,
+    texture: Option<TextureRef<'_>>,
+    sampler: Option<SamplerRef<'_>>,
+) -> Result<(Option<driver::IrTextureSpec>, Option<IrSamplerState>), IrSubmitError> {
+    if !matches!(
+        pipeline.state.fragment,
+        IrFragmentProgram::TextureRgba
+            | IrFragmentProgram::TextureRgbIgnoreAlpha
+            | IrFragmentProgram::TextureAlphaMask
+    ) {
+        return Ok((None, None));
+    }
+    let texture = texture.ok_or(IrSubmitError::InvalidIr(ir::Error::TextureBindingNotSet))?;
+    let sampler = sampler.ok_or(IrSubmitError::InvalidIr(ir::Error::TextureBindingNotSet))?;
+    let descriptor = resources.texture(texture)?;
+    if !descriptor.usage().contains(TextureUsage::SAMPLED) {
+        return Err(IrSubmitError::InvalidIr(ir::Error::InvalidUsage));
+    }
+    if descriptor.format() == TextureFormat::R8Unorm
+        && !matches!(pipeline.state.fragment, IrFragmentProgram::TextureAlphaMask)
+    {
+        return Err(IrSubmitError::Unsupported(
+            UnsupportedIrFeature::FragmentProgram,
+        ));
+    }
+    let sampler_descriptor = resources.sampler(sampler)?;
+    Ok((
+        Some(texture_spec(texture, descriptor)),
+        Some(sampler_state(sampler_descriptor, sampler.index)),
+    ))
+}
+
+fn sampler_state(descriptor: SamplerDesc, slot: usize) -> IrSamplerState {
+    IrSamplerState {
+        slot,
+        min_filter: match descriptor.min_filter() {
+            FilterMode::Nearest => IrFilterMode::Nearest,
+            FilterMode::Linear => IrFilterMode::Linear,
+        },
+        mag_filter: match descriptor.mag_filter() {
+            FilterMode::Nearest => IrFilterMode::Nearest,
+            FilterMode::Linear => IrFilterMode::Linear,
+        },
+        address_u: match descriptor.address_u() {
+            AddressMode::ClampToEdge => IrAddressMode::ClampToEdge,
+            AddressMode::Repeat => IrAddressMode::Repeat,
+            AddressMode::MirrorRepeat => IrAddressMode::MirrorRepeat,
+        },
+        address_v: match descriptor.address_v() {
+            AddressMode::ClampToEdge => IrAddressMode::ClampToEdge,
+            AddressMode::Repeat => IrAddressMode::Repeat,
+            AddressMode::MirrorRepeat => IrAddressMode::MirrorRepeat,
+        },
+    }
+}
+
+fn decode_vertices(
+    resources: &ResourceTable,
+    bytes: &[u8],
+    buffer: BufferRef<'_>,
+    vertex_offset: u64,
+    first_vertex: u32,
+    vertex_count: u32,
+    pipeline: PipelineInfo,
+) -> Result<Vec<IrVertex>, IrSubmitError> {
+    let count = usize::try_from(vertex_count).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    let first = usize::try_from(first_vertex).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    if vertex_count == 0 || vertex_count % 3 != 0 {
+        return Err(IrSubmitError::InvalidVertexData);
+    }
+    let mut vertices = Vec::new();
+    vertices
+        .try_reserve_exact(count)
+        .map_err(|_| IrSubmitError::OutOfMemory)?;
+    for relative in 0..count {
+        let vertex_index = first
+            .checked_add(relative)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        vertices.push(decode_vertex(
+            resources,
+            bytes,
+            buffer,
+            vertex_offset,
+            vertex_index,
+            pipeline,
+        )?);
+    }
+    if vertices.len() != count {
+        return Err(IrSubmitError::InvalidVertexData);
+    }
+    Ok(vertices)
+}
+
+fn decode_vertex(
+    resources: &ResourceTable,
+    bytes: &[u8],
+    buffer: BufferRef<'_>,
+    vertex_offset: u64,
+    vertex_index: usize,
+    pipeline: PipelineInfo,
+) -> Result<IrVertex, IrSubmitError> {
+    let descriptor = resources.buffer(buffer)?;
+    if !descriptor.usage().contains(BufferUsage::VERTEX) {
+        return Err(IrSubmitError::InvalidIr(ir::Error::InvalidUsage));
+    }
+    let stride = usize::try_from(pipeline.stride).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    let start = usize::try_from(vertex_offset)
+        .ok()
+        .and_then(|offset| {
+            vertex_index
+                .checked_mul(stride)
+                .and_then(|value| offset.checked_add(value))
+        })
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let end = start
+        .checked_add(stride)
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let record = bytes
+        .get(start..end)
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let position = decode_position(record, pipeline.position)?;
+    let (color, uv) = decode_secondary(record, pipeline.secondary, pipeline.state.fragment)?;
+    Ok(IrVertex {
+        position,
+        color,
+        uv,
+    })
+}
+
+fn decode_position(record: &[u8], attribute: VertexAttribute) -> Result<[f32; 4], IrSubmitError> {
+    let offset =
+        usize::try_from(attribute.offset()).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    let position = match attribute.format() {
+        VertexFormat::Float32x2 => [
+            read_f32(record, offset)?,
+            read_f32(record, offset + 4)?,
+            0.0,
+            1.0,
+        ],
+        VertexFormat::Float32x3 => [
+            read_f32(record, offset)?,
+            read_f32(record, offset + 4)?,
+            read_f32(record, offset + 8)?,
+            1.0,
+        ],
+        VertexFormat::Float32x4 => [
+            read_f32(record, offset)?,
+            read_f32(record, offset + 4)?,
+            read_f32(record, offset + 8)?,
+            read_f32(record, offset + 12)?,
+        ],
+        VertexFormat::Unorm8x4 => return Err(IrSubmitError::InvalidVertexData),
+    };
+    if !position.iter().all(|value| value.is_finite()) {
+        return Err(IrSubmitError::InvalidVertexData);
+    }
+    Ok(position)
+}
+
+fn decode_secondary(
+    record: &[u8],
+    attribute: Option<VertexAttribute>,
+    fragment: IrFragmentProgram,
+) -> Result<([f32; 4], [f32; 2]), IrSubmitError> {
+    let Some(attribute) = attribute else {
+        return Ok(([1.0; 4], [0.0; 2]));
+    };
+    let offset =
+        usize::try_from(attribute.offset()).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    match fragment {
+        IrFragmentProgram::Solid => Ok(([1.0; 4], [0.0; 2])),
+        IrFragmentProgram::VertexColor => {
+            let color = match attribute.format() {
+                VertexFormat::Float32x3 => [
+                    read_f32(record, offset)?,
+                    read_f32(record, offset + 4)?,
+                    read_f32(record, offset + 8)?,
+                    1.0,
+                ],
+                VertexFormat::Float32x4 => [
+                    read_f32(record, offset)?,
+                    read_f32(record, offset + 4)?,
+                    read_f32(record, offset + 8)?,
+                    read_f32(record, offset + 12)?,
+                ],
+                VertexFormat::Unorm8x4 => [
+                    read_u8(record, offset)? as f32 / 255.0,
+                    read_u8(record, offset + 1)? as f32 / 255.0,
+                    read_u8(record, offset + 2)? as f32 / 255.0,
+                    read_u8(record, offset + 3)? as f32 / 255.0,
+                ],
+                VertexFormat::Float32x2 => return Err(IrSubmitError::InvalidVertexData),
+            };
+            if !color
+                .iter()
+                .all(|value| value.is_finite() && (0.0..=1.0).contains(value))
             {
                 return Err(IrSubmitError::InvalidVertexData);
             }
-            vertices.push(VertexClip4Color3::new(clip_position, color));
+            Ok((color, [0.0; 2]))
         }
-        if vertices.len() != count {
-            return Err(IrSubmitError::InvalidVertexData);
+        IrFragmentProgram::TextureRgba
+        | IrFragmentProgram::TextureRgbIgnoreAlpha
+        | IrFragmentProgram::TextureAlphaMask => {
+            if attribute.format() != VertexFormat::Float32x2 {
+                return Err(IrSubmitError::InvalidVertexData);
+            }
+            let uv = [read_f32(record, offset)?, read_f32(record, offset + 4)?];
+            if !uv.iter().all(|value| value.is_finite()) {
+                return Err(IrSubmitError::InvalidVertexData);
+            }
+            Ok(([1.0; 4], uv))
         }
-        Ok(vertices)
     }
+}
 
-    fn read_f32(bytes: &[u8], cursor: &mut usize) -> Result<f32, IrSubmitError> {
-        let end = cursor
-            .checked_add(size_of::<f32>())
-            .ok_or(IrSubmitError::InvalidVertexData)?;
-        let encoded = bytes
-            .get(*cursor..end)
-            .ok_or(IrSubmitError::InvalidVertexData)?;
-        let encoded: [u8; 4] = encoded
-            .try_into()
-            .map_err(|_| IrSubmitError::InvalidVertexData)?;
-        *cursor = end;
-        Ok(f32::from_le_bytes(encoded))
-    }
+fn read_f32(bytes: &[u8], offset: usize) -> Result<f32, IrSubmitError> {
+    let end = offset
+        .checked_add(4)
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let array: [u8; 4] = bytes
+        .get(offset..end)
+        .ok_or(IrSubmitError::InvalidVertexData)?
+        .try_into()
+        .map_err(|_| IrSubmitError::InvalidVertexData)?;
+    Ok(f32::from_le_bytes(array))
+}
 
-    const fn unsupported_sequence() -> IrSubmitError {
-        IrSubmitError::Unsupported(UnsupportedIrFeature::CommandSequence)
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16, IrSubmitError> {
+    let end = offset
+        .checked_add(2)
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let array: [u8; 2] = bytes
+        .get(offset..end)
+        .ok_or(IrSubmitError::InvalidVertexData)?
+        .try_into()
+        .map_err(|_| IrSubmitError::InvalidVertexData)?;
+    Ok(u16::from_le_bytes(array))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, IrSubmitError> {
+    let end = offset
+        .checked_add(4)
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let array: [u8; 4] = bytes
+        .get(offset..end)
+        .ok_or(IrSubmitError::InvalidVertexData)?
+        .try_into()
+        .map_err(|_| IrSubmitError::InvalidVertexData)?;
+    Ok(u32::from_le_bytes(array))
+}
+
+fn read_u8(bytes: &[u8], offset: usize) -> Result<u8, IrSubmitError> {
+    bytes
+        .get(offset)
+        .copied()
+        .ok_or(IrSubmitError::InvalidVertexData)
+}
+
+fn convert_texture_upload(
+    texture: driver::IrTextureSpec,
+    write: TextureWrite<'_>,
+) -> Result<IrTextureUpload, IrSubmitError> {
+    let destination = write.destination();
+    let tight = usize::try_from(destination.width())
+        .ok()
+        .and_then(|width| {
+            width.checked_mul(match texture.format {
+                IrTextureFormat::R8 => 1,
+                IrTextureFormat::Bgra8 | IrTextureFormat::Rgba8 => 4,
+            })
+        })
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    let source_stride =
+        usize::try_from(write.bytes_per_row()).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    let height =
+        usize::try_from(destination.height()).map_err(|_| IrSubmitError::InvalidVertexData)?;
+    let required = source_stride
+        .checked_mul(
+            height
+                .checked_sub(1)
+                .ok_or(IrSubmitError::InvalidVertexData)?,
+        )
+        .and_then(|value| value.checked_add(tight))
+        .ok_or(IrSubmitError::InvalidVertexData)?;
+    if write.data().len() < required || source_stride < tight {
+        return Err(IrSubmitError::InvalidVertexData);
     }
+    let output_len = usize::try_from(destination.width())
+        .ok()
+        .and_then(|width| width.checked_mul(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or(IrSubmitError::OutOfMemory)?;
+    let mut pixels = Vec::new();
+    pixels
+        .try_reserve_exact(output_len)
+        .map_err(|_| IrSubmitError::OutOfMemory)?;
+    for row in 0..height {
+        let start = row
+            .checked_mul(source_stride)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        let source = write
+            .data()
+            .get(start..start + tight)
+            .ok_or(IrSubmitError::InvalidVertexData)?;
+        match texture.format {
+            IrTextureFormat::Bgra8 => pixels.extend_from_slice(source),
+            IrTextureFormat::Rgba8 => {
+                for pixel in source.chunks_exact(4) {
+                    pixels.extend_from_slice(&[pixel[2], pixel[1], pixel[0], pixel[3]]);
+                }
+            }
+            IrTextureFormat::R8 => {
+                for value in source {
+                    pixels.extend_from_slice(&[0, 0, 0, *value]);
+                }
+            }
+        }
+    }
+    Ok(IrTextureUpload {
+        texture,
+        destination: IrRect {
+            x: destination.x(),
+            y: destination.y(),
+            width: destination.width(),
+            height: destination.height(),
+        },
+        pixels,
+    })
+}
+
+fn uniform_state(uniforms: DrawUniforms) -> IrUniforms {
+    IrUniforms {
+        transform: uniforms.transform().columns(),
+        color: uniforms.color().components(),
+    }
+}
+
+fn fragment_program(fragment: FragmentProgram) -> IrFragmentProgram {
+    match fragment {
+        FragmentProgram::Solid => IrFragmentProgram::Solid,
+        FragmentProgram::VertexColor => IrFragmentProgram::VertexColor,
+        FragmentProgram::Texture(TextureSampleMode::Rgba) => IrFragmentProgram::TextureRgba,
+        FragmentProgram::Texture(TextureSampleMode::RgbIgnoreAlpha) => {
+            IrFragmentProgram::TextureRgbIgnoreAlpha
+        }
+        FragmentProgram::Texture(TextureSampleMode::AlphaMask) => {
+            IrFragmentProgram::TextureAlphaMask
+        }
+    }
+}
+
+fn blend_state(state: BlendState) -> IrBlendState {
+    IrBlendState {
+        color: blend_component(state.color()),
+        alpha: blend_component(state.alpha()),
+    }
+}
+
+fn blend_component(component: BlendComponent) -> IrBlendComponent {
+    IrBlendComponent {
+        source_factor: match component.source_factor() {
+            BlendFactor::Zero => IrBlendFactor::Zero,
+            BlendFactor::One => IrBlendFactor::One,
+            BlendFactor::SourceAlpha => IrBlendFactor::SourceAlpha,
+            BlendFactor::OneMinusSourceAlpha => IrBlendFactor::OneMinusSourceAlpha,
+            BlendFactor::DestinationAlpha => IrBlendFactor::DestinationAlpha,
+            BlendFactor::OneMinusDestinationAlpha => IrBlendFactor::OneMinusDestinationAlpha,
+        },
+        destination_factor: match component.destination_factor() {
+            BlendFactor::Zero => IrBlendFactor::Zero,
+            BlendFactor::One => IrBlendFactor::One,
+            BlendFactor::SourceAlpha => IrBlendFactor::SourceAlpha,
+            BlendFactor::OneMinusSourceAlpha => IrBlendFactor::OneMinusSourceAlpha,
+            BlendFactor::DestinationAlpha => IrBlendFactor::DestinationAlpha,
+            BlendFactor::OneMinusDestinationAlpha => IrBlendFactor::OneMinusDestinationAlpha,
+        },
+        operation: match component.operation() {
+            BlendOp::Add => IrBlendOp::Add,
+            BlendOp::Subtract => IrBlendOp::Subtract,
+            BlendOp::ReverseSubtract => IrBlendOp::ReverseSubtract,
+        },
+    }
+}
+
+fn rect_within(rectangle: ir::PixelRect, area: IrRect) -> bool {
+    rectangle.x() >= area.x
+        && rectangle.y() >= area.y
+        && rectangle
+            .x()
+            .checked_add(rectangle.width())
+            .is_some_and(|right| right <= area.x + area.width)
+        && rectangle
+            .y()
+            .checked_add(rectangle.height())
+            .is_some_and(|bottom| bottom <= area.y + area.height)
+}
+
+fn ir_rect(rectangle: ir::PixelRect) -> IrRect {
+    IrRect {
+        x: rectangle.x(),
+        y: rectangle.y(),
+        width: rectangle.width(),
+        height: rectangle.height(),
+    }
+}
+
+fn texture_spec(texture: TextureRef<'_>, descriptor: TextureDesc) -> driver::IrTextureSpec {
+    let extent = descriptor.extent();
+    let usage = descriptor.usage();
+    driver::IrTextureSpec {
+        slot: texture.index,
+        width: extent.width(),
+        height: extent.height(),
+        sampled: usage.contains(TextureUsage::SAMPLED),
+        render_attachment: usage.contains(TextureUsage::RENDER_ATTACHMENT),
+        copy_destination: usage.contains(TextureUsage::COPY_DST),
+        present: usage.contains(TextureUsage::PRESENT),
+        format: match descriptor.format() {
+            TextureFormat::Bgra8Unorm => IrTextureFormat::Bgra8,
+            TextureFormat::Rgba8Unorm => IrTextureFormat::Rgba8,
+            TextureFormat::R8Unorm => IrTextureFormat::R8,
+        },
+    }
+}
+
+fn materializable_texture(spec: driver::IrTextureSpec) -> bool {
+    spec.sampled || spec.render_attachment || spec.copy_destination || spec.present
 }

--- a/user/lib/sgfx/src/lib.rs
+++ b/user/lib/sgfx/src/lib.rs
@@ -32,7 +32,7 @@ mod driver;
 mod ir_execute;
 mod virgl;
 
-pub use ir_execute::{IrPresentTarget, IrSubmitError, UnsupportedIrFeature};
+pub use ir_execute::{IrResources, IrSubmitError, UnsupportedIrFeature};
 
 /// Device capabilities expressed in application rendering terms.
 #[derive(Debug, Clone, Copy)]
@@ -119,6 +119,25 @@ pub struct Context {
 }
 
 impl Context {
+    /// Create an empty persistent cache for one logical IR resource table.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Table whose opaque logical references this cache will resolve.
+    ///
+    /// # Returns
+    ///
+    /// An empty IR resource cache, or [`IrSubmitError::OutOfMemory`] when its
+    /// bounded mapping metadata or persistent private backend storage cannot be
+    /// allocated. Textures, samplers, and pipelines materialize lazily for this
+    /// context as they are first referenced by IR submission.
+    pub fn create_ir_resources<'r, 'image>(
+        &self,
+        resources: &'r ir::ResourceTable,
+    ) -> Result<IrResources<'r, 'image>, IrSubmitError> {
+        IrResources::new(resources, &self.backend)
+    }
+
     /// Create a presentation-capable render-target image.
     ///
     /// # Arguments

--- a/user/lib/sgfx/src/lib.rs
+++ b/user/lib/sgfx/src/lib.rs
@@ -22,8 +22,17 @@ use std::{
     ipc::SharedMemory,
 };
 
+/// Backend-neutral logical graphics intermediate representation.
+///
+/// This module defines validated resource descriptors and command buffers.
+/// Supported command subsets can be lowered through [`Queue::submit_ir`].
+pub mod ir;
+
 mod driver;
+mod ir_execute;
 mod virgl;
+
+pub use ir_execute::{IrPresentTarget, IrSubmitError, UnsupportedIrFeature};
 
 /// Device capabilities expressed in application rendering terms.
 #[derive(Debug, Clone, Copy)]

--- a/user/lib/sgfx/src/virgl.rs
+++ b/user/lib/sgfx/src/virgl.rs
@@ -6,9 +6,10 @@ use core::cell::Cell;
 use framebuffer::DisplaySurface;
 use gpu_raw::{
     GPU_DEVICE_STATE_READY, GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD, GPU_EXECUTION_SUPPORT_PRESENTATION,
-    GPU_EXECUTION_SUPPORT_QUEUE, GPU_IMAGE_USAGE_SAMPLED, GPU_IMAGE_USAGE_TRANSFER_DST,
-    GPU_RESULT_SUCCESS, Gpu as RawGpu, GpuBuffer as RawBuffer, GpuContext as RawContext,
-    GpuDialect as RawDialect, GpuImage as RawImage, GpuImageBgraRect, GpuQueue as RawQueue,
+    GPU_EXECUTION_SUPPORT_QUEUE, GPU_IMAGE_USAGE_RENDER_TARGET, GPU_IMAGE_USAGE_SAMPLED,
+    GPU_IMAGE_USAGE_TRANSFER_DST, GPU_RESULT_SUCCESS, Gpu as RawGpu, GpuBuffer as RawBuffer,
+    GpuContext as RawContext, GpuDialect as RawDialect, GpuImage as RawImage, GpuImageBgraRect,
+    GpuQueue as RawQueue,
 };
 #[cfg(feature = "std")]
 use scarlet_os::handle::{HandleError, HandleResult};
@@ -20,6 +21,11 @@ use std::{
     ipc::SharedMemory,
 };
 
+use crate::driver::{
+    IrAddressMode, IrBlendFactor, IrBlendOp, IrBlendState, IrCullMode, IrDraw, IrFilterMode,
+    IrFragmentProgram, IrFrontFace, IrPipelineState, IrSamplerState, IrSubmission, IrTextureCopy,
+    IrTextureSpec, IrTextureUpload, IrVertex, MAX_IR_VERTICES,
+};
 use crate::{
     Capabilities, Color, CullMode, FrontFace, MAX_COMPOSITION_OPERATIONS, PipelineDesc,
     PipelineKind, PixelRect, SourceAlpha, VertexClip4Color3, Viewport,
@@ -34,6 +40,8 @@ const VIRGL_CCMD_CLEAR: u32 = 7;
 const VIRGL_CCMD_DRAW_VBO: u32 = 8;
 const VIRGL_CCMD_RESOURCE_INLINE_WRITE: u32 = 9;
 const VIRGL_CCMD_SET_SAMPLER_VIEWS: u32 = 10;
+const VIRGL_CCMD_RESOURCE_COPY_REGION: u32 = 17;
+const VIRGL_CCMD_SET_CONSTANT_BUFFER: u32 = 12;
 const VIRGL_CCMD_SET_SCISSOR_STATE: u32 = 15;
 const VIRGL_CCMD_BIND_SAMPLER_STATES: u32 = 18;
 const VIRGL_CCMD_BIND_SHADER: u32 = 31;
@@ -72,7 +80,7 @@ const COMPOSITION_VERTEX_ELEMENTS_HANDLE: u32 = 22;
 const COMPOSITION_SAMPLER_STATE_HANDLE: u32 = 23;
 const FIRST_DYNAMIC_OBJECT_HANDLE: u32 = 64;
 const VIRGL_RASTERIZER_DEPTH_CLIP: u32 = 1 << 1;
-const VIRGL_RASTERIZER_SCISSOR: u32 = 1;
+const VIRGL_RASTERIZER_SCISSOR: u32 = 1 << 14;
 const VIRGL_RASTERIZER_CULL_FACE_SHIFT: u32 = 8;
 const VIRGL_RASTERIZER_FRONT_CCW: u32 = 1 << 15;
 const VIRGL_BLEND_ENABLE: u32 = 1;
@@ -83,14 +91,27 @@ const VIRGL_BLEND_ALPHA_DST_FACTOR_SHIFT: u32 = 22;
 const VIRGL_BLEND_COLORMASK_SHIFT: u32 = 27;
 const PIPE_BLENDFACTOR_ONE: u32 = 1;
 const PIPE_BLENDFACTOR_SRC_ALPHA: u32 = 3;
+const PIPE_BLENDFACTOR_DST_ALPHA: u32 = 4;
+const PIPE_BLENDFACTOR_ZERO: u32 = 0x11;
 const PIPE_BLENDFACTOR_INV_SRC_ALPHA: u32 = 19;
+const PIPE_BLENDFACTOR_INV_DST_ALPHA: u32 = 20;
+const PIPE_BLEND_ADD: u32 = 0;
+const PIPE_BLEND_SUBTRACT: u32 = 1;
+const PIPE_BLEND_REVERSE_SUBTRACT: u32 = 2;
+const PIPE_TEX_WRAP_REPEAT: u32 = 0;
 const PIPE_TEX_WRAP_CLAMP_TO_EDGE: u32 = 2;
+const PIPE_TEX_WRAP_MIRROR_REPEAT: u32 = 4;
+const PIPE_TEX_FILTER_NEAREST: u32 = 0;
 const PIPE_TEX_FILTER_LINEAR: u32 = 1;
 const PIPE_TEX_MIPFILTER_NONE: u32 = 2;
 const PIPE_SWIZZLE_X: u32 = 0;
 const PIPE_SWIZZLE_Y: u32 = 1;
 const PIPE_SWIZZLE_Z: u32 = 2;
 const PIPE_SWIZZLE_W: u32 = 3;
+const IR_VERTEX_BUFFER_BYTES: usize = MAX_IR_VERTICES * 10 * core::mem::size_of::<f32>();
+const IR_TEXTURE_SLOTS: usize = 1_024;
+const IR_SAMPLER_SLOTS: usize = 256;
+const IR_PIPELINE_SLOTS: usize = 256;
 
 #[derive(Clone, Copy)]
 struct FramebufferOrientation {
@@ -170,8 +191,78 @@ const COMPOSITION_SOLID_SHADER: &str = "FRAG\n\
 PROPERTY FS_COLOR0_WRITES_ALL_CBUFS 1\n\
 DCL IN[1], COLOR, PERSPECTIVE\n\
 DCL OUT[0], COLOR\n\
-  0: MOV OUT[0], IN[1]\n\
+   0: MOV OUT[0], IN[1]\n\
+   1: END\n";
+
+const IR_VERTEX_SHADER: &str = "VERT\n\
+DCL IN[0]\n\
+DCL IN[1]\n\
+DCL IN[2]\n\
+DCL CONST[0..3]\n\
+DCL OUT[0], POSITION\n\
+DCL OUT[1], COLOR\n\
+DCL OUT[2], GENERIC[0]\n\
+DCL TEMP[0]\n\
+  0: MUL TEMP[0], CONST[0], IN[0].xxxx\n\
+  1: MAD TEMP[0], CONST[1], IN[0].yyyy, TEMP[0]\n\
+  2: MAD TEMP[0], CONST[2], IN[0].zzzz, TEMP[0]\n\
+  3: MAD OUT[0], CONST[3], IN[0].wwww, TEMP[0]\n\
+  4: MOV OUT[1], IN[1]\n\
+  5: MOV OUT[2], IN[2]\n\
+  6: END\n";
+
+const IR_SOLID_FRAGMENT_SHADER: &str = "FRAG\n\
+PROPERTY FS_COLOR0_WRITES_ALL_CBUFS 1\n\
+DCL CONST[0]\n\
+DCL OUT[0], COLOR\n\
+  0: MOV OUT[0], CONST[0]\n\
   1: END\n";
+
+const IR_VERTEX_COLOR_FRAGMENT_SHADER: &str = "FRAG\n\
+PROPERTY FS_COLOR0_WRITES_ALL_CBUFS 1\n\
+DCL IN[0], COLOR, PERSPECTIVE\n\
+DCL CONST[0]\n\
+DCL OUT[0], COLOR\n\
+  0: MUL OUT[0], IN[0], CONST[0]\n\
+  1: END\n";
+
+const IR_TEXTURE_RGBA_FRAGMENT_SHADER: &str = "FRAG\n\
+PROPERTY FS_COLOR0_WRITES_ALL_CBUFS 1\n\
+DCL IN[0], GENERIC[0], PERSPECTIVE\n\
+DCL CONST[0]\n\
+DCL SAMP[0]\n\
+DCL SVIEW[0], 2D, FLOAT\n\
+DCL OUT[0], COLOR\n\
+DCL TEMP[0]\n\
+  0: TEX TEMP[0], IN[0], SAMP[0], 2D\n\
+  1: MUL OUT[0], TEMP[0], CONST[0]\n\
+  2: END\n";
+
+const IR_TEXTURE_RGB_IGNORE_ALPHA_FRAGMENT_SHADER: &str = "FRAG\n\
+PROPERTY FS_COLOR0_WRITES_ALL_CBUFS 1\n\
+DCL IN[0], GENERIC[0], PERSPECTIVE\n\
+DCL CONST[0]\n\
+DCL SAMP[0]\n\
+DCL SVIEW[0], 2D, FLOAT\n\
+DCL OUT[0], COLOR\n\
+DCL TEMP[0]\n\
+  0: TEX TEMP[0], IN[0], SAMP[0], 2D\n\
+  1: MUL OUT[0].xyz, TEMP[0].xyzx, CONST[0].xyzx\n\
+  2: MOV OUT[0].w, CONST[0].wwww\n\
+  3: END\n";
+
+const IR_TEXTURE_ALPHA_MASK_FRAGMENT_SHADER: &str = "FRAG\n\
+PROPERTY FS_COLOR0_WRITES_ALL_CBUFS 1\n\
+DCL IN[0], GENERIC[0], PERSPECTIVE\n\
+DCL CONST[0]\n\
+DCL SAMP[0]\n\
+DCL SVIEW[0], 2D, FLOAT\n\
+DCL OUT[0], COLOR\n\
+DCL TEMP[0]\n\
+  0: TEX TEMP[0], IN[0], SAMP[0], 2D\n\
+  1: MOV OUT[0].xyz, CONST[0].xyzx\n\
+  2: MUL OUT[0].w, TEMP[0].wwww, CONST[0].wwww\n\
+  3: END\n";
 
 pub(crate) struct Device {
     raw: RawGpu,
@@ -240,6 +331,8 @@ impl Context {
             height,
             composition_surface_handle: self.allocate_object_handle()?,
             composition_surface_initialized: Cell::new(false),
+            ir_surface_handle: self.allocate_object_handle()?,
+            ir_surface_initialized: Cell::new(false),
         })
     }
 
@@ -268,6 +361,8 @@ impl Context {
             context_handle: self.handle_id(),
             sampler_view_handle: self.allocate_object_handle()?,
             sampler_view_initialized: Cell::new(false),
+            ir_surface_handle: self.allocate_object_handle()?,
+            ir_surface_initialized: Cell::new(false),
         })
     }
 
@@ -299,6 +394,8 @@ impl Context {
             context_handle: self.handle_id(),
             sampler_view_handle: self.allocate_object_handle()?,
             sampler_view_initialized: Cell::new(false),
+            ir_surface_handle: self.allocate_object_handle()?,
+            ir_surface_initialized: Cell::new(false),
         })
     }
 
@@ -320,6 +417,41 @@ impl Context {
             source_stride,
             GpuImageBgraRect::new(damage.x(), damage.y(), damage.width(), damage.height()),
         )
+    }
+
+    fn create_ir_texture(&self, spec: IrTextureSpec) -> HandleResult<Texture> {
+        if spec.width == 0 || spec.height == 0 || spec.present {
+            return Err(HandleError::InvalidParameter);
+        }
+        let mut usage = 0;
+        if spec.render_attachment {
+            usage |= GPU_IMAGE_USAGE_RENDER_TARGET;
+        }
+        if spec.sampled {
+            usage |= GPU_IMAGE_USAGE_SAMPLED;
+        }
+        if spec.copy_destination {
+            usage |= GPU_IMAGE_USAGE_TRANSFER_DST;
+        }
+        if usage == 0 {
+            return Err(HandleError::InvalidParameter);
+        }
+        let raw = self
+            .device
+            .raw
+            .create_image_with_usage(spec.width, spec.height, usage)?;
+        let resource_id = resource_id_from_token(self.raw.attach_image(&raw)?)?;
+        Ok(Texture {
+            raw,
+            resource_id,
+            width: spec.width,
+            height: spec.height,
+            context_handle: self.handle_id(),
+            sampler_view_handle: self.allocate_object_handle()?,
+            sampler_view_initialized: Cell::new(false),
+            ir_surface_handle: self.allocate_object_handle()?,
+            ir_surface_initialized: Cell::new(false),
+        })
     }
 
     pub(crate) fn transfer_imported_bgra_rect(
@@ -404,6 +536,72 @@ impl Context {
         })
     }
 
+    pub(crate) fn create_ir_resources(&self) -> HandleResult<IrResources> {
+        let vertex_bytes =
+            u64::try_from(IR_VERTEX_BUFFER_BYTES).map_err(|_| HandleError::InvalidParameter)?;
+        let vertex_buffer = self.device.raw.create_buffer(vertex_bytes, 0)?;
+        let vertex_resource_id = resource_id_from_token(self.raw.attach_buffer(&vertex_buffer)?)?;
+        Ok(IrResources {
+            context_handle: self.handle_id(),
+            vertex_buffer,
+            vertex_resource_id,
+            textures: empty_slots(IR_TEXTURE_SLOTS)?,
+            texture_specs: empty_slots(IR_TEXTURE_SLOTS)?,
+            samplers: empty_slots(IR_SAMPLER_SLOTS)?,
+            pipelines: empty_slots(IR_PIPELINE_SLOTS)?,
+            vertex_shader_handle: self.allocate_object_handle()?,
+            solid_fragment_shader_handle: self.allocate_object_handle()?,
+            vertex_color_fragment_shader_handle: self.allocate_object_handle()?,
+            texture_rgba_fragment_shader_handle: self.allocate_object_handle()?,
+            texture_rgb_ignore_alpha_fragment_shader_handle: self.allocate_object_handle()?,
+            texture_alpha_mask_fragment_shader_handle: self.allocate_object_handle()?,
+            vertex_elements_handle: self.allocate_object_handle()?,
+            initialized: Cell::new(false),
+        })
+    }
+
+    pub(crate) fn map_ir_image(
+        &self,
+        resources: &mut IrResources,
+        texture: IrTextureSpec,
+        image: &Image,
+    ) -> HandleResult<()> {
+        if resources.context_handle != self.handle_id()
+            || image.context_handle != self.handle_id()
+            || texture.slot >= resources.textures.len()
+            || texture.width != image.width
+            || texture.height != image.height
+            || !texture.render_attachment
+            || !texture.present
+        {
+            return Err(HandleError::InvalidParameter);
+        }
+        let slot = resources
+            .textures
+            .get_mut(texture.slot)
+            .ok_or(HandleError::InvalidParameter)?;
+        if slot.is_some() {
+            return Err(HandleError::InvalidParameter);
+        }
+        *slot = Some(IrTexture::Mapped(MappedIrTexture {
+            resource_id: image.resource_id,
+            width: image.width,
+            height: image.height,
+            sampler_view_handle: self.allocate_object_handle()?,
+            sampler_view_initialized: Cell::new(false),
+            surface_handle: image.ir_surface_handle,
+            surface_initialized: Cell::new(image.ir_surface_initialized.get()),
+        }));
+        if let Some(spec) = resources.texture_specs.get_mut(texture.slot) {
+            *spec = Some(texture);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn context_id(&self) -> i32 {
+        self.handle_id()
+    }
+
     fn handle_id(&self) -> i32 {
         self.raw.as_handle().as_raw()
     }
@@ -443,6 +641,125 @@ pub(crate) enum CompositionOperation<'a> {
     },
 }
 
+pub(crate) struct IrResources {
+    context_handle: i32,
+    vertex_buffer: RawBuffer,
+    vertex_resource_id: u32,
+    textures: Vec<Option<IrTexture>>,
+    texture_specs: Vec<Option<IrTextureSpec>>,
+    samplers: Vec<Option<IrSampler>>,
+    pipelines: Vec<Option<IrPipeline>>,
+    vertex_shader_handle: u32,
+    solid_fragment_shader_handle: u32,
+    vertex_color_fragment_shader_handle: u32,
+    texture_rgba_fragment_shader_handle: u32,
+    texture_rgb_ignore_alpha_fragment_shader_handle: u32,
+    texture_alpha_mask_fragment_shader_handle: u32,
+    vertex_elements_handle: u32,
+    initialized: Cell<bool>,
+}
+
+struct IrSampler {
+    handle: u32,
+    state: IrSamplerState,
+    initialized: Cell<bool>,
+}
+
+struct IrPipeline {
+    blend_handle: u32,
+    rasterizer_handle: u32,
+    state: IrPipelineState,
+    initialized: Cell<bool>,
+}
+
+enum IrTexture {
+    Internal(Texture),
+    Mapped(MappedIrTexture),
+}
+
+struct MappedIrTexture {
+    resource_id: u32,
+    width: u32,
+    height: u32,
+    sampler_view_handle: u32,
+    sampler_view_initialized: Cell<bool>,
+    surface_handle: u32,
+    surface_initialized: Cell<bool>,
+}
+
+struct IrPassTarget {
+    resource_id: u32,
+    surface_handle: u32,
+    surface_initialized: bool,
+    width: u32,
+    height: u32,
+    orientation: FramebufferOrientation,
+}
+
+impl IrTexture {
+    fn resource_id(&self) -> u32 {
+        match self {
+            Self::Internal(texture) => texture.resource_id,
+            Self::Mapped(texture) => texture.resource_id,
+        }
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self {
+            Self::Internal(texture) => (texture.width, texture.height),
+            Self::Mapped(texture) => (texture.width, texture.height),
+        }
+    }
+
+    fn sampler_view_handle(&self) -> u32 {
+        match self {
+            Self::Internal(texture) => texture.sampler_view_handle,
+            Self::Mapped(texture) => texture.sampler_view_handle,
+        }
+    }
+
+    fn sampler_view_initialized(&self) -> bool {
+        match self {
+            Self::Internal(texture) => texture.sampler_view_initialized.get(),
+            Self::Mapped(texture) => texture.sampler_view_initialized.get(),
+        }
+    }
+
+    fn set_sampler_view_initialized(&self) {
+        match self {
+            Self::Internal(texture) => texture.sampler_view_initialized.set(true),
+            Self::Mapped(texture) => texture.sampler_view_initialized.set(true),
+        }
+    }
+
+    fn surface_handle(&self) -> u32 {
+        match self {
+            Self::Internal(texture) => texture.ir_surface_handle,
+            Self::Mapped(texture) => texture.surface_handle,
+        }
+    }
+
+    fn surface_initialized(&self) -> bool {
+        match self {
+            Self::Internal(texture) => texture.ir_surface_initialized.get(),
+            Self::Mapped(texture) => texture.surface_initialized.get(),
+        }
+    }
+
+    fn set_surface_initialized(&self) {
+        match self {
+            Self::Internal(texture) => texture.ir_surface_initialized.set(true),
+            Self::Mapped(texture) => texture.surface_initialized.set(true),
+        }
+    }
+}
+
+impl Drop for IrResources {
+    fn drop(&mut self) {
+        let _ = &self.vertex_buffer;
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct CompositionVertex {
@@ -476,6 +793,332 @@ struct CompositionQuad {
 }
 
 impl Queue {
+    pub(crate) fn context_id(&self) -> i32 {
+        self.context_handle
+    }
+
+    pub(crate) fn upload_ir_texture(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        spec: IrTextureSpec,
+        upload: &IrTextureUpload,
+    ) -> HandleResult<()> {
+        if self.context_handle != context.handle_id()
+            || resources.context_handle != context.handle_id()
+            || upload.texture.slot != spec.slot
+            || upload.texture.width != spec.width
+            || upload.texture.height != spec.height
+        {
+            return Err(HandleError::InvalidParameter);
+        }
+        let texture = ir_texture(context, resources, spec)?;
+        let IrTexture::Internal(texture) = texture else {
+            return Err(HandleError::InvalidParameter);
+        };
+        context.upload_texture_bgra(
+            texture,
+            &upload.pixels,
+            upload
+                .destination
+                .width
+                .checked_mul(4)
+                .ok_or(HandleError::InvalidParameter)?,
+            ir_rect_to_pixel_rect(upload.destination)?,
+        )
+    }
+
+    pub(crate) fn copy_ir_texture(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        copy: IrTextureCopy,
+    ) -> HandleResult<()> {
+        if self.context_handle != context.handle_id()
+            || resources.context_handle != context.handle_id()
+            || !ir_rect_is_within(copy.source_rect, copy.source.width, copy.source.height)
+            || !ir_rect_is_within(
+                copy.destination_rect,
+                copy.destination.width,
+                copy.destination.height,
+            )
+            || copy.source_rect.width != copy.destination_rect.width
+            || copy.source_rect.height != copy.destination_rect.height
+        {
+            return Err(HandleError::InvalidParameter);
+        }
+        let source = ir_texture(context, resources, copy.source)?;
+        let source_id = source.resource_id();
+        let destination = ir_texture(context, resources, copy.destination)?;
+        let destination_id = destination.resource_id();
+        let mut commands = Vec::new();
+        commands
+            .try_reserve_exact(56)
+            .map_err(|_| HandleError::OutOfResources)?;
+        push_resource_copy(
+            &mut commands,
+            destination_id,
+            copy.destination_rect,
+            source_id,
+            copy.source_rect,
+        );
+        self.raw.submit(&commands).map(|_| ())
+    }
+
+    pub(crate) fn submit_ir_internal(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        target: IrTextureSpec,
+        submission: &IrSubmission,
+    ) -> HandleResult<()> {
+        if !target.render_attachment
+            || self.context_handle != context.handle_id()
+            || resources.context_handle != context.handle_id()
+        {
+            return Err(HandleError::InvalidParameter);
+        }
+        let pass_target = {
+            let texture = ir_texture(context, resources, target)?;
+            let (width, height) = texture.dimensions();
+            if matches!(texture, IrTexture::Mapped(_))
+                || width != target.width
+                || height != target.height
+            {
+                return Err(HandleError::InvalidParameter);
+            }
+            IrPassTarget {
+                resource_id: texture.resource_id(),
+                surface_handle: texture.surface_handle(),
+                surface_initialized: texture.surface_initialized(),
+                width,
+                height,
+                orientation: FramebufferOrientation::UPPER_LEFT,
+            }
+        };
+        self.submit_ir_target(context, resources, pass_target, submission)?;
+        let texture = resources
+            .textures
+            .get(target.slot)
+            .and_then(Option::as_ref)
+            .ok_or(HandleError::InvalidParameter)?;
+        texture.set_surface_initialized();
+        Ok(())
+    }
+
+    pub(crate) fn submit_ir(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        image: &Image,
+        submission: &IrSubmission,
+    ) -> HandleResult<()> {
+        self.submit_ir_target(
+            context,
+            resources,
+            IrPassTarget {
+                resource_id: image.resource_id,
+                surface_handle: image.ir_surface_handle,
+                surface_initialized: image.ir_surface_initialized.get(),
+                width: image.width,
+                height: image.height,
+                orientation: image.orientation,
+            },
+            submission,
+        )?;
+        image.ir_surface_initialized.set(true);
+        Ok(())
+    }
+
+    fn submit_ir_target(
+        &self,
+        context: &Context,
+        resources: &mut IrResources,
+        target: IrPassTarget,
+        submission: &IrSubmission,
+    ) -> HandleResult<()> {
+        if self.context_handle != context.handle_id()
+            || resources.context_handle != context.handle_id()
+            || submission.vertices.len() > MAX_IR_VERTICES
+            || submission.draws.is_empty()
+            || !ir_rect_is_within(submission.render_area, target.width, target.height)
+            || submission
+                .clear_color
+                .is_some_and(|color| !color.iter().all(|component| component.is_finite()))
+        {
+            return Err(HandleError::InvalidParameter);
+        }
+
+        let mut commands = Vec::new();
+        commands
+            .try_reserve(16 * 1024)
+            .map_err(|_| HandleError::OutOfResources)?;
+        let mut initialized_samplers = Vec::new();
+        let mut initialized_pipelines = Vec::new();
+        let mut initialized_views = Vec::new();
+        if !resources.initialized.get() {
+            push_ir_setup(&mut commands, resources);
+        }
+        if !target.surface_initialized {
+            push_surface(&mut commands, target.surface_handle, target.resource_id);
+        }
+        for upload in &submission.texture_uploads {
+            let texture = ir_texture(context, resources, IrTextureSpec { ..upload.texture })?;
+            let view_is_pending = initialized_views
+                .iter()
+                .any(|slot| *slot == upload.texture.slot);
+            if !texture.sampler_view_initialized() && !view_is_pending {
+                push_sampler_view(
+                    &mut commands,
+                    texture.sampler_view_handle(),
+                    texture.resource_id(),
+                );
+                initialized_views.push(upload.texture.slot);
+            }
+        }
+        for draw in &submission.draws {
+            validate_ir_draw(
+                resources,
+                target.width,
+                target.height,
+                draw,
+                submission.vertices.len(),
+            )?;
+            let pipeline = ir_pipeline(context, resources, draw.pipeline)?;
+            let pipeline_is_pending = initialized_pipelines
+                .iter()
+                .any(|slot| *slot == draw.pipeline.slot);
+            if !pipeline.initialized.get() && !pipeline_is_pending {
+                push_ir_pipeline(&mut commands, pipeline);
+                initialized_pipelines.push(draw.pipeline.slot);
+            }
+            if let (Some(texture_spec), Some(sampler)) = (draw.texture, draw.sampler) {
+                let texture = ir_texture(context, resources, texture_spec)?;
+                let view_is_pending = initialized_views
+                    .iter()
+                    .any(|pending| *pending == texture_spec.slot);
+                if !texture.sampler_view_initialized() && !view_is_pending {
+                    push_sampler_view(
+                        &mut commands,
+                        texture.sampler_view_handle(),
+                        texture.resource_id(),
+                    );
+                    initialized_views.push(texture_spec.slot);
+                }
+                let sampler = ir_sampler(context, resources, sampler)?;
+                let sampler_is_pending = initialized_samplers
+                    .iter()
+                    .any(|slot| *slot == sampler.state.slot);
+                if !sampler.initialized.get() && !sampler_is_pending {
+                    push_ir_sampler(&mut commands, sampler);
+                    initialized_samplers.push(sampler.state.slot);
+                }
+            }
+        }
+
+        push_ir_bind_pass_state(
+            &mut commands,
+            target.surface_handle,
+            resources.vertex_resource_id,
+            target.width,
+            target.height,
+            target.orientation,
+            resources.vertex_shader_handle,
+            resources.vertex_elements_handle,
+        );
+        push_scissor(
+            &mut commands,
+            ir_rect_to_pixel_rect(submission.render_area)?,
+        )?;
+        if let Some(clear_color) = submission.clear_color {
+            push_ir_clear(&mut commands, clear_color);
+        }
+        push_ir_inline_write(
+            &mut commands,
+            resources.vertex_resource_id,
+            &submission.vertices,
+        )?;
+        for draw in &submission.draws {
+            let pipeline = resources
+                .pipelines
+                .get(draw.pipeline.slot)
+                .and_then(Option::as_ref)
+                .ok_or(HandleError::InvalidParameter)?;
+            push_bind_object(&mut commands, VIRGL_OBJECT_BLEND, pipeline.blend_handle);
+            push_bind_object(
+                &mut commands,
+                VIRGL_OBJECT_RASTERIZER,
+                pipeline.rasterizer_handle,
+            );
+            push_fragment_shader(
+                &mut commands,
+                ir_fragment_shader_handle(resources, draw.pipeline.fragment),
+            );
+            push_constant_buffer(&mut commands, PIPE_SHADER_VERTEX, &draw.uniforms.transform)?;
+            push_constant_buffer(&mut commands, PIPE_SHADER_FRAGMENT, &draw.uniforms.color)?;
+            push_scissor(&mut commands, ir_rect_to_pixel_rect(draw.scissor)?)?;
+            if let (Some(texture_spec), Some(sampler)) = (draw.texture, draw.sampler) {
+                let texture = resources
+                    .textures
+                    .get(texture_spec.slot)
+                    .and_then(Option::as_ref)
+                    .ok_or(HandleError::InvalidParameter)?;
+                let sampler = resources
+                    .samplers
+                    .get(sampler.slot)
+                    .and_then(Option::as_ref)
+                    .ok_or(HandleError::InvalidParameter)?;
+                push_sampler_view_binding(&mut commands, texture.sampler_view_handle());
+                push_sampler_state_binding(&mut commands, sampler.handle);
+            }
+            push_draw(&mut commands, draw.start_vertex, draw.vertex_count)?;
+        }
+        if commands.len() > self.raw.max_opaque_command_size() as usize {
+            return Err(HandleError::InvalidParameter);
+        }
+
+        for upload in &submission.texture_uploads {
+            let texture = resources
+                .textures
+                .get(upload.texture.slot)
+                .and_then(Option::as_ref)
+                .ok_or(HandleError::InvalidParameter)?;
+            let IrTexture::Internal(texture) = texture else {
+                return Err(HandleError::InvalidParameter);
+            };
+            context.upload_texture_bgra(
+                texture,
+                &upload.pixels,
+                upload
+                    .destination
+                    .width
+                    .checked_mul(4)
+                    .ok_or(HandleError::InvalidParameter)?,
+                ir_rect_to_pixel_rect(upload.destination)?,
+            )?;
+        }
+        self.raw.submit(&commands)?;
+        if !resources.initialized.get() {
+            resources.initialized.set(true);
+        }
+        for slot in initialized_samplers {
+            if let Some(Some(sampler)) = resources.samplers.get(slot) {
+                sampler.initialized.set(true);
+            }
+        }
+        for slot in initialized_pipelines {
+            if let Some(Some(pipeline)) = resources.pipelines.get(slot) {
+                pipeline.initialized.set(true);
+            }
+        }
+        for slot in initialized_views {
+            if let Some(Some(texture)) = resources.textures.get(slot) {
+                texture.set_sampler_view_initialized();
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn submit(
         &self,
         image: &Image,
@@ -732,6 +1375,8 @@ pub(crate) struct Image {
     height: u32,
     composition_surface_handle: u32,
     composition_surface_initialized: Cell<bool>,
+    ir_surface_handle: u32,
+    ir_surface_initialized: Cell<bool>,
 }
 
 pub(crate) struct Texture {
@@ -742,6 +1387,8 @@ pub(crate) struct Texture {
     context_handle: i32,
     sampler_view_handle: u32,
     sampler_view_initialized: Cell<bool>,
+    ir_surface_handle: u32,
+    ir_surface_initialized: Cell<bool>,
 }
 
 impl Drop for Queue {
@@ -751,6 +1398,10 @@ impl Drop for Queue {
 }
 
 impl Image {
+    pub(crate) fn context_id(&self) -> i32 {
+        self.context_handle
+    }
+
     pub(crate) fn present(&self, display: &DisplaySurface) -> HandleResult<()> {
         display.present_image(self.raw.as_handle(), None)
     }
@@ -771,6 +1422,229 @@ impl Drop for Pipeline {
     fn drop(&mut self) {
         let _ = &self.vertex_buffer;
     }
+}
+
+fn empty_slots<T>(count: usize) -> HandleResult<Vec<Option<T>>> {
+    let mut slots = Vec::new();
+    slots
+        .try_reserve_exact(count)
+        .map_err(|_| HandleError::OutOfResources)?;
+    for _ in 0..count {
+        slots.push(None);
+    }
+    Ok(slots)
+}
+
+fn ir_texture<'resources>(
+    context: &Context,
+    resources: &'resources mut IrResources,
+    spec: IrTextureSpec,
+) -> HandleResult<&'resources IrTexture> {
+    let known_spec = resources
+        .texture_specs
+        .get(spec.slot)
+        .and_then(|known| *known);
+    if let Some(known_spec) = known_spec {
+        if known_spec != spec {
+            return Err(HandleError::InvalidParameter);
+        }
+    } else if let Some(known_spec) = resources.texture_specs.get_mut(spec.slot) {
+        *known_spec = Some(spec);
+    }
+    let texture_slot = resources
+        .textures
+        .get_mut(spec.slot)
+        .ok_or(HandleError::InvalidParameter)?;
+    if texture_slot.is_none() {
+        *texture_slot = Some(IrTexture::Internal(context.create_ir_texture(spec)?));
+    }
+    let texture = texture_slot.as_ref().ok_or(HandleError::InvalidParameter)?;
+    let (width, height) = texture.dimensions();
+    if width != spec.width || height != spec.height {
+        return Err(HandleError::InvalidParameter);
+    }
+    Ok(texture)
+}
+
+fn ir_sampler<'resources>(
+    context: &Context,
+    resources: &'resources mut IrResources,
+    state: IrSamplerState,
+) -> HandleResult<&'resources IrSampler> {
+    let sampler_slot = resources
+        .samplers
+        .get_mut(state.slot)
+        .ok_or(HandleError::InvalidParameter)?;
+    if sampler_slot.is_none() {
+        *sampler_slot = Some(IrSampler {
+            handle: context.allocate_object_handle()?,
+            state,
+            initialized: Cell::new(false),
+        });
+    }
+    let sampler = sampler_slot.as_ref().ok_or(HandleError::InvalidParameter)?;
+    if !ir_sampler_states_equal(sampler.state, state) {
+        return Err(HandleError::InvalidParameter);
+    }
+    Ok(sampler)
+}
+
+fn ir_pipeline<'resources>(
+    context: &Context,
+    resources: &'resources mut IrResources,
+    state: IrPipelineState,
+) -> HandleResult<&'resources IrPipeline> {
+    let pipeline_slot = resources
+        .pipelines
+        .get_mut(state.slot)
+        .ok_or(HandleError::InvalidParameter)?;
+    if pipeline_slot.is_none() {
+        *pipeline_slot = Some(IrPipeline {
+            blend_handle: context.allocate_object_handle()?,
+            rasterizer_handle: context.allocate_object_handle()?,
+            state,
+            initialized: Cell::new(false),
+        });
+    }
+    let pipeline = pipeline_slot
+        .as_ref()
+        .ok_or(HandleError::InvalidParameter)?;
+    if !ir_pipeline_states_equal(pipeline.state, state) {
+        return Err(HandleError::InvalidParameter);
+    }
+    Ok(pipeline)
+}
+
+fn ir_sampler_states_equal(left: IrSamplerState, right: IrSamplerState) -> bool {
+    left.slot == right.slot
+        && ir_filter_modes_equal(left.min_filter, right.min_filter)
+        && ir_filter_modes_equal(left.mag_filter, right.mag_filter)
+        && ir_address_modes_equal(left.address_u, right.address_u)
+        && ir_address_modes_equal(left.address_v, right.address_v)
+}
+
+fn ir_pipeline_states_equal(left: IrPipelineState, right: IrPipelineState) -> bool {
+    left.slot == right.slot
+        && ir_fragment_programs_equal(left.fragment, right.fragment)
+        && ir_blend_states_equal(left.blend, right.blend)
+        && ir_cull_modes_equal(left.cull_mode, right.cull_mode)
+        && ir_front_faces_equal(left.front_face, right.front_face)
+}
+
+fn ir_fragment_programs_equal(left: IrFragmentProgram, right: IrFragmentProgram) -> bool {
+    core::mem::discriminant(&left) == core::mem::discriminant(&right)
+}
+
+fn ir_blend_states_equal(left: IrBlendState, right: IrBlendState) -> bool {
+    ir_blend_components_equal(left.color, right.color)
+        && ir_blend_components_equal(left.alpha, right.alpha)
+}
+
+fn ir_blend_components_equal(
+    left: crate::driver::IrBlendComponent,
+    right: crate::driver::IrBlendComponent,
+) -> bool {
+    ir_blend_factors_equal(left.source_factor, right.source_factor)
+        && ir_blend_factors_equal(left.destination_factor, right.destination_factor)
+        && ir_blend_ops_equal(left.operation, right.operation)
+}
+
+fn ir_blend_factors_equal(left: IrBlendFactor, right: IrBlendFactor) -> bool {
+    core::mem::discriminant(&left) == core::mem::discriminant(&right)
+}
+
+fn ir_blend_ops_equal(left: IrBlendOp, right: IrBlendOp) -> bool {
+    core::mem::discriminant(&left) == core::mem::discriminant(&right)
+}
+
+fn ir_cull_modes_equal(left: IrCullMode, right: IrCullMode) -> bool {
+    core::mem::discriminant(&left) == core::mem::discriminant(&right)
+}
+
+fn ir_front_faces_equal(left: IrFrontFace, right: IrFrontFace) -> bool {
+    core::mem::discriminant(&left) == core::mem::discriminant(&right)
+}
+
+fn ir_filter_modes_equal(left: IrFilterMode, right: IrFilterMode) -> bool {
+    core::mem::discriminant(&left) == core::mem::discriminant(&right)
+}
+
+fn ir_address_modes_equal(left: IrAddressMode, right: IrAddressMode) -> bool {
+    core::mem::discriminant(&left) == core::mem::discriminant(&right)
+}
+
+fn ir_rect_is_within(rect: crate::driver::IrRect, width: u32, height: u32) -> bool {
+    rect.width != 0
+        && rect.height != 0
+        && rect
+            .x
+            .checked_add(rect.width)
+            .is_some_and(|right| right <= width)
+        && rect
+            .y
+            .checked_add(rect.height)
+            .is_some_and(|bottom| bottom <= height)
+}
+
+fn ir_rect_to_pixel_rect(rect: crate::driver::IrRect) -> HandleResult<PixelRect> {
+    if rect.width == 0
+        || rect.height == 0
+        || rect.x.checked_add(rect.width).is_none()
+        || rect.y.checked_add(rect.height).is_none()
+    {
+        return Err(HandleError::InvalidParameter);
+    }
+    Ok(PixelRect::new(rect.x, rect.y, rect.width, rect.height))
+}
+
+fn validate_ir_draw(
+    resources: &IrResources,
+    target_width: u32,
+    target_height: u32,
+    draw: &IrDraw,
+    vertices_len: usize,
+) -> HandleResult<()> {
+    let end = draw
+        .start_vertex
+        .checked_add(draw.vertex_count)
+        .ok_or(HandleError::InvalidParameter)?;
+    if draw.vertex_count == 0
+        || draw.vertex_count % 3 != 0
+        || end > vertices_len
+        || !ir_rect_is_within(draw.scissor, target_width, target_height)
+        || !draw
+            .uniforms
+            .transform
+            .iter()
+            .all(|value| value.is_finite())
+        || !draw.uniforms.color.iter().all(|value| value.is_finite())
+        || draw.pipeline.slot >= resources.pipelines.len()
+    {
+        return Err(HandleError::InvalidParameter);
+    }
+    match draw.pipeline.fragment {
+        IrFragmentProgram::TextureRgba
+        | IrFragmentProgram::TextureRgbIgnoreAlpha
+        | IrFragmentProgram::TextureAlphaMask => {
+            let Some(texture) = draw.texture else {
+                return Err(HandleError::InvalidParameter);
+            };
+            if texture.width == 0
+                || texture.height == 0
+                || !texture.sampled
+                || texture.slot >= resources.textures.len()
+                || draw.sampler.is_none()
+            {
+                return Err(HandleError::InvalidParameter);
+            }
+        }
+        IrFragmentProgram::Solid | IrFragmentProgram::VertexColor => {
+            if draw.texture.is_some() || draw.sampler.is_some() {
+                return Err(HandleError::InvalidParameter);
+            }
+        }
+    }
+    Ok(())
 }
 
 fn resource_id_from_token(token: u64) -> HandleResult<u32> {
@@ -1112,6 +1986,332 @@ fn push_sampler_view_binding(commands: &mut Vec<u8>, handle: u32) {
     push_dword(commands, PIPE_SHADER_FRAGMENT);
     push_dword(commands, 0);
     push_dword(commands, handle);
+}
+
+fn push_resource_copy(
+    commands: &mut Vec<u8>,
+    destination_resource: u32,
+    destination: crate::driver::IrRect,
+    source_resource: u32,
+    source: crate::driver::IrRect,
+) {
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_RESOURCE_COPY_REGION, 0, 13),
+    );
+    push_dword(commands, destination_resource);
+    push_dword(commands, 0);
+    push_dword(commands, destination.x);
+    push_dword(commands, destination.y);
+    push_dword(commands, 0);
+    push_dword(commands, source_resource);
+    push_dword(commands, 0);
+    push_dword(commands, source.x);
+    push_dword(commands, source.y);
+    push_dword(commands, 0);
+    push_dword(commands, source.width);
+    push_dword(commands, source.height);
+    push_dword(commands, 1);
+}
+
+fn push_sampler_state_binding(commands: &mut Vec<u8>, handle: u32) {
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_BIND_SAMPLER_STATES, 0, 3),
+    );
+    push_dword(commands, PIPE_SHADER_FRAGMENT);
+    push_dword(commands, 0);
+    push_dword(commands, handle);
+}
+
+fn push_constant_buffer(
+    commands: &mut Vec<u8>,
+    shader_type: u32,
+    values: &[f32],
+) -> HandleResult<()> {
+    let payload = u32::try_from(values.len())
+        .ok()
+        .and_then(|length| length.checked_add(2))
+        .ok_or(HandleError::InvalidParameter)?;
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_SET_CONSTANT_BUFFER, 0, payload),
+    );
+    push_dword(commands, shader_type);
+    push_dword(commands, 0);
+    for value in values {
+        push_float(commands, *value);
+    }
+    Ok(())
+}
+
+fn push_ir_setup(commands: &mut Vec<u8>, resources: &IrResources) {
+    push_shader(
+        commands,
+        resources.vertex_shader_handle,
+        PIPE_SHADER_VERTEX,
+        IR_VERTEX_SHADER,
+    );
+    push_shader(
+        commands,
+        resources.solid_fragment_shader_handle,
+        PIPE_SHADER_FRAGMENT,
+        IR_SOLID_FRAGMENT_SHADER,
+    );
+    push_shader(
+        commands,
+        resources.vertex_color_fragment_shader_handle,
+        PIPE_SHADER_FRAGMENT,
+        IR_VERTEX_COLOR_FRAGMENT_SHADER,
+    );
+    push_shader(
+        commands,
+        resources.texture_rgba_fragment_shader_handle,
+        PIPE_SHADER_FRAGMENT,
+        IR_TEXTURE_RGBA_FRAGMENT_SHADER,
+    );
+    push_shader(
+        commands,
+        resources.texture_rgb_ignore_alpha_fragment_shader_handle,
+        PIPE_SHADER_FRAGMENT,
+        IR_TEXTURE_RGB_IGNORE_ALPHA_FRAGMENT_SHADER,
+    );
+    push_shader(
+        commands,
+        resources.texture_alpha_mask_fragment_shader_handle,
+        PIPE_SHADER_FRAGMENT,
+        IR_TEXTURE_ALPHA_MASK_FRAGMENT_SHADER,
+    );
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_VERTEX_ELEMENTS, 13),
+    );
+    push_dword(commands, resources.vertex_elements_handle);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+    push_dword(commands, VIRGL_FORMAT_R32G32B32A32_FLOAT);
+    push_dword(commands, 16);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+    push_dword(commands, VIRGL_FORMAT_R32G32B32A32_FLOAT);
+    push_dword(commands, 32);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+    push_dword(commands, VIRGL_FORMAT_R32G32_FLOAT);
+}
+
+fn push_ir_pipeline(commands: &mut Vec<u8>, pipeline: &IrPipeline) {
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_BLEND, 11),
+    );
+    push_dword(commands, pipeline.blend_handle);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+    let blend = pipeline.state.blend;
+    push_dword(
+        commands,
+        VIRGL_BLEND_ENABLE
+            | (ir_blend_op(blend.color.operation) << 1)
+            | (ir_blend_factor(blend.color.source_factor) << VIRGL_BLEND_RGB_SRC_FACTOR_SHIFT)
+            | (ir_blend_factor(blend.color.destination_factor) << VIRGL_BLEND_RGB_DST_FACTOR_SHIFT)
+            | (ir_blend_op(blend.alpha.operation) << 14)
+            | (ir_blend_factor(blend.alpha.source_factor) << VIRGL_BLEND_ALPHA_SRC_FACTOR_SHIFT)
+            | (ir_blend_factor(blend.alpha.destination_factor)
+                << VIRGL_BLEND_ALPHA_DST_FACTOR_SHIFT)
+            | (0xf << VIRGL_BLEND_COLORMASK_SHIFT),
+    );
+    for _ in 0..7 {
+        push_dword(commands, 0);
+    }
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_RASTERIZER, 9),
+    );
+    push_dword(commands, pipeline.rasterizer_handle);
+    push_dword(
+        commands,
+        ir_rasterizer_flags(pipeline.state.cull_mode, pipeline.state.front_face),
+    );
+    push_float(commands, 1.0);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+    push_float(commands, 1.0);
+    push_float(commands, 0.0);
+    push_float(commands, 0.0);
+    push_float(commands, 0.0);
+}
+
+fn push_ir_sampler(commands: &mut Vec<u8>, sampler: &IrSampler) {
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_SAMPLER_STATE, 9),
+    );
+    push_dword(commands, sampler.handle);
+    let state = sampler.state;
+    push_dword(
+        commands,
+        ir_address_mode(state.address_u)
+            | (ir_address_mode(state.address_v) << 3)
+            | (PIPE_TEX_WRAP_CLAMP_TO_EDGE << 6)
+            | (ir_filter_mode(state.min_filter) << 9)
+            | (PIPE_TEX_MIPFILTER_NONE << 11)
+            | (ir_filter_mode(state.mag_filter) << 13),
+    );
+    push_float(commands, 0.0);
+    push_float(commands, 0.0);
+    push_float(commands, 0.0);
+    for _ in 0..4 {
+        push_dword(commands, 0);
+    }
+}
+
+fn push_ir_bind_pass_state(
+    commands: &mut Vec<u8>,
+    surface_handle: u32,
+    vertex_resource_id: u32,
+    width: u32,
+    height: u32,
+    orientation: FramebufferOrientation,
+    vertex_shader_handle: u32,
+    vertex_elements_handle: u32,
+) {
+    push_dword(commands, command_header(VIRGL_CCMD_BIND_SHADER, 0, 2));
+    push_dword(commands, vertex_shader_handle);
+    push_dword(commands, PIPE_SHADER_VERTEX);
+    push_bind_object(
+        commands,
+        VIRGL_OBJECT_VERTEX_ELEMENTS,
+        vertex_elements_handle,
+    );
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_SET_FRAMEBUFFER_STATE, 0, 3),
+    );
+    push_dword(commands, 1);
+    push_dword(commands, 0);
+    push_dword(commands, surface_handle);
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_SET_VERTEX_BUFFERS, 0, 3),
+    );
+    push_dword(commands, 40);
+    push_dword(commands, 0);
+    push_dword(commands, vertex_resource_id);
+    push_viewport(commands, Viewport::new(width, height), orientation);
+}
+
+fn push_ir_clear(commands: &mut Vec<u8>, color: [f32; 4]) {
+    push_dword(commands, command_header(VIRGL_CCMD_CLEAR, 0, 8));
+    push_dword(commands, PIPE_CLEAR_COLOR0);
+    for component in color {
+        push_float(commands, component);
+    }
+    let depth = 1.0f64.to_bits();
+    push_dword(commands, depth as u32);
+    push_dword(commands, (depth >> 32) as u32);
+    push_dword(commands, 0);
+}
+
+fn push_ir_inline_write(
+    commands: &mut Vec<u8>,
+    resource_id: u32,
+    vertices: &[IrVertex],
+) -> HandleResult<()> {
+    let components = vertices
+        .len()
+        .checked_mul(10)
+        .ok_or(HandleError::InvalidParameter)?;
+    let components = u32::try_from(components).map_err(|_| HandleError::InvalidParameter)?;
+    let byte_len = vertices
+        .len()
+        .checked_mul(40)
+        .and_then(|length| u32::try_from(length).ok())
+        .ok_or(HandleError::InvalidParameter)?;
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_RESOURCE_INLINE_WRITE, 0, 11 + components),
+    );
+    push_dword(commands, resource_id);
+    for _ in 0..7 {
+        push_dword(commands, 0);
+    }
+    push_dword(commands, byte_len);
+    push_dword(commands, 1);
+    push_dword(commands, 1);
+    for vertex in vertices {
+        for component in vertex.position {
+            push_float(commands, component);
+        }
+        for component in vertex.color {
+            push_float(commands, component);
+        }
+        for component in vertex.uv {
+            push_float(commands, component);
+        }
+    }
+    Ok(())
+}
+
+fn ir_fragment_shader_handle(resources: &IrResources, fragment: IrFragmentProgram) -> u32 {
+    match fragment {
+        IrFragmentProgram::Solid => resources.solid_fragment_shader_handle,
+        IrFragmentProgram::VertexColor => resources.vertex_color_fragment_shader_handle,
+        IrFragmentProgram::TextureRgba => resources.texture_rgba_fragment_shader_handle,
+        IrFragmentProgram::TextureRgbIgnoreAlpha => {
+            resources.texture_rgb_ignore_alpha_fragment_shader_handle
+        }
+        IrFragmentProgram::TextureAlphaMask => resources.texture_alpha_mask_fragment_shader_handle,
+    }
+}
+
+fn ir_blend_factor(factor: IrBlendFactor) -> u32 {
+    match factor {
+        IrBlendFactor::Zero => PIPE_BLENDFACTOR_ZERO,
+        IrBlendFactor::One => PIPE_BLENDFACTOR_ONE,
+        IrBlendFactor::SourceAlpha => PIPE_BLENDFACTOR_SRC_ALPHA,
+        IrBlendFactor::OneMinusSourceAlpha => PIPE_BLENDFACTOR_INV_SRC_ALPHA,
+        IrBlendFactor::DestinationAlpha => PIPE_BLENDFACTOR_DST_ALPHA,
+        IrBlendFactor::OneMinusDestinationAlpha => PIPE_BLENDFACTOR_INV_DST_ALPHA,
+    }
+}
+
+fn ir_blend_op(operation: IrBlendOp) -> u32 {
+    match operation {
+        IrBlendOp::Add => PIPE_BLEND_ADD,
+        IrBlendOp::Subtract => PIPE_BLEND_SUBTRACT,
+        IrBlendOp::ReverseSubtract => PIPE_BLEND_REVERSE_SUBTRACT,
+    }
+}
+
+fn ir_filter_mode(filter: IrFilterMode) -> u32 {
+    match filter {
+        IrFilterMode::Nearest => PIPE_TEX_FILTER_NEAREST,
+        IrFilterMode::Linear => PIPE_TEX_FILTER_LINEAR,
+    }
+}
+
+fn ir_address_mode(address: IrAddressMode) -> u32 {
+    match address {
+        IrAddressMode::ClampToEdge => PIPE_TEX_WRAP_CLAMP_TO_EDGE,
+        IrAddressMode::Repeat => PIPE_TEX_WRAP_REPEAT,
+        IrAddressMode::MirrorRepeat => PIPE_TEX_WRAP_MIRROR_REPEAT,
+    }
+}
+
+fn ir_rasterizer_flags(cull_mode: IrCullMode, front_face: IrFrontFace) -> u32 {
+    let cull_face = match cull_mode {
+        IrCullMode::None => 0,
+        IrCullMode::Front => 1,
+        IrCullMode::Back => 2,
+    } << VIRGL_RASTERIZER_CULL_FACE_SHIFT;
+    let front_ccw = if matches!(front_face, IrFrontFace::CounterClockwise) {
+        VIRGL_RASTERIZER_FRONT_CCW
+    } else {
+        0
+    };
+    VIRGL_RASTERIZER_DEPTH_CLIP | VIRGL_RASTERIZER_SCISSOR | cull_face | front_ccw
 }
 
 fn push_scissor(commands: &mut Vec<u8>, clip: PixelRect) -> HandleResult<()> {

--- a/user/std-bin/Cargo.lock
+++ b/user/std-bin/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 name = "framebuffer"
 version = "0.16.0"
 dependencies = [
- "scarlet-os 0.16.0",
+ "scarlet-os",
 ]
 
 [[package]]
@@ -713,7 +713,7 @@ dependencies = [
 name = "gpu-raw"
 version = "0.16.0"
 dependencies = [
- "scarlet-os 0.16.0",
+ "scarlet-os",
 ]
 
 [[package]]
@@ -1742,7 +1742,7 @@ name = "sas-client"
 version = "0.1.0"
 dependencies = [
  "sas-protocol",
- "scarlet-os 0.16.0",
+ "scarlet-os",
 ]
 
 [[package]]
@@ -1754,33 +1754,19 @@ name = "scarlet-abi"
 version = "0.16.0"
 
 [[package]]
-name = "scarlet-abi"
-version = "0.16.0"
-source = "git+https://github.com/petitstrawberry/Scarlet?branch=dev#75ae8a20a84a94d291250472a0b2a05a448243e9"
-
-[[package]]
 name = "scarlet-os"
 version = "0.16.0"
 dependencies = [
- "scarlet-abi 0.16.0",
+ "scarlet-abi",
  "scarlet-rt",
- "scarlet-sys 0.16.0",
-]
-
-[[package]]
-name = "scarlet-os"
-version = "0.16.0"
-source = "git+https://github.com/petitstrawberry/Scarlet?branch=dev#75ae8a20a84a94d291250472a0b2a05a448243e9"
-dependencies = [
- "scarlet-abi 0.16.0 (git+https://github.com/petitstrawberry/Scarlet?branch=dev)",
- "scarlet-sys 0.16.0 (git+https://github.com/petitstrawberry/Scarlet?branch=dev)",
+ "scarlet-sys",
 ]
 
 [[package]]
 name = "scarlet-rt"
 version = "0.16.0"
 dependencies = [
- "scarlet-sys 0.16.0",
+ "scarlet-sys",
 ]
 
 [[package]]
@@ -1798,8 +1784,8 @@ dependencies = [
  "rust_h264",
  "sas-client",
  "sas-protocol",
- "scarlet-os 0.16.0",
- "scarlet-sys 0.16.0",
+ "scarlet-os",
+ "scarlet-sys",
  "scarlet-ui",
  "scarlet-ui-macros",
  "serde",
@@ -1814,21 +1800,12 @@ dependencies = [
 name = "scarlet-sys"
 version = "0.16.0"
 dependencies = [
- "scarlet-abi 0.16.0",
-]
-
-[[package]]
-name = "scarlet-sys"
-version = "0.16.0"
-source = "git+https://github.com/petitstrawberry/Scarlet?branch=dev#75ae8a20a84a94d291250472a0b2a05a448243e9"
-dependencies = [
- "scarlet-abi 0.16.0 (git+https://github.com/petitstrawberry/Scarlet?branch=dev)",
+ "scarlet-abi",
 ]
 
 [[package]]
 name = "scarlet-ui"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "scarlet-ui-core",
  "scarlet-ui-platform-sws",
@@ -1838,7 +1815,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-core"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "ab_glyph",
  "bitflags 2.13.0",
@@ -1852,7 +1828,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-macros"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1862,7 +1837,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-platform-sws"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "scarlet-ui-core",
  "sws-client",
@@ -1872,7 +1846,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-platform-winit"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "raw-window-handle",
  "scarlet-ui-core",
@@ -1954,7 +1927,7 @@ version = "0.16.0"
 dependencies = [
  "framebuffer",
  "gpu-raw",
- "scarlet-os 0.16.0",
+ "scarlet-os",
 ]
 
 [[package]]
@@ -2112,16 +2085,14 @@ dependencies = [
 [[package]]
 name = "sws-client"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/Scarlet?branch=dev#75ae8a20a84a94d291250472a0b2a05a448243e9"
 dependencies = [
- "scarlet-os 0.16.0 (git+https://github.com/petitstrawberry/Scarlet?branch=dev)",
+ "scarlet-os",
  "sws-protocol",
 ]
 
 [[package]]
 name = "sws-protocol"
 version = "0.16.0"
-source = "git+https://github.com/petitstrawberry/Scarlet?branch=dev#75ae8a20a84a94d291250472a0b2a05a448243e9"
 
 [[package]]
 name = "symphonia-codec-aac"
@@ -2959,3 +2930,7 @@ checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]
+
+[[patch.unused]]
+name = "scarlet-std"
+version = "0.16.0"

--- a/user/std-bin/Cargo.toml
+++ b/user/std-bin/Cargo.toml
@@ -186,6 +186,10 @@ name = "sgfx_texture"
 path = "src/sgfx_texture.rs"
 
 [[bin]]
+name = "sgfx_showcase"
+path = "src/sgfx_showcase.rs"
+
+[[bin]]
 name = "markdown_demo"
 path = "src/markdown_demo.rs"
 

--- a/user/std-bin/src/sgfx_showcase.rs
+++ b/user/std-bin/src/sgfx_showcase.rs
@@ -1,0 +1,336 @@
+//! Visible advanced scene submitted through the backend-neutral `sgfx` IR.
+
+use std::process::ExitCode;
+use std::thread;
+use std::time::Duration;
+use std::vec::Vec;
+
+use framebuffer::DisplaySurface;
+use sgfx::Device;
+use sgfx::ir::{
+    BlendState, BufferDesc, BufferUsage, Color, CommandEncoder, DrawUniforms, Error, Extent2D,
+    FragmentProgram, LoadOp, PixelRect, PrimitiveTopology, RasterState, RenderPassDesc,
+    RenderPipelineDesc, ResourceTable, StoreOp, TextureDesc, TextureFormat, TextureUsage,
+    Transform, VertexAttribute, VertexBufferLayout, VertexFormat,
+};
+
+const VERTEX_STRIDE: usize = 28;
+const STAR_SEGMENTS: usize = 32;
+const FRAME_HOLD_INTERVAL: Duration = Duration::from_secs(1);
+
+fn fail(message: &str, error: impl core::fmt::Debug) -> ExitCode {
+    println!("sgfx_showcase: {message}: {error:?}");
+    ExitCode::from(1)
+}
+
+fn push_f32(bytes: &mut Vec<u8>, value: f32) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_vertex(bytes: &mut Vec<u8>, x: f32, y: f32, color: [f32; 3]) {
+    for component in [x, y, 0.0, 1.0] {
+        push_f32(bytes, component);
+    }
+    for component in color {
+        push_f32(bytes, component);
+    }
+}
+
+fn push_triangle(bytes: &mut Vec<u8>, positions: [[f32; 2]; 3], colors: [[f32; 3]; 3]) {
+    for index in 0..3 {
+        push_vertex(
+            bytes,
+            positions[index][0],
+            positions[index][1],
+            colors[index],
+        );
+    }
+}
+
+fn push_panel(
+    bytes: &mut Vec<u8>,
+    left: f32,
+    bottom: f32,
+    right: f32,
+    top: f32,
+    colors: [[f32; 3]; 4],
+) {
+    push_triangle(
+        bytes,
+        [[left, bottom], [right, bottom], [left, top]],
+        [colors[0], colors[1], colors[2]],
+    );
+    push_triangle(
+        bytes,
+        [[left, top], [right, bottom], [right, top]],
+        [colors[2], colors[1], colors[3]],
+    );
+}
+
+fn scene_vertices(width: u32, height: u32) -> sgfx::ir::Result<(Vec<u8>, u32)> {
+    let maximum_vertices = STAR_SEGMENTS
+        .checked_mul(3)
+        .and_then(|value| value.checked_add(30))
+        .ok_or(Error::Overflow)?;
+    let capacity = maximum_vertices
+        .checked_mul(VERTEX_STRIDE)
+        .ok_or(Error::Overflow)?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(capacity)
+        .map_err(|_| Error::OutOfMemory)?;
+
+    let aspect_scale = if width > height {
+        height as f32 / width as f32
+    } else {
+        1.0
+    };
+    push_panel(
+        &mut bytes,
+        -0.96,
+        -0.90,
+        0.96,
+        0.90,
+        [
+            [0.025, 0.055, 0.13],
+            [0.08, 0.03, 0.17],
+            [0.025, 0.16, 0.22],
+            [0.18, 0.055, 0.22],
+        ],
+    );
+    push_panel(
+        &mut bytes,
+        -0.88,
+        -0.78,
+        -0.50,
+        0.72,
+        [
+            [0.04, 0.22, 0.30],
+            [0.04, 0.08, 0.16],
+            [0.14, 0.48, 0.56],
+            [0.10, 0.18, 0.34],
+        ],
+    );
+    push_panel(
+        &mut bytes,
+        0.54,
+        -0.70,
+        0.86,
+        -0.18,
+        [
+            [0.50, 0.10, 0.30],
+            [0.20, 0.04, 0.24],
+            [0.96, 0.34, 0.38],
+            [0.52, 0.08, 0.36],
+        ],
+    );
+
+    let center = [0.16 * aspect_scale, 0.10];
+    let outer_radius_x = 0.62 * aspect_scale;
+    let outer_radius_y = 0.62;
+    let inner_radius_x = 0.24 * aspect_scale;
+    let inner_radius_y = 0.24;
+    for segment in 0..STAR_SEGMENTS {
+        let angle0 = core::f32::consts::TAU * segment as f32 / STAR_SEGMENTS as f32;
+        let angle1 = core::f32::consts::TAU * (segment + 1) as f32 / STAR_SEGMENTS as f32;
+        let radius0 = if segment % 2 == 0 {
+            [outer_radius_x, outer_radius_y]
+        } else {
+            [inner_radius_x, inner_radius_y]
+        };
+        let radius1 = if (segment + 1) % 2 == 0 {
+            [outer_radius_x, outer_radius_y]
+        } else {
+            [inner_radius_x, inner_radius_y]
+        };
+        let edge0 = [
+            center[0] + libm::cosf(angle0) * radius0[0],
+            center[1] + libm::sinf(angle0) * radius0[1],
+        ];
+        let edge1 = [
+            center[0] + libm::cosf(angle1) * radius1[0],
+            center[1] + libm::sinf(angle1) * radius1[1],
+        ];
+        let phase = segment as f32 / STAR_SEGMENTS as f32;
+        let edge_color0 = [0.20 + phase * 0.76, 0.82 - phase * 0.42, 0.92];
+        let edge_color1 = [0.96, 0.20 + phase * 0.55, 0.50 + phase * 0.42];
+        push_triangle(
+            &mut bytes,
+            [center, edge0, edge1],
+            [[1.0, 0.92, 0.64], edge_color0, edge_color1],
+        );
+    }
+
+    let vertex_count = bytes.len() / VERTEX_STRIDE;
+    if bytes.len() % VERTEX_STRIDE != 0 || vertex_count % 3 != 0 {
+        return Err(Error::InvalidValue);
+    }
+    Ok((
+        bytes,
+        u32::try_from(vertex_count).map_err(|_| Error::Overflow)?,
+    ))
+}
+
+fn main() -> ExitCode {
+    let display = match DisplaySurface::open_primary() {
+        Ok(display) => display,
+        Err(error) => return fail("failed to open primary display", error),
+    };
+    let display_info = match display.get_info() {
+        Ok(info) => info,
+        Err(error) => return fail("failed to query display", error),
+    };
+    let device = match Device::open("/dev/gpu0") {
+        Ok(device) => device,
+        Err(error) => return fail("failed to open GPU", error),
+    };
+    let capabilities = device.capabilities();
+    if !capabilities.supports_rendering() || !capabilities.supports_presentation() {
+        println!("sgfx_showcase: rendering or presentation is unsupported");
+        return ExitCode::from(1);
+    }
+    let context = match device.create_context() {
+        Ok(context) => context,
+        Err(error) => return fail("failed to create context", error),
+    };
+    let image = match context.create_image(display_info.width, display_info.height) {
+        Ok(image) => image,
+        Err(error) => return fail("failed to create render target", error),
+    };
+    let queue = match context.create_queue() {
+        Ok(queue) => queue,
+        Err(error) => return fail("failed to create queue", error),
+    };
+    let (vertex_bytes, vertex_count) = match scene_vertices(image.width(), image.height()) {
+        Ok(scene) => scene,
+        Err(error) => return fail("failed to build scene vertices", error),
+    };
+
+    let resources = ResourceTable::new();
+    let extent = match Extent2D::new(image.width(), image.height()) {
+        Ok(extent) => extent,
+        Err(error) => return fail("invalid display extent", error),
+    };
+    let target_desc = match TextureDesc::new(
+        TextureFormat::Bgra8Unorm,
+        extent,
+        TextureUsage::RENDER_ATTACHMENT | TextureUsage::PRESENT,
+    ) {
+        Ok(desc) => desc,
+        Err(error) => return fail("invalid target descriptor", error),
+    };
+    let target = match resources.define_texture(target_desc) {
+        Ok(target) => target,
+        Err(error) => return fail("failed to define IR target", error),
+    };
+    let buffer_size = match u64::try_from(vertex_bytes.len()) {
+        Ok(size) => size,
+        Err(error) => return fail("vertex buffer size overflow", error),
+    };
+    let vertex_buffer_desc =
+        match BufferDesc::new(buffer_size, BufferUsage::VERTEX | BufferUsage::COPY_DST) {
+            Ok(desc) => desc,
+            Err(error) => return fail("invalid vertex buffer descriptor", error),
+        };
+    let vertex_buffer = match resources.define_buffer(vertex_buffer_desc) {
+        Ok(buffer) => buffer,
+        Err(error) => return fail("failed to define IR vertex buffer", error),
+    };
+    let mut attributes = Vec::new();
+    if attributes.try_reserve_exact(2).is_err() {
+        return fail("failed to reserve vertex attributes", Error::OutOfMemory);
+    }
+    attributes.push(VertexAttribute::new(0, VertexFormat::Float32x4, 0));
+    attributes.push(VertexAttribute::new(1, VertexFormat::Float32x3, 16));
+    let layout = match VertexBufferLayout::new(VERTEX_STRIDE as u32, attributes) {
+        Ok(layout) => layout,
+        Err(error) => return fail("invalid vertex layout", error),
+    };
+    let pipeline_desc = match RenderPipelineDesc::new(
+        TextureFormat::Bgra8Unorm,
+        PrimitiveTopology::TriangleList,
+        layout,
+        FragmentProgram::VertexColor,
+        BlendState::REPLACE,
+        RasterState::new(
+            sgfx::ir::CullMode::None,
+            sgfx::ir::FrontFace::CounterClockwise,
+        ),
+    ) {
+        Ok(desc) => desc,
+        Err(error) => return fail("invalid pipeline descriptor", error),
+    };
+    let pipeline = match resources.define_render_pipeline(pipeline_desc) {
+        Ok(pipeline) => pipeline,
+        Err(error) => return fail("failed to define IR pipeline", error),
+    };
+
+    let mut encoder = CommandEncoder::new(&resources);
+    if let Err(error) = encoder.write_buffer(vertex_buffer, 0, &vertex_bytes) {
+        return fail("failed to record vertex upload", error);
+    }
+    let area = match PixelRect::new(0, 0, image.width(), image.height()) {
+        Ok(area) => area,
+        Err(error) => return fail("invalid render area", error),
+    };
+    let pass_desc = match RenderPassDesc::new(
+        &resources,
+        target,
+        area,
+        LoadOp::Clear(match Color::rgba(0.008, 0.012, 0.028, 1.0) {
+            Ok(color) => color,
+            Err(error) => return fail("invalid clear color", error),
+        }),
+        StoreOp::Store,
+    ) {
+        Ok(desc) => desc,
+        Err(error) => return fail("invalid render pass", error),
+    };
+    let mut pass = match encoder.begin_render_pass(pass_desc) {
+        Ok(pass) => pass,
+        Err(error) => return fail("failed to begin IR render pass", error),
+    };
+    if let Err(error) = pass.set_pipeline(pipeline) {
+        return fail("failed to bind IR pipeline", error);
+    }
+    if let Err(error) = pass.set_vertex_buffer(vertex_buffer, 0) {
+        return fail("failed to bind IR vertex buffer", error);
+    }
+    let white = match Color::rgba(1.0, 1.0, 1.0, 1.0) {
+        Ok(color) => color,
+        Err(error) => return fail("invalid draw color", error),
+    };
+    if let Err(error) = pass.set_uniforms(DrawUniforms::new(Transform::identity(), white)) {
+        return fail("failed to bind IR uniforms", error);
+    }
+    if let Err(error) = pass.draw(vertex_count, 0) {
+        return fail("failed to record IR draw", error);
+    }
+    if let Err(error) = pass.end() {
+        return fail("failed to end IR render pass", error);
+    }
+    let commands = match encoder.finish() {
+        Ok(commands) => commands,
+        Err(error) => return fail("failed to finish IR commands", error),
+    };
+    let present_target = match image.map_ir_present_target(&resources, target) {
+        Ok(target) => target,
+        Err(error) => return fail("failed to map IR presentation target", error),
+    };
+    if let Err(error) = queue.submit_ir(&context, present_target, &commands) {
+        return fail("IR submission failed", error);
+    }
+    if let Err(error) = image.present(&display) {
+        return fail("image present failed", error);
+    }
+
+    println!(
+        "sgfx_showcase: displaying {} IR-derived vertices at {}x{}",
+        vertex_count,
+        image.width(),
+        image.height()
+    );
+    loop {
+        thread::sleep(FRAME_HOLD_INTERVAL);
+    }
+}

--- a/user/std-bin/src/sgfx_showcase.rs
+++ b/user/std-bin/src/sgfx_showcase.rs
@@ -1,4 +1,4 @@
-//! Visible advanced scene submitted through the backend-neutral `sgfx` IR.
+//! Animated multi-pass showcase for the backend-neutral `sgfx` IR.
 
 use std::process::ExitCode;
 use std::thread;
@@ -8,329 +8,641 @@ use std::vec::Vec;
 use framebuffer::DisplaySurface;
 use sgfx::Device;
 use sgfx::ir::{
-    BlendState, BufferDesc, BufferUsage, Color, CommandEncoder, DrawUniforms, Error, Extent2D,
-    FragmentProgram, LoadOp, PixelRect, PrimitiveTopology, RasterState, RenderPassDesc,
-    RenderPipelineDesc, ResourceTable, StoreOp, TextureDesc, TextureFormat, TextureUsage,
-    Transform, VertexAttribute, VertexBufferLayout, VertexFormat,
+    AddressMode, BlendState, BufferDesc, BufferUsage, Color, CommandEncoder, DrawUniforms, Error,
+    Extent2D, FilterMode, FragmentProgram, IndexFormat, LoadOp, PixelRect, PrimitiveTopology,
+    RasterState, RenderPassDesc, RenderPipelineDesc, ResourceTable, SamplerDesc, StoreOp,
+    TextureDesc, TextureFormat, TextureSampleMode, TextureUsage, TextureWrite, Transform,
+    VertexAttribute, VertexBufferLayout, VertexFormat,
 };
 
-const VERTEX_STRIDE: usize = 28;
-const STAR_SEGMENTS: usize = 32;
-const FRAME_HOLD_INTERVAL: Duration = Duration::from_secs(1);
+const COLOR_VERTEX_STRIDE: usize = 32;
+const TEXTURE_VERTEX_STRIDE: usize = 24;
+const QUAD_VERTEX_COUNT: usize = 4;
+const INDEX_COUNT: u32 = 6;
+const MASK_SIZE: u32 = 64;
+const FRAME_INTERVAL: Duration = Duration::from_millis(16);
 
 fn fail(message: &str, error: impl core::fmt::Debug) -> ExitCode {
     println!("sgfx_showcase: {message}: {error:?}");
     ExitCode::from(1)
 }
 
-fn push_f32(bytes: &mut Vec<u8>, value: f32) {
-    bytes.extend_from_slice(&value.to_le_bytes());
-}
-
-fn push_vertex(bytes: &mut Vec<u8>, x: f32, y: f32, color: [f32; 3]) {
-    for component in [x, y, 0.0, 1.0] {
-        push_f32(bytes, component);
-    }
-    for component in color {
-        push_f32(bytes, component);
-    }
-}
-
-fn push_triangle(bytes: &mut Vec<u8>, positions: [[f32; 2]; 3], colors: [[f32; 3]; 3]) {
-    for index in 0..3 {
-        push_vertex(
-            bytes,
-            positions[index][0],
-            positions[index][1],
-            colors[index],
-        );
-    }
-}
-
-fn push_panel(
-    bytes: &mut Vec<u8>,
-    left: f32,
-    bottom: f32,
-    right: f32,
-    top: f32,
-    colors: [[f32; 3]; 4],
-) {
-    push_triangle(
-        bytes,
-        [[left, bottom], [right, bottom], [left, top]],
-        [colors[0], colors[1], colors[2]],
-    );
-    push_triangle(
-        bytes,
-        [[left, top], [right, bottom], [right, top]],
-        [colors[2], colors[1], colors[3]],
-    );
-}
-
-fn scene_vertices(width: u32, height: u32) -> sgfx::ir::Result<(Vec<u8>, u32)> {
-    let maximum_vertices = STAR_SEGMENTS
-        .checked_mul(3)
-        .and_then(|value| value.checked_add(30))
-        .ok_or(Error::Overflow)?;
-    let capacity = maximum_vertices
-        .checked_mul(VERTEX_STRIDE)
-        .ok_or(Error::Overflow)?;
+fn reserved_bytes(capacity: usize) -> sgfx::ir::Result<Vec<u8>> {
     let mut bytes = Vec::new();
     bytes
         .try_reserve_exact(capacity)
         .map_err(|_| Error::OutOfMemory)?;
+    Ok(bytes)
+}
 
-    let aspect_scale = if width > height {
-        height as f32 / width as f32
-    } else {
-        1.0
-    };
-    push_panel(
-        &mut bytes,
-        -0.96,
-        -0.90,
-        0.96,
-        0.90,
-        [
-            [0.025, 0.055, 0.13],
-            [0.08, 0.03, 0.17],
-            [0.025, 0.16, 0.22],
-            [0.18, 0.055, 0.22],
-        ],
-    );
-    push_panel(
-        &mut bytes,
-        -0.88,
-        -0.78,
-        -0.50,
-        0.72,
-        [
-            [0.04, 0.22, 0.30],
-            [0.04, 0.08, 0.16],
-            [0.14, 0.48, 0.56],
-            [0.10, 0.18, 0.34],
-        ],
-    );
-    push_panel(
-        &mut bytes,
-        0.54,
-        -0.70,
-        0.86,
-        -0.18,
-        [
-            [0.50, 0.10, 0.30],
-            [0.20, 0.04, 0.24],
-            [0.96, 0.34, 0.38],
-            [0.52, 0.08, 0.36],
-        ],
-    );
+fn push_f32(bytes: &mut Vec<u8>, value: f32) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
 
-    let center = [0.16 * aspect_scale, 0.10];
-    let outer_radius_x = 0.62 * aspect_scale;
-    let outer_radius_y = 0.62;
-    let inner_radius_x = 0.24 * aspect_scale;
-    let inner_radius_y = 0.24;
-    for segment in 0..STAR_SEGMENTS {
-        let angle0 = core::f32::consts::TAU * segment as f32 / STAR_SEGMENTS as f32;
-        let angle1 = core::f32::consts::TAU * (segment + 1) as f32 / STAR_SEGMENTS as f32;
-        let radius0 = if segment % 2 == 0 {
-            [outer_radius_x, outer_radius_y]
-        } else {
-            [inner_radius_x, inner_radius_y]
-        };
-        let radius1 = if (segment + 1) % 2 == 0 {
-            [outer_radius_x, outer_radius_y]
-        } else {
-            [inner_radius_x, inner_radius_y]
-        };
-        let edge0 = [
-            center[0] + libm::cosf(angle0) * radius0[0],
-            center[1] + libm::sinf(angle0) * radius0[1],
-        ];
-        let edge1 = [
-            center[0] + libm::cosf(angle1) * radius1[0],
-            center[1] + libm::sinf(angle1) * radius1[1],
-        ];
-        let phase = segment as f32 / STAR_SEGMENTS as f32;
-        let edge_color0 = [0.20 + phase * 0.76, 0.82 - phase * 0.42, 0.92];
-        let edge_color1 = [0.96, 0.20 + phase * 0.55, 0.50 + phase * 0.42];
-        push_triangle(
-            &mut bytes,
-            [center, edge0, edge1],
-            [[1.0, 0.92, 0.64], edge_color0, edge_color1],
-        );
+fn push_position(bytes: &mut Vec<u8>, x: f32, y: f32) {
+    for component in [x, y, 0.0, 1.0] {
+        push_f32(bytes, component);
     }
+}
 
-    let vertex_count = bytes.len() / VERTEX_STRIDE;
-    if bytes.len() % VERTEX_STRIDE != 0 || vertex_count % 3 != 0 {
+fn color_quad_bytes() -> sgfx::ir::Result<Vec<u8>> {
+    let capacity = QUAD_VERTEX_COUNT
+        .checked_mul(COLOR_VERTEX_STRIDE)
+        .ok_or(Error::Overflow)?;
+    let mut bytes = reserved_bytes(capacity)?;
+    let vertices = [
+        ([-0.78, -0.72], [0.02, 0.72, 0.82, 0.94]),
+        ([0.78, -0.72], [0.96, 0.25, 0.30, 0.94]),
+        ([0.78, 0.72], [1.0, 0.73, 0.24, 0.96]),
+        ([-0.78, 0.72], [0.04, 0.28, 0.42, 0.94]),
+    ];
+    for (position, color) in vertices {
+        push_position(&mut bytes, position[0], position[1]);
+        for component in color {
+            push_f32(&mut bytes, component);
+        }
+    }
+    if bytes.len() != capacity {
         return Err(Error::InvalidValue);
     }
-    Ok((
-        bytes,
-        u32::try_from(vertex_count).map_err(|_| Error::Overflow)?,
-    ))
+    Ok(bytes)
+}
+
+fn texture_quad_bytes() -> sgfx::ir::Result<Vec<u8>> {
+    let capacity = QUAD_VERTEX_COUNT
+        .checked_mul(TEXTURE_VERTEX_STRIDE)
+        .ok_or(Error::Overflow)?;
+    let mut bytes = reserved_bytes(capacity)?;
+    let vertices = [
+        ([-1.0, -1.0], [0.0, 1.0]),
+        ([1.0, -1.0], [1.0, 1.0]),
+        ([1.0, 1.0], [1.0, 0.0]),
+        ([-1.0, 1.0], [0.0, 0.0]),
+    ];
+    for (position, uv) in vertices {
+        push_position(&mut bytes, position[0], position[1]);
+        push_f32(&mut bytes, uv[0]);
+        push_f32(&mut bytes, uv[1]);
+    }
+    if bytes.len() != capacity {
+        return Err(Error::InvalidValue);
+    }
+    Ok(bytes)
+}
+
+fn index_bytes() -> sgfx::ir::Result<Vec<u8>> {
+    let mut bytes = reserved_bytes(INDEX_COUNT as usize * core::mem::size_of::<u16>())?;
+    for index in [0_u16, 1, 2, 0, 2, 3] {
+        bytes.extend_from_slice(&index.to_le_bytes());
+    }
+    Ok(bytes)
+}
+
+fn mask_bytes() -> sgfx::ir::Result<Vec<u8>> {
+    let side = usize::try_from(MASK_SIZE).map_err(|_| Error::Overflow)?;
+    let length = side.checked_mul(side).ok_or(Error::Overflow)?;
+    let mut bytes = reserved_bytes(length)?;
+    bytes.resize(length, 0);
+    let center = MASK_SIZE as f32 * 0.5;
+    for y in 0..MASK_SIZE {
+        for x in 0..MASK_SIZE {
+            let dx = x as f32 + 0.5 - center;
+            let dy = y as f32 + 0.5 - center;
+            let radius = libm::sqrtf(dx * dx + dy * dy);
+            let spoke = libm::sinf(libm::atan2f(dy, dx) * 8.0).abs();
+            let ring = (radius - 19.0).abs() < 2.3;
+            let core = radius < 9.0;
+            let rays = radius > 11.0 && radius < 27.0 && spoke > 0.86;
+            let coverage = if ring || core || rays { 255 } else { 0 };
+            let offset = usize::try_from(y)
+                .ok()
+                .and_then(|row| row.checked_mul(side))
+                .and_then(|row| {
+                    usize::try_from(x)
+                        .ok()
+                        .and_then(|column| row.checked_add(column))
+                })
+                .ok_or(Error::Overflow)?;
+            bytes[offset] = coverage;
+        }
+    }
+    Ok(bytes)
+}
+
+fn attributes(values: &[(u32, VertexFormat, u32)]) -> sgfx::ir::Result<Vec<VertexAttribute>> {
+    let mut attributes = Vec::new();
+    attributes
+        .try_reserve_exact(values.len())
+        .map_err(|_| Error::OutOfMemory)?;
+    for (location, format, offset) in values {
+        attributes.push(VertexAttribute::new(*location, *format, *offset));
+    }
+    Ok(attributes)
+}
+
+fn transform_2d(
+    scale_x: f32,
+    scale_y: f32,
+    angle: f32,
+    x: f32,
+    y: f32,
+) -> sgfx::ir::Result<Transform> {
+    let cosine = libm::cosf(angle);
+    let sine = libm::sinf(angle);
+    Transform::from_columns([
+        cosine * scale_x,
+        sine * scale_x,
+        0.0,
+        0.0,
+        -sine * scale_y,
+        cosine * scale_y,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        x,
+        y,
+        0.0,
+        1.0,
+    ])
+}
+
+fn inset_rect(width: u32, height: u32) -> sgfx::ir::Result<PixelRect> {
+    let margin = (width.min(height) / 18).max(1);
+    let horizontal = margin.checked_mul(2).ok_or(Error::Overflow)?;
+    if width <= horizontal || height <= horizontal {
+        PixelRect::new(0, 0, width, height)
+    } else {
+        PixelRect::new(margin, margin, width - horizontal, height - horizontal)
+    }
 }
 
 fn main() -> ExitCode {
-    let display = match DisplaySurface::open_primary() {
-        Ok(display) => display,
-        Err(error) => return fail("failed to open primary display", error),
-    };
-    let display_info = match display.get_info() {
-        Ok(info) => info,
-        Err(error) => return fail("failed to query display", error),
-    };
-    let device = match Device::open("/dev/gpu0") {
-        Ok(device) => device,
-        Err(error) => return fail("failed to open GPU", error),
-    };
+    macro_rules! attempt {
+        ($expression:expr, $message:literal) => {
+            match $expression {
+                Ok(value) => value,
+                Err(error) => return fail($message, error),
+            }
+        };
+    }
+
+    let display = attempt!(
+        DisplaySurface::open_primary(),
+        "failed to open primary display"
+    );
+    let display_info = attempt!(display.get_info(), "failed to query display");
+    let device = attempt!(Device::open("/dev/gpu0"), "failed to open GPU");
     let capabilities = device.capabilities();
-    if !capabilities.supports_rendering() || !capabilities.supports_presentation() {
-        println!("sgfx_showcase: rendering or presentation is unsupported");
+    if !capabilities.supports_rendering()
+        || !capabilities.supports_presentation()
+        || !capabilities.supports_image_upload()
+    {
+        println!("sgfx_showcase: required GPU capabilities are unavailable");
         return ExitCode::from(1);
     }
-    let context = match device.create_context() {
-        Ok(context) => context,
-        Err(error) => return fail("failed to create context", error),
-    };
-    let image = match context.create_image(display_info.width, display_info.height) {
-        Ok(image) => image,
-        Err(error) => return fail("failed to create render target", error),
-    };
-    let queue = match context.create_queue() {
-        Ok(queue) => queue,
-        Err(error) => return fail("failed to create queue", error),
-    };
-    let (vertex_bytes, vertex_count) = match scene_vertices(image.width(), image.height()) {
-        Ok(scene) => scene,
-        Err(error) => return fail("failed to build scene vertices", error),
-    };
+    let context = attempt!(device.create_context(), "failed to create context");
+    let image = attempt!(
+        context.create_image(display_info.width, display_info.height),
+        "failed to create presentation image"
+    );
+    let queue = attempt!(context.create_queue(), "failed to create queue");
+
+    let offscreen_width = image.width().min(640).max(1);
+    let offscreen_height = image.height().min(400).max(1);
+    let screen_extent = attempt!(
+        Extent2D::new(image.width(), image.height()),
+        "invalid screen extent"
+    );
+    let offscreen_extent = attempt!(
+        Extent2D::new(offscreen_width, offscreen_height),
+        "invalid offscreen extent"
+    );
+    let mask_extent = attempt!(Extent2D::new(MASK_SIZE, MASK_SIZE), "invalid mask extent");
+    let screen_area = attempt!(
+        PixelRect::new(0, 0, image.width(), image.height()),
+        "invalid screen area"
+    );
+    let offscreen_area = attempt!(
+        PixelRect::new(0, 0, offscreen_width, offscreen_height),
+        "invalid offscreen area"
+    );
+    let mask_area = attempt!(
+        PixelRect::new(0, 0, MASK_SIZE, MASK_SIZE),
+        "invalid mask area"
+    );
+
+    let color_vertices = attempt!(color_quad_bytes(), "failed to build color vertices");
+    let texture_vertices = attempt!(texture_quad_bytes(), "failed to build texture vertices");
+    let indices = attempt!(index_bytes(), "failed to build indices");
+    let mask = attempt!(mask_bytes(), "failed to build alpha mask");
+    let color_buffer_size = attempt!(
+        u64::try_from(color_vertices.len()).map_err(|_| Error::Overflow),
+        "color vertex buffer is too large"
+    );
+    let texture_buffer_size = attempt!(
+        u64::try_from(texture_vertices.len()).map_err(|_| Error::Overflow),
+        "texture vertex buffer is too large"
+    );
+    let index_buffer_size = attempt!(
+        u64::try_from(indices.len()).map_err(|_| Error::Overflow),
+        "index buffer is too large"
+    );
 
     let resources = ResourceTable::new();
-    let extent = match Extent2D::new(image.width(), image.height()) {
-        Ok(extent) => extent,
-        Err(error) => return fail("invalid display extent", error),
-    };
-    let target_desc = match TextureDesc::new(
-        TextureFormat::Bgra8Unorm,
-        extent,
-        TextureUsage::RENDER_ATTACHMENT | TextureUsage::PRESENT,
-    ) {
-        Ok(desc) => desc,
-        Err(error) => return fail("invalid target descriptor", error),
-    };
-    let target = match resources.define_texture(target_desc) {
-        Ok(target) => target,
-        Err(error) => return fail("failed to define IR target", error),
-    };
-    let buffer_size = match u64::try_from(vertex_bytes.len()) {
-        Ok(size) => size,
-        Err(error) => return fail("vertex buffer size overflow", error),
-    };
-    let vertex_buffer_desc =
-        match BufferDesc::new(buffer_size, BufferUsage::VERTEX | BufferUsage::COPY_DST) {
-            Ok(desc) => desc,
-            Err(error) => return fail("invalid vertex buffer descriptor", error),
-        };
-    let vertex_buffer = match resources.define_buffer(vertex_buffer_desc) {
-        Ok(buffer) => buffer,
-        Err(error) => return fail("failed to define IR vertex buffer", error),
-    };
-    let mut attributes = Vec::new();
-    if attributes.try_reserve_exact(2).is_err() {
-        return fail("failed to reserve vertex attributes", Error::OutOfMemory);
-    }
-    attributes.push(VertexAttribute::new(0, VertexFormat::Float32x4, 0));
-    attributes.push(VertexAttribute::new(1, VertexFormat::Float32x3, 16));
-    let layout = match VertexBufferLayout::new(VERTEX_STRIDE as u32, attributes) {
-        Ok(layout) => layout,
-        Err(error) => return fail("invalid vertex layout", error),
-    };
-    let pipeline_desc = match RenderPipelineDesc::new(
-        TextureFormat::Bgra8Unorm,
-        PrimitiveTopology::TriangleList,
-        layout,
-        FragmentProgram::VertexColor,
-        BlendState::REPLACE,
-        RasterState::new(
-            sgfx::ir::CullMode::None,
-            sgfx::ir::FrontFace::CounterClockwise,
-        ),
-    ) {
-        Ok(desc) => desc,
-        Err(error) => return fail("invalid pipeline descriptor", error),
-    };
-    let pipeline = match resources.define_render_pipeline(pipeline_desc) {
-        Ok(pipeline) => pipeline,
-        Err(error) => return fail("failed to define IR pipeline", error),
-    };
+    let screen = attempt!(
+        resources.define_texture(attempt!(
+            TextureDesc::new(
+                TextureFormat::Bgra8Unorm,
+                screen_extent,
+                TextureUsage::RENDER_ATTACHMENT | TextureUsage::PRESENT,
+            ),
+            "invalid screen descriptor"
+        )),
+        "failed to define screen texture"
+    );
+    let offscreen = attempt!(
+        resources.define_texture(attempt!(
+            TextureDesc::new(
+                TextureFormat::Bgra8Unorm,
+                offscreen_extent,
+                TextureUsage::RENDER_ATTACHMENT | TextureUsage::SAMPLED | TextureUsage::COPY_SRC,
+            ),
+            "invalid offscreen descriptor"
+        )),
+        "failed to define offscreen texture"
+    );
+    let copied = attempt!(
+        resources.define_texture(attempt!(
+            TextureDesc::new(
+                TextureFormat::Bgra8Unorm,
+                offscreen_extent,
+                TextureUsage::SAMPLED | TextureUsage::COPY_DST,
+            ),
+            "invalid copied texture descriptor"
+        )),
+        "failed to define copied texture"
+    );
+    let alpha_mask = attempt!(
+        resources.define_texture(attempt!(
+            TextureDesc::new(
+                TextureFormat::R8Unorm,
+                mask_extent,
+                TextureUsage::SAMPLED | TextureUsage::COPY_DST,
+            ),
+            "invalid alpha-mask descriptor"
+        )),
+        "failed to define alpha-mask texture"
+    );
 
-    let mut encoder = CommandEncoder::new(&resources);
-    if let Err(error) = encoder.write_buffer(vertex_buffer, 0, &vertex_bytes) {
-        return fail("failed to record vertex upload", error);
-    }
-    let area = match PixelRect::new(0, 0, image.width(), image.height()) {
-        Ok(area) => area,
-        Err(error) => return fail("invalid render area", error),
-    };
-    let pass_desc = match RenderPassDesc::new(
-        &resources,
-        target,
-        area,
-        LoadOp::Clear(match Color::rgba(0.008, 0.012, 0.028, 1.0) {
-            Ok(color) => color,
-            Err(error) => return fail("invalid clear color", error),
-        }),
-        StoreOp::Store,
-    ) {
-        Ok(desc) => desc,
-        Err(error) => return fail("invalid render pass", error),
-    };
-    let mut pass = match encoder.begin_render_pass(pass_desc) {
-        Ok(pass) => pass,
-        Err(error) => return fail("failed to begin IR render pass", error),
-    };
-    if let Err(error) = pass.set_pipeline(pipeline) {
-        return fail("failed to bind IR pipeline", error);
-    }
-    if let Err(error) = pass.set_vertex_buffer(vertex_buffer, 0) {
-        return fail("failed to bind IR vertex buffer", error);
-    }
-    let white = match Color::rgba(1.0, 1.0, 1.0, 1.0) {
-        Ok(color) => color,
-        Err(error) => return fail("invalid draw color", error),
-    };
-    if let Err(error) = pass.set_uniforms(DrawUniforms::new(Transform::identity(), white)) {
-        return fail("failed to bind IR uniforms", error);
-    }
-    if let Err(error) = pass.draw(vertex_count, 0) {
-        return fail("failed to record IR draw", error);
-    }
-    if let Err(error) = pass.end() {
-        return fail("failed to end IR render pass", error);
-    }
-    let commands = match encoder.finish() {
-        Ok(commands) => commands,
-        Err(error) => return fail("failed to finish IR commands", error),
-    };
-    let present_target = match image.map_ir_present_target(&resources, target) {
-        Ok(target) => target,
-        Err(error) => return fail("failed to map IR presentation target", error),
-    };
-    if let Err(error) = queue.submit_ir(&context, present_target, &commands) {
-        return fail("IR submission failed", error);
-    }
-    if let Err(error) = image.present(&display) {
-        return fail("image present failed", error);
+    let color_buffer = attempt!(
+        resources.define_buffer(attempt!(
+            BufferDesc::new(
+                color_buffer_size,
+                BufferUsage::VERTEX | BufferUsage::COPY_DST,
+            ),
+            "invalid color buffer descriptor"
+        )),
+        "failed to define color buffer"
+    );
+    let texture_buffer = attempt!(
+        resources.define_buffer(attempt!(
+            BufferDesc::new(
+                texture_buffer_size,
+                BufferUsage::VERTEX | BufferUsage::COPY_DST,
+            ),
+            "invalid texture buffer descriptor"
+        )),
+        "failed to define texture buffer"
+    );
+    let index_buffer = attempt!(
+        resources.define_buffer(attempt!(
+            BufferDesc::new(
+                index_buffer_size,
+                BufferUsage::INDEX | BufferUsage::COPY_DST,
+            ),
+            "invalid index buffer descriptor"
+        )),
+        "failed to define index buffer"
+    );
+
+    let color_layout = attempt!(
+        VertexBufferLayout::new(
+            COLOR_VERTEX_STRIDE as u32,
+            attempt!(
+                attributes(&[
+                    (0, VertexFormat::Float32x4, 0),
+                    (1, VertexFormat::Float32x4, 16),
+                ]),
+                "failed to build color attributes"
+            ),
+        ),
+        "invalid color vertex layout"
+    );
+    let texture_layout = attempt!(
+        VertexBufferLayout::new(
+            TEXTURE_VERTEX_STRIDE as u32,
+            attempt!(
+                attributes(&[
+                    (0, VertexFormat::Float32x4, 0),
+                    (1, VertexFormat::Float32x2, 16),
+                ]),
+                "failed to build texture attributes"
+            ),
+        ),
+        "invalid texture vertex layout"
+    );
+    let raster = RasterState::new(
+        sgfx::ir::CullMode::None,
+        sgfx::ir::FrontFace::CounterClockwise,
+    );
+    let color_pipeline = attempt!(
+        resources.define_render_pipeline(attempt!(
+            RenderPipelineDesc::new(
+                TextureFormat::Bgra8Unorm,
+                PrimitiveTopology::TriangleList,
+                color_layout.clone(),
+                FragmentProgram::VertexColor,
+                BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
+                raster,
+            ),
+            "invalid color pipeline"
+        )),
+        "failed to define color pipeline"
+    );
+    let solid_pipeline = attempt!(
+        resources.define_render_pipeline(attempt!(
+            RenderPipelineDesc::new(
+                TextureFormat::Bgra8Unorm,
+                PrimitiveTopology::TriangleList,
+                color_layout,
+                FragmentProgram::Solid,
+                BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
+                raster,
+            ),
+            "invalid solid pipeline"
+        )),
+        "failed to define solid pipeline"
+    );
+    let texture_pipeline = attempt!(
+        resources.define_render_pipeline(attempt!(
+            RenderPipelineDesc::new(
+                TextureFormat::Bgra8Unorm,
+                PrimitiveTopology::TriangleList,
+                texture_layout.clone(),
+                FragmentProgram::Texture(TextureSampleMode::Rgba),
+                BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
+                raster,
+            ),
+            "invalid texture pipeline"
+        )),
+        "failed to define texture pipeline"
+    );
+    let mask_pipeline = attempt!(
+        resources.define_render_pipeline(attempt!(
+            RenderPipelineDesc::new(
+                TextureFormat::Bgra8Unorm,
+                PrimitiveTopology::TriangleList,
+                texture_layout,
+                FragmentProgram::Texture(TextureSampleMode::AlphaMask),
+                BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
+                raster,
+            ),
+            "invalid mask pipeline"
+        )),
+        "failed to define mask pipeline"
+    );
+    let sampler = attempt!(
+        resources.define_sampler(SamplerDesc::new(
+            FilterMode::Linear,
+            FilterMode::Linear,
+            AddressMode::ClampToEdge,
+            AddressMode::ClampToEdge,
+        )),
+        "failed to define sampler"
+    );
+
+    let mut ir_resources = attempt!(
+        context.create_ir_resources(&resources),
+        "failed to create IR resource cache"
+    );
+    if let Err(error) = ir_resources.map_image(screen, &image) {
+        return fail("failed to map presentation image", error);
     }
 
     println!(
-        "sgfx_showcase: displaying {} IR-derived vertices at {}x{}",
-        vertex_count,
+        "sgfx_showcase: animated {}x{} multi-pass IR scene",
         image.width(),
         image.height()
     );
+    let white = attempt!(Color::rgba(1.0, 1.0, 1.0, 1.0), "invalid white color");
+    let mut first_frame = true;
+    let mut frame = 0_u32;
     loop {
-        thread::sleep(FRAME_HOLD_INTERVAL);
+        let phase = frame as f32 * 0.012;
+        let mut encoder = CommandEncoder::new(&resources);
+        if first_frame {
+            if let Err(error) = encoder.write_buffer(color_buffer, 0, &color_vertices) {
+                return fail("failed to upload color vertices", error);
+            }
+            if let Err(error) = encoder.write_buffer(texture_buffer, 0, &texture_vertices) {
+                return fail("failed to upload texture vertices", error);
+            }
+            if let Err(error) = encoder.write_buffer(index_buffer, 0, &indices) {
+                return fail("failed to upload indices", error);
+            }
+            let mask_write = attempt!(
+                TextureWrite::new(mask_area, MASK_SIZE, &mask),
+                "invalid mask upload"
+            );
+            if let Err(error) = encoder.write_texture(alpha_mask, mask_write) {
+                return fail("failed to record mask upload", error);
+            }
+        }
+
+        let offscreen_pass = attempt!(
+            RenderPassDesc::new(
+                &resources,
+                offscreen,
+                offscreen_area,
+                LoadOp::Clear(attempt!(
+                    Color::rgba(0.008, 0.035, 0.065, 1.0),
+                    "invalid offscreen clear color"
+                )),
+                StoreOp::Store,
+            ),
+            "invalid offscreen pass"
+        );
+        {
+            let mut pass = attempt!(
+                encoder.begin_render_pass(offscreen_pass),
+                "failed to begin offscreen pass"
+            );
+            if let Err(error) = pass.set_pipeline(color_pipeline) {
+                return fail("failed to bind color pipeline", error);
+            }
+            if let Err(error) = pass.set_vertex_buffer(color_buffer, 0) {
+                return fail("failed to bind color vertices", error);
+            }
+            if let Err(error) = pass.set_index_buffer(index_buffer, 0, IndexFormat::Uint16) {
+                return fail("failed to bind indices", error);
+            }
+            if let Err(error) = pass.set_scissor(Some(attempt!(
+                inset_rect(offscreen_width, offscreen_height),
+                "invalid offscreen scissor"
+            ))) {
+                return fail("failed to set offscreen scissor", error);
+            }
+            let orbit = attempt!(
+                transform_2d(0.92, 0.92, phase, 0.0, 0.0),
+                "invalid orbit transform"
+            );
+            if let Err(error) = pass.set_uniforms(DrawUniforms::new(orbit, white)) {
+                return fail("failed to set orbit uniforms", error);
+            }
+            if let Err(error) = pass.draw_indexed(INDEX_COUNT, 0, 0) {
+                return fail("failed to record indexed orbit", error);
+            }
+            let echo = attempt!(
+                transform_2d(0.42, 0.42, -phase * 1.7, 0.42, -0.34),
+                "invalid echo transform"
+            );
+            let echo_tint = attempt!(Color::rgba(0.25, 0.92, 1.0, 0.72), "invalid echo tint");
+            if let Err(error) = pass.set_uniforms(DrawUniforms::new(echo, echo_tint)) {
+                return fail("failed to set echo uniforms", error);
+            }
+            if let Err(error) = pass.draw_indexed(INDEX_COUNT, 0, 0) {
+                return fail("failed to record indexed echo", error);
+            }
+            if let Err(error) = pass.end() {
+                return fail("failed to end offscreen pass", error);
+            }
+        }
+        if let Err(error) =
+            encoder.copy_texture_to_texture(offscreen, offscreen_area, copied, offscreen_area)
+        {
+            return fail("failed to record offscreen copy", error);
+        }
+
+        let screen_pass = attempt!(
+            RenderPassDesc::new(
+                &resources,
+                screen,
+                screen_area,
+                LoadOp::Clear(attempt!(
+                    Color::rgba(0.004, 0.008, 0.018, 1.0),
+                    "invalid screen clear color"
+                )),
+                StoreOp::Store,
+            ),
+            "invalid screen pass"
+        );
+        {
+            let mut pass = attempt!(
+                encoder.begin_render_pass(screen_pass),
+                "failed to begin screen pass"
+            );
+            if let Err(error) = pass.set_pipeline(texture_pipeline) {
+                return fail("failed to bind texture pipeline", error);
+            }
+            if let Err(error) = pass.set_vertex_buffer(texture_buffer, 0) {
+                return fail("failed to bind texture vertices", error);
+            }
+            if let Err(error) = pass.set_index_buffer(index_buffer, 0, IndexFormat::Uint16) {
+                return fail("failed to bind screen indices", error);
+            }
+            if let Err(error) = pass.set_texture(copied) {
+                return fail("failed to bind copied texture", error);
+            }
+            if let Err(error) = pass.set_sampler(sampler) {
+                return fail("failed to bind sampler", error);
+            }
+            if let Err(error) = pass.set_scissor(Some(attempt!(
+                inset_rect(image.width(), image.height()),
+                "invalid screen scissor"
+            ))) {
+                return fail("failed to set screen scissor", error);
+            }
+            let main_panel = attempt!(
+                transform_2d(0.72, 0.70, 0.025 * libm::sinf(phase), -0.10, 0.02),
+                "invalid main-panel transform"
+            );
+            if let Err(error) = pass.set_uniforms(DrawUniforms::new(main_panel, white)) {
+                return fail("failed to set main-panel uniforms", error);
+            }
+            if let Err(error) = pass.draw_indexed(INDEX_COUNT, 0, 0) {
+                return fail("failed to draw copied panel", error);
+            }
+
+            if let Err(error) = pass.set_texture(offscreen) {
+                return fail("failed to bind offscreen texture", error);
+            }
+            let thumbnail = attempt!(
+                transform_2d(0.23, 0.23, -phase * 0.65, 0.67, -0.62),
+                "invalid thumbnail transform"
+            );
+            let cool_tint = attempt!(Color::rgba(0.50, 0.92, 1.0, 0.82), "invalid thumbnail tint");
+            if let Err(error) = pass.set_uniforms(DrawUniforms::new(thumbnail, cool_tint)) {
+                return fail("failed to set thumbnail uniforms", error);
+            }
+            if let Err(error) = pass.draw_indexed(INDEX_COUNT, 0, 0) {
+                return fail("failed to draw offscreen thumbnail", error);
+            }
+
+            if let Err(error) = pass.set_pipeline(mask_pipeline) {
+                return fail("failed to bind mask pipeline", error);
+            }
+            if let Err(error) = pass.set_texture(alpha_mask) {
+                return fail("failed to bind alpha mask", error);
+            }
+            if let Err(error) = pass.set_scissor(None) {
+                return fail("failed to reset scissor", error);
+            }
+            let badge = attempt!(
+                transform_2d(0.17, 0.17, phase * 1.9, -0.72, 0.62),
+                "invalid badge transform"
+            );
+            let gold = attempt!(Color::rgba(1.0, 0.72, 0.22, 0.94), "invalid badge color");
+            if let Err(error) = pass.set_uniforms(DrawUniforms::new(badge, gold)) {
+                return fail("failed to set badge uniforms", error);
+            }
+            if let Err(error) = pass.draw_indexed(INDEX_COUNT, 0, 0) {
+                return fail("failed to draw alpha-mask badge", error);
+            }
+
+            if let Err(error) = pass.set_pipeline(solid_pipeline) {
+                return fail("failed to bind solid pipeline", error);
+            }
+            if let Err(error) = pass.set_vertex_buffer(color_buffer, 0) {
+                return fail("failed to bind solid vertices", error);
+            }
+            let accent = attempt!(
+                transform_2d(0.10, 0.018, 0.0, -0.72, 0.38),
+                "invalid accent transform"
+            );
+            let coral = attempt!(Color::rgba(1.0, 0.24, 0.28, 0.88), "invalid accent color");
+            if let Err(error) = pass.set_uniforms(DrawUniforms::new(accent, coral)) {
+                return fail("failed to set accent uniforms", error);
+            }
+            if let Err(error) = pass.draw_indexed(INDEX_COUNT, 0, 0) {
+                return fail("failed to draw solid accent", error);
+            }
+            if let Err(error) = pass.end() {
+                return fail("failed to end screen pass", error);
+            }
+        }
+
+        let commands = attempt!(encoder.finish(), "failed to finish IR commands");
+        if let Err(error) = queue.submit_ir(&context, &mut ir_resources, &commands) {
+            return fail("IR submission failed", error);
+        }
+        if let Err(error) = image.present(&display) {
+            return fail("image present failed", error);
+        }
+        first_frame = false;
+        frame = frame.wrapping_add(1);
+        thread::sleep(FRAME_INTERVAL);
     }
 }

--- a/user/video_player/Cargo.lock
+++ b/user/video_player/Cargo.lock
@@ -222,7 +222,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "scarlet-ui-core",
  "scarlet-ui-platform-sws",
@@ -231,7 +230,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-core"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "ab_glyph",
  "bitflags",
@@ -245,7 +243,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-macros"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -255,7 +252,6 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-platform-sws"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#c5751b15fc6ca73291b562d20941c117b247e0e5"
 dependencies = [
  "scarlet-std",
  "scarlet-ui-core",


### PR DESCRIPTION
This pull request introduces a new backend-neutral graphics intermediate representation (IR) to the `sgfx` library, adds support for IR resource management and command validation, and integrates these features into the driver and build system. The changes lay the groundwork for portable, validated graphics command buffers and resource descriptors, enabling future extensibility and backend abstraction. Additionally, a new showcase binary is added for demonstration and testing.

The most important changes are:

### Graphics IR Introduction and Integration

* Added a new `ir` module to `user/lib/sgfx` that defines a validated, backend-neutral logical graphics IR, including resource descriptors, command buffers, and comprehensive error handling. This module is designed for future backend abstraction and safe command recording. [[1]](diffhunk://#diff-b06d6131b4ca45ec2c6946f4253a080eaa359c54fbed071db87f67025ce275eaR1-R27) [[2]](diffhunk://#diff-0bdd763a83558fb392ae8bd91eee79c4ace8536dd65cc3a1b197167da2db30b0R1-R280) [[3]](diffhunk://#diff-d28686799e9607719d4f6eb120dcee05bdc25f55a8a85f45ec2d44fb97c987b6R25-R36)
* Introduced new types and validation logic for colors, pixel rectangles, transforms, and error handling in `ir/types.rs`, providing robust building blocks for IR operations.

### Driver API Extensions

* Extended the `Context`, `Queue`, and `Image` enums in `driver.rs` with methods for IR resource management, image mapping, and IR submission, enabling the driver to interact with the new IR system. [[1]](diffhunk://#diff-6e293874bd329d0ce5744eeb1413f533d2e5f8e467ca2ccc3579712f69c553c3R47-R71) [[2]](diffhunk://#diff-6e293874bd329d0ce5744eeb1413f533d2e5f8e467ca2ccc3579712f69c553c3R171-R234) [[3]](diffhunk://#diff-6e293874bd329d0ce5744eeb1413f533d2e5f8e467ca2ccc3579712f69c553c3R300-R489)
* Added the `IrResources`, `IrSubmitError`, and `UnsupportedIrFeature` types to the public API for IR execution and error reporting.

### Build System and Showcase Binary

* Registered a new binary, `sgfx_showcase`, in `user/std-bin/Cargo.toml` and exposed it in the build system via `bundles/desktop/bundle.toml`, providing a demonstration of the new IR features. [[1]](diffhunk://#diff-a247e035bcd0ed2a224a1def5143ff428e353cc61d30f181450af1a4e41d96beR188-R191) [[2]](diffhunk://#diff-5460488d3b96091943223c199eeac274b9ba4cc995a1db719176ad4bf0321363R154-R159)

### Public API Additions

* Added a public method `Context::create_ir_resources` for creating persistent IR resource caches, with detailed documentation and error handling.

These changes establish a solid foundation for portable graphics rendering and resource management, and enable future expansion to multiple backends and advanced validation.