### PR TITLE
Add SGFX depth and SWS pointer lock

### DIFF
--- a/kernel/src/device/gpu/abi.rs
+++ b/kernel/src/device/gpu/abi.rs
@@ -84,6 +84,8 @@ pub const GPU_QUEUE_SUBMIT_FLAGS_VALID: u32 = GPU_QUEUE_SUBMIT_FLAG_SIGNAL_TIMEL
 
 /// Generic BGRA8 normalized unsigned image format.
 pub const GPU_IMAGE_FORMAT_BGRA8_UNORM: u32 = 1;
+/// Generic 32-bit floating-point depth image format.
+pub const GPU_IMAGE_FORMAT_DEPTH32_FLOAT: u32 = 2;
 /// Image usage permitting the image to be bound as a render target.
 pub const GPU_IMAGE_USAGE_RENDER_TARGET: u32 = 1 << 0;
 /// Image usage permitting the image to be selected for display scanout.
@@ -92,11 +94,14 @@ pub const GPU_IMAGE_USAGE_PRESENTABLE: u32 = 1 << 1;
 pub const GPU_IMAGE_USAGE_SAMPLED: u32 = 1 << 2;
 /// Image usage permitting BGRA pixel transfers into the image.
 pub const GPU_IMAGE_USAGE_TRANSFER_DST: u32 = 1 << 3;
+/// Image usage permitting binding as a depth-stencil attachment.
+pub const GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT: u32 = 1 << 4;
 /// All currently defined GPU image usage flags.
 pub const GPU_IMAGE_USAGE_VALID: u32 = GPU_IMAGE_USAGE_RENDER_TARGET
     | GPU_IMAGE_USAGE_PRESENTABLE
     | GPU_IMAGE_USAGE_SAMPLED
-    | GPU_IMAGE_USAGE_TRANSFER_DST;
+    | GPU_IMAGE_USAGE_TRANSFER_DST
+    | GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT;
 
 /// Fixed-width request and response for [`GPU_CREATE_IMAGE`].
 #[repr(C)]

--- a/kernel/src/device/gpu/backend.rs
+++ b/kernel/src/device/gpu/backend.rs
@@ -26,6 +26,8 @@ pub const GPU_EXECUTION_SUPPORT_TIMELINE: u32 = 1 << 3;
 pub const GPU_EXECUTION_SUPPORT_PRESENTATION: u32 = 1 << 4;
 /// Generic image upload operations are available.
 pub const GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD: u32 = 1 << 5;
+/// Generic depth attachment and depth-test operations are available.
+pub const GPU_EXECUTION_SUPPORT_DEPTH: u32 = 1 << 6;
 
 /// Stable state of a GPU device.
 #[repr(u32)]

--- a/kernel/src/device/gpu/mod.rs
+++ b/kernel/src/device/gpu/mod.rs
@@ -20,28 +20,29 @@ pub use abi::{
     GPU_CONTEXT_TRANSFER_IMPORTED_IMAGE_BGRA, GPU_CONTEXT_UPLOAD_IMAGE_BGRA, GPU_CREATE_BUFFER,
     GPU_CREATE_CONTEXT, GPU_CREATE_IMAGE, GPU_CREATE_IMPORTED_IMAGE_BGRA, GPU_CREATE_QUEUE,
     GPU_CREATE_TIMELINE, GPU_DIALECT_INFO_BYTES, GPU_IMAGE_FORMAT_BGRA8_UNORM,
-    GPU_IMAGE_QUERY_INFO, GPU_IMAGE_USAGE_PRESENTABLE, GPU_IMAGE_USAGE_RENDER_TARGET,
-    GPU_IMAGE_USAGE_SAMPLED, GPU_IMAGE_USAGE_TRANSFER_DST, GPU_IMAGE_USAGE_VALID,
-    GPU_MAX_IMAGE_UPLOAD_SIZE, GPU_MAX_OPAQUE_COMMAND_SIZE, GPU_QUERY_DIALECT, GPU_QUERY_INFO,
-    GPU_QUEUE_QUERY, GPU_QUEUE_SUBMIT, GPU_QUEUE_SUBMIT_FLAG_SIGNAL_TIMELINE,
-    GPU_QUEUE_SUBMIT_FLAGS_VALID, GPU_RESULT_INVALID_ABI, GPU_RESULT_INVALID_ARGUMENT,
-    GPU_RESULT_INVALID_STATE, GPU_RESULT_OUT_OF_RESOURCES, GPU_RESULT_SUCCESS,
-    GPU_RESULT_UNSUPPORTED, GPU_TIMELINE_CREATE_POINT, GPU_TIMELINE_FAIL, GPU_TIMELINE_QUERY,
-    GPU_TIMELINE_SIGNAL, GpuBufferInfo, GpuContextAttachBuffer, GpuContextAttachImage,
-    GpuContextDetachImage, GpuContextInfo, GpuContextTransferImportedImageBgra,
-    GpuContextUploadImageBgra, GpuCreateBuffer, GpuCreateContext, GpuCreateImage,
-    GpuCreateImportedImageBgra, GpuCreateQueue, GpuCreateTimeline, GpuImageInfo, GpuQueryDialect,
-    GpuQueryInfo, GpuQueueInfo, GpuQueueSubmit, GpuTimelineCreatePoint, GpuTimelineFail,
-    GpuTimelineInfo, GpuTimelineSignal,
+    GPU_IMAGE_FORMAT_DEPTH32_FLOAT, GPU_IMAGE_QUERY_INFO, GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT,
+    GPU_IMAGE_USAGE_PRESENTABLE, GPU_IMAGE_USAGE_RENDER_TARGET, GPU_IMAGE_USAGE_SAMPLED,
+    GPU_IMAGE_USAGE_TRANSFER_DST, GPU_IMAGE_USAGE_VALID, GPU_MAX_IMAGE_UPLOAD_SIZE,
+    GPU_MAX_OPAQUE_COMMAND_SIZE, GPU_QUERY_DIALECT, GPU_QUERY_INFO, GPU_QUEUE_QUERY,
+    GPU_QUEUE_SUBMIT, GPU_QUEUE_SUBMIT_FLAG_SIGNAL_TIMELINE, GPU_QUEUE_SUBMIT_FLAGS_VALID,
+    GPU_RESULT_INVALID_ABI, GPU_RESULT_INVALID_ARGUMENT, GPU_RESULT_INVALID_STATE,
+    GPU_RESULT_OUT_OF_RESOURCES, GPU_RESULT_SUCCESS, GPU_RESULT_UNSUPPORTED,
+    GPU_TIMELINE_CREATE_POINT, GPU_TIMELINE_FAIL, GPU_TIMELINE_QUERY, GPU_TIMELINE_SIGNAL,
+    GpuBufferInfo, GpuContextAttachBuffer, GpuContextAttachImage, GpuContextDetachImage,
+    GpuContextInfo, GpuContextTransferImportedImageBgra, GpuContextUploadImageBgra,
+    GpuCreateBuffer, GpuCreateContext, GpuCreateImage, GpuCreateImportedImageBgra, GpuCreateQueue,
+    GpuCreateTimeline, GpuImageInfo, GpuQueryDialect, GpuQueryInfo, GpuQueueInfo, GpuQueueSubmit,
+    GpuTimelineCreatePoint, GpuTimelineFail, GpuTimelineInfo, GpuTimelineSignal,
 };
 pub use backend::{
-    GPU_EXECUTION_SUPPORT_ADDRESS_SPACE, GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD,
-    GPU_EXECUTION_SUPPORT_MEMORY, GPU_EXECUTION_SUPPORT_NONE, GPU_EXECUTION_SUPPORT_PRESENTATION,
-    GPU_EXECUTION_SUPPORT_QUEUE, GPU_EXECUTION_SUPPORT_TIMELINE, GpuBackend, GpuBackendBuffer,
-    GpuBackendBufferInfo, GpuBackendContext, GpuBackendContextInfo, GpuBackendDialectDescriptor,
-    GpuBackendDialectInfo, GpuBackendImage, GpuBackendImageInfo, GpuBackendInfo, GpuBackendQueue,
-    GpuBackendQueueInfo, GpuBufferCreateInfo, GpuDeviceInfo, GpuDeviceState, GpuImageBackingInfo,
-    GpuImageCreateInfo, GpuImageUploadInfo,
+    GPU_EXECUTION_SUPPORT_ADDRESS_SPACE, GPU_EXECUTION_SUPPORT_DEPTH,
+    GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD, GPU_EXECUTION_SUPPORT_MEMORY, GPU_EXECUTION_SUPPORT_NONE,
+    GPU_EXECUTION_SUPPORT_PRESENTATION, GPU_EXECUTION_SUPPORT_QUEUE,
+    GPU_EXECUTION_SUPPORT_TIMELINE, GpuBackend, GpuBackendBuffer, GpuBackendBufferInfo,
+    GpuBackendContext, GpuBackendContextInfo, GpuBackendDialectDescriptor, GpuBackendDialectInfo,
+    GpuBackendImage, GpuBackendImageInfo, GpuBackendInfo, GpuBackendQueue, GpuBackendQueueInfo,
+    GpuBufferCreateInfo, GpuDeviceInfo, GpuDeviceState, GpuImageBackingInfo, GpuImageCreateInfo,
+    GpuImageUploadInfo,
 };
 pub use connection::GpuConnection;
 pub use execution::{GpuContext, GpuQueue};
@@ -64,13 +65,14 @@ mod tests {
 
     use super::{
         GPU_ABI_VERSION, GPU_BUFFER_FLAG_CPU_VISIBLE, GPU_EXECUTION_SUPPORT_MEMORY,
-        GPU_EXECUTION_SUPPORT_TIMELINE, GPU_IMAGE_FORMAT_BGRA8_UNORM, GPU_IMAGE_USAGE_PRESENTABLE,
-        GPU_IMAGE_USAGE_RENDER_TARGET, GPU_IMAGE_USAGE_SAMPLED, GPU_IMAGE_USAGE_TRANSFER_DST,
-        GPU_RESULT_INVALID_ABI, GPU_RESULT_INVALID_ARGUMENT, GPU_RESULT_SUCCESS, GpuBackend,
-        GpuBackendBuffer, GpuBackendBufferInfo, GpuBackendImageInfo, GpuBackendInfo, GpuBuffer,
-        GpuBufferCreateInfo, GpuConnection, GpuContextUploadImageBgra, GpuControlDevice,
-        GpuDeviceInfo, GpuDeviceState, GpuImageCreateInfo, GpuObject, GpuQueryInfo, GpuTimeline,
-        GpuTimelinePoint,
+        GPU_EXECUTION_SUPPORT_TIMELINE, GPU_IMAGE_FORMAT_BGRA8_UNORM,
+        GPU_IMAGE_FORMAT_DEPTH32_FLOAT, GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT,
+        GPU_IMAGE_USAGE_PRESENTABLE, GPU_IMAGE_USAGE_RENDER_TARGET, GPU_IMAGE_USAGE_SAMPLED,
+        GPU_IMAGE_USAGE_TRANSFER_DST, GPU_RESULT_INVALID_ABI, GPU_RESULT_INVALID_ARGUMENT,
+        GPU_RESULT_SUCCESS, GpuBackend, GpuBackendBuffer, GpuBackendBufferInfo,
+        GpuBackendImageInfo, GpuBackendInfo, GpuBuffer, GpuBufferCreateInfo, GpuConnection,
+        GpuContextUploadImageBgra, GpuControlDevice, GpuDeviceInfo, GpuDeviceState,
+        GpuImageCreateInfo, GpuObject, GpuQueryInfo, GpuTimeline, GpuTimelinePoint,
     };
     use crate::device::Device;
     use crate::object::KernelObject;
@@ -266,6 +268,22 @@ mod tests {
         ));
         assert!(!super::resource::image_create_is_valid(
             GpuImageCreateInfo::new(valid.format, valid.usage, 0, valid.height,)
+        ));
+        assert!(super::resource::image_create_is_valid(
+            GpuImageCreateInfo::new(
+                GPU_IMAGE_FORMAT_DEPTH32_FLOAT,
+                GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT,
+                valid.width,
+                valid.height,
+            )
+        ));
+        assert!(!super::resource::image_create_is_valid(
+            GpuImageCreateInfo::new(
+                GPU_IMAGE_FORMAT_DEPTH32_FLOAT,
+                GPU_IMAGE_USAGE_RENDER_TARGET,
+                valid.width,
+                valid.height,
+            )
         ));
     }
 

--- a/kernel/src/device/gpu/resource.rs
+++ b/kernel/src/device/gpu/resource.rs
@@ -106,14 +106,21 @@ pub trait GpuObject: Send + Sync {
 ///
 /// # Returns
 ///
-/// `true` only for a non-empty BGRA8 image with one or more known usage bits.
+/// `true` for a non-empty BGRA8 image with known color usages, or a
+/// `Depth32Float` image used exclusively as a depth-stencil attachment.
 pub(crate) const fn image_create_is_valid(create: GpuImageCreateInfo) -> bool {
-    create.format == GPU_IMAGE_FORMAT_BGRA8_UNORM
+    (create.format == GPU_IMAGE_FORMAT_BGRA8_UNORM
+        || create.format == super::GPU_IMAGE_FORMAT_DEPTH32_FLOAT)
         && create.usage != 0
         && create.usage & !GPU_IMAGE_USAGE_VALID == 0
         && create.width != 0
         && create.height != 0
         && create.width <= u32::MAX / 4
+        && if create.format == super::GPU_IMAGE_FORMAT_DEPTH32_FLOAT {
+            create.usage == super::GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT
+        } else {
+            create.usage & super::GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT == 0
+        }
 }
 
 /// Return whether a generic image descriptor is valid for imported SHM backing.

--- a/kernel/src/drivers/graphics/virtio_gpu.rs
+++ b/kernel/src/drivers/graphics/virtio_gpu.rs
@@ -13,9 +13,11 @@ use crate::{
     device::{
         Device, DeviceType,
         gpu::{
-            GPU_DIALECT_INFO_BYTES, GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD,
-            GPU_EXECUTION_SUPPORT_MEMORY, GPU_EXECUTION_SUPPORT_PRESENTATION,
-            GPU_EXECUTION_SUPPORT_QUEUE, GPU_EXECUTION_SUPPORT_TIMELINE,
+            GPU_DIALECT_INFO_BYTES, GPU_EXECUTION_SUPPORT_DEPTH,
+            GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD, GPU_EXECUTION_SUPPORT_MEMORY,
+            GPU_EXECUTION_SUPPORT_PRESENTATION, GPU_EXECUTION_SUPPORT_QUEUE,
+            GPU_EXECUTION_SUPPORT_TIMELINE, GPU_IMAGE_FORMAT_BGRA8_UNORM,
+            GPU_IMAGE_FORMAT_DEPTH32_FLOAT, GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT,
             GPU_IMAGE_USAGE_PRESENTABLE, GPU_IMAGE_USAGE_RENDER_TARGET, GPU_IMAGE_USAGE_SAMPLED,
             GPU_IMAGE_USAGE_TRANSFER_DST, GPU_MAX_OPAQUE_COMMAND_SIZE, GpuBackend,
             GpuBackendBuffer, GpuBackendBufferInfo, GpuBackendContext, GpuBackendContextInfo,
@@ -82,6 +84,7 @@ const VIRTIO_GPU_CONTROL_MAX_SPINS: u64 = 10_000_000;
 
 // VirtIO GPU Formats
 const VIRTIO_GPU_FORMAT_B8G8R8A8_UNORM: u32 = 1;
+const VIRGL_FORMAT_Z32_FLOAT: u32 = 18;
 const VIRTIO_GPU_FORMAT_B8G8R8X8_UNORM: u32 = 2;
 const VIRTIO_GPU_FORMAT_A8R8G8B8_UNORM: u32 = 3;
 const VIRTIO_GPU_FORMAT_X8R8G8B8_UNORM: u32 = 4;
@@ -94,6 +97,7 @@ const VIRTIO_GPU_FORMAT_R8G8B8X8_UNORM: u32 = 134;
 const PIPE_BUFFER: u32 = 0;
 const PIPE_TEXTURE_2D: u32 = 2;
 const PIPE_BIND_RENDER_TARGET: u32 = 1 << 1;
+const PIPE_BIND_DEPTH_STENCIL: u32 = 1 << 0;
 const PIPE_BIND_SAMPLER_VIEW: u32 = 1 << 3;
 const PIPE_BIND_VERTEX_BUFFER: u32 = 1 << 4;
 const PIPE_BIND_SCANOUT: u32 = 1 << 19;
@@ -306,6 +310,9 @@ fn virgl_image_bind(usage: u32) -> u32 {
     let mut bind = 0;
     if usage & GPU_IMAGE_USAGE_RENDER_TARGET != 0 {
         bind |= PIPE_BIND_RENDER_TARGET;
+    }
+    if usage & GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT != 0 {
+        bind |= PIPE_BIND_DEPTH_STENCIL;
     }
     if usage & GPU_IMAGE_USAGE_SAMPLED != 0 {
         bind |= PIPE_BIND_SAMPLER_VIEW;
@@ -746,6 +753,7 @@ impl VirtioGpuDeviceCore {
                     | GPU_EXECUTION_SUPPORT_TIMELINE
                     | if acceleration_usable {
                         GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD
+                            | GPU_EXECUTION_SUPPORT_DEPTH
                             | GPU_EXECUTION_SUPPORT_QUEUE
                             | GPU_EXECUTION_SUPPORT_PRESENTATION
                     } else {
@@ -2033,7 +2041,11 @@ impl GpuBackend for VirtioGpuBackend {
         let resource_id = core.create_acceleration_resource(VirtioGpuAccelerationResource3d {
             resource_id: 0,
             target: PIPE_TEXTURE_2D,
-            format: VIRTIO_GPU_FORMAT_B8G8R8A8_UNORM,
+            format: match create.format {
+                GPU_IMAGE_FORMAT_BGRA8_UNORM => VIRTIO_GPU_FORMAT_B8G8R8A8_UNORM,
+                GPU_IMAGE_FORMAT_DEPTH32_FLOAT => VIRGL_FORMAT_Z32_FLOAT,
+                _ => return Err("VirtIO GPU image format is unsupported"),
+            },
             bind: virgl_image_bind(create.usage),
             width: create.width,
             height: create.height,
@@ -2203,6 +2215,10 @@ mod tests {
                     | GPU_IMAGE_USAGE_SAMPLED,
             ),
             PIPE_BIND_RENDER_TARGET | PIPE_BIND_SCANOUT | PIPE_BIND_SAMPLER_VIEW
+        );
+        assert_eq!(
+            virgl_image_bind(GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT),
+            PIPE_BIND_DEPTH_STENCIL
         );
     }
 

--- a/user/bin/src/sws/compositor.rs
+++ b/user/bin/src/sws/compositor.rs
@@ -5,6 +5,10 @@ use super::cursor::Cursor;
 use super::gpu_compositor::{GpuCompositor, SgfxBufferError, SgfxBufferIdentity, SgfxCommitToken};
 use super::input::{CompositorInputEvent, InputManager, key_codes};
 use super::ipc::{IpcEvent, IpcServer, send_message_to_client, send_response_to_client};
+use super::pointer_lock::{
+    CorrelatedReply, PointerInteractionState, PointerLockDenial, PointerLockState, captured_window,
+    confirmed_lock_state, correlated_reply, cursor_visible, input_route, validate_request,
+};
 use super::window::WindowManager;
 use core::sync::atomic::{AtomicU8, Ordering};
 use core::time::Duration;
@@ -501,6 +505,8 @@ pub struct Compositor {
     /// Window currently owning pointer hover while no implicit button grab is active.
     pointer_focus_window_id: Option<u32>,
     pointer_grab_window_id: Option<u32>,
+    /// Explicit client-owned pointer capture, independent of implicit button grabs.
+    pointer_lock: Option<PointerLockState>,
     move_drag: Option<MoveDragState>,
     resize_drag: Option<ResizeDragState>,
     resize_outline: Option<(i32, i32, u32, u32)>,
@@ -703,6 +709,7 @@ impl Compositor {
             last_left_down_cursor: None,
             pointer_focus_window_id: None,
             pointer_grab_window_id: None,
+            pointer_lock: None,
             move_drag: None,
             resize_drag: None,
             resize_outline: None,
@@ -1597,6 +1604,7 @@ impl Compositor {
             &self.cursor,
             self.bg_color,
             self.resize_outline,
+            cursor_visible(self.pointer_lock),
         );
         match result {
             Ok(releases) => {
@@ -2200,16 +2208,18 @@ impl Compositor {
                 );
             }
 
-            // Layer 3: Draw cursor
-            let cursor = &self.cursor;
-            cursor.draw_to_buffer_direct_clipped(
-                backbuffer,
-                screen_width,
-                screen_height,
-                bytes_per_pixel,
-                stride,
-                clip,
-            );
+            // Layer 3: Draw cursor unless an application owns pointer lock.
+            if cursor_visible(self.pointer_lock) {
+                let cursor = &self.cursor;
+                cursor.draw_to_buffer_direct_clipped(
+                    backbuffer,
+                    screen_width,
+                    screen_height,
+                    bytes_per_pixel,
+                    stride,
+                    clip,
+                );
+            }
         }
 
         // Validate composition against expected pixels before presenting.
@@ -2273,6 +2283,12 @@ impl Compositor {
 
     /// Broadcast focus change event to all connected clients
     fn broadcast_focus_change(&mut self, window_id: u32) {
+        if self
+            .pointer_lock
+            .is_some_and(|state| state.window_id != window_id)
+        {
+            self.release_pointer_lock();
+        }
         // Only broadcast if the focused window actually changed
         if self.last_focused_window_id == Some(window_id) {
             println!(
@@ -2507,6 +2523,178 @@ impl Compositor {
         }
     }
 
+    fn cursor_rect(&self) -> (i32, i32, u32, u32) {
+        (
+            self.cursor.x,
+            self.cursor.y,
+            self.cursor.width,
+            self.cursor.height,
+        )
+    }
+
+    fn send_pointer_lock_changed(&self, state: PointerLockState, locked: bool) {
+        super::ipc::send_message_to_client(
+            state.client_id,
+            sws_protocol::server_msg::POINTER_LOCK_CHANGED,
+            sws_protocol::payload_pointer_lock_changed(state.window_id, locked).to_vec(),
+        );
+    }
+
+    /// Release explicit capture and damage the cursor layer for redisplay.
+    fn release_pointer_lock(&mut self) -> bool {
+        let Some(state) = self.pointer_lock.take() else {
+            return false;
+        };
+        self.add_pending_damage(self.cursor_rect());
+        self.send_pointer_lock_changed(state, false);
+        true
+    }
+
+    fn pointer_lock_is_valid(&self, state: PointerLockState) -> bool {
+        self.window_manager
+            .get_window(state.window_id)
+            .is_some_and(|window| {
+                !state.must_release(
+                    window.owner_client_id,
+                    window.visible,
+                    window.minimized,
+                    window.focused,
+                    self.window_manager.get_focused_window_id() == Some(state.window_id),
+                )
+            })
+    }
+
+    fn release_invalid_pointer_lock(&mut self) -> bool {
+        let Some(state) = self.pointer_lock else {
+            return false;
+        };
+        if !self.pointer_lock_is_valid(state) {
+            return self.release_pointer_lock();
+        }
+        if let Some((x, y, width, height)) = self
+            .window_manager
+            .get_window(state.window_id)
+            .map(|window| (window.x, window.y, window.width, window.height))
+        {
+            let max_x = x.saturating_add(width.saturating_sub(1) as i32);
+            let max_y = y.saturating_add(height.saturating_sub(1) as i32);
+            self.cursor.set_position(
+                self.cursor.x.clamp(x, max_x),
+                self.cursor.y.clamp(y, max_y),
+                self.screen_width,
+                self.screen_height,
+            );
+        }
+        false
+    }
+
+    fn set_pointer_lock(
+        &mut self,
+        client_id: usize,
+        window_id: u32,
+        locked: bool,
+    ) -> Result<bool, u32> {
+        if !locked {
+            if self
+                .pointer_lock
+                .is_some_and(|state| state.client_id == client_id && state.window_id == window_id)
+            {
+                return Ok(self.release_pointer_lock());
+            }
+            return Ok(false);
+        }
+
+        let Some(window) = self.window_manager.get_window(window_id) else {
+            return Err(sws_protocol::error_codes::POINTER_LOCK_NOT_OWNED);
+        };
+        let mut interaction = PointerInteractionState {
+            focused_window_id: self.window_manager.get_focused_window_id(),
+            implicit_grab_window_id: self.pointer_grab_window_id,
+            locked_window_id: self.pointer_lock.map(|state| state.window_id),
+        };
+        let interaction_allows_lock = interaction.request_lock(window_id);
+        validate_request(
+            window.owner_client_id,
+            client_id,
+            window.visible,
+            window.minimized,
+            window.focused,
+            self.window_manager.get_focused_window_id() == Some(window_id),
+            !interaction_allows_lock || self.move_drag.is_some() || self.resize_drag.is_some(),
+        )
+        .map_err(|denial| match denial {
+            PointerLockDenial::NotOwned => sws_protocol::error_codes::POINTER_LOCK_NOT_OWNED,
+            PointerLockDenial::Denied => sws_protocol::error_codes::POINTER_LOCK_DENIED,
+        })?;
+        if let Some(existing) = self.pointer_lock {
+            if existing.client_id == client_id && existing.window_id == window_id {
+                return Ok(false);
+            }
+            return Err(sws_protocol::error_codes::POINTER_LOCK_DENIED);
+        }
+
+        let cursor_rect = self.cursor_rect();
+        let max_x = window
+            .x
+            .saturating_add(window.width.saturating_sub(1) as i32);
+        let max_y = window
+            .y
+            .saturating_add(window.height.saturating_sub(1) as i32);
+        let locked_x = self.cursor.x.clamp(window.x, max_x);
+        let locked_y = self.cursor.y.clamp(window.y, max_y);
+        self.add_pending_damage(cursor_rect);
+        self.cursor
+            .set_position(locked_x, locked_y, self.screen_width, self.screen_height);
+        if self.pointer_grab_window_id != interaction.implicit_grab_window_id {
+            self.pointer_grab_window_id = interaction.implicit_grab_window_id;
+            self.last_left_down_cursor = None;
+        }
+        self.pointer_focus_window_id = Some(window_id);
+        let state = PointerLockState::new(client_id, window_id);
+        self.pointer_lock = Some(state);
+        self.send_pointer_lock_changed(state, true);
+        Ok(true)
+    }
+
+    fn send_locked_relative_motion(&self, window_id: u32, dx: i32, dy: i32) {
+        self.send_locked_input_event(
+            window_id,
+            0,
+            super::input::event_types::EV_REL,
+            super::input::rel_codes::REL_X,
+            dx,
+        );
+        self.send_locked_input_event(
+            window_id,
+            0,
+            super::input::event_types::EV_REL,
+            super::input::rel_codes::REL_Y,
+            dy,
+        );
+        self.send_locked_input_event(window_id, 0, super::input::event_types::EV_SYN, 0, 0);
+    }
+
+    fn send_locked_input_event(
+        &self,
+        window_id: u32,
+        time: u64,
+        type_: u16,
+        code: u16,
+        value: i32,
+    ) {
+        let extension_owner = self
+            .window_manager
+            .get_window(window_id)
+            .and_then(|window| window.extension_owner);
+        super::ipc::send_pointer_lock_input_event(
+            input_route(window_id, extension_owner),
+            time,
+            type_,
+            code,
+            value,
+        );
+    }
+
     fn wait_for_event_signal(&mut self) {
         let mut handles = [PollHandle::new(self.wake_read.as_raw() as u32, POLLIN)];
         let ready = match poll(&mut handles, COMPOSITOR_IDLE_RECHECK_NS) {
@@ -2726,6 +2914,11 @@ impl Compositor {
     fn handle_input_event(&mut self, event: CompositorInputEvent) -> Result<bool, &'static str> {
         match event {
             CompositorInputEvent::MouseMove { dx, dy } => {
+                self.release_invalid_pointer_lock();
+                if let Some(window_id) = captured_window(self.pointer_lock) {
+                    self.send_locked_relative_motion(window_id, dx, dy);
+                    return Ok(true);
+                }
                 self.cursor
                     .update_position(dx, dy, self.screen_width, self.screen_height);
 
@@ -2818,6 +3011,15 @@ impl Compositor {
                 Ok(true)
             }
             CompositorInputEvent::MouseAbsolute { x, y } => {
+                self.release_invalid_pointer_lock();
+                if let Some(state) = self.pointer_lock.as_mut() {
+                    let delta = state.absolute_delta(x, y);
+                    let window_id = state.window_id;
+                    if let Some((dx, dy)) = delta {
+                        self.send_locked_relative_motion(window_id, dx, dy);
+                    }
+                    return Ok(true);
+                }
                 self.cursor
                     .set_position(x, y, self.screen_width, self.screen_height);
 
@@ -2899,10 +3101,11 @@ impl Compositor {
                 let hi_dy = dy.saturating_mul(120);
                 let hi_dx = dx.saturating_mul(120);
 
-                if let Some(win_id) = self
-                    .window_manager
-                    .window_at_point(self.cursor.x, self.cursor.y)
-                {
+                let lock_target = captured_window(self.pointer_lock);
+                if let Some(win_id) = lock_target.or_else(|| {
+                    self.window_manager
+                        .window_at_point(self.cursor.x, self.cursor.y)
+                }) {
                     if let Some(window) = self.window_manager.get_window(win_id) {
                         if self.cursor_position_in_window(window).is_some()
                             || window.extension_owner.is_some()
@@ -2965,6 +3168,27 @@ impl Compositor {
                 Ok(true)
             }
             CompositorInputEvent::MouseButton { button, pressed } => {
+                self.release_invalid_pointer_lock();
+                if let Some(state) = self.pointer_lock {
+                    if button == key_codes::BTN_LEFT {
+                        self.left_button_down = pressed;
+                    }
+                    self.send_locked_input_event(
+                        state.window_id,
+                        0,
+                        super::input::event_types::EV_KEY,
+                        button,
+                        if pressed { 1 } else { 0 },
+                    );
+                    self.send_locked_input_event(
+                        state.window_id,
+                        0,
+                        super::input::event_types::EV_SYN,
+                        0,
+                        0,
+                    );
+                    return Ok(true);
+                }
                 let mut grab_target = None;
 
                 if button == key_codes::BTN_LEFT {
@@ -3019,11 +3243,18 @@ impl Compositor {
                         .window_manager
                         .window_at_point(self.cursor.x, self.cursor.y);
                     if let Some(win_id) = win_id_opt {
-                        self.pointer_grab_window_id = Some(win_id);
+                        let accepts_focus = self.window_manager.window_accepts_focus(win_id);
+                        let mut interaction = PointerInteractionState {
+                            focused_window_id: self.window_manager.get_focused_window_id(),
+                            implicit_grab_window_id: self.pointer_grab_window_id,
+                            locked_window_id: self.pointer_lock.map(|state| state.window_id),
+                        };
+                        interaction.button_pressed(win_id, accepts_focus);
+                        self.pointer_grab_window_id = interaction.implicit_grab_window_id;
                         self.update_pointer_focus(Some(win_id));
                         // Only change focus if the window accepts focus
                         // Taskbar and Desktop windows are global UI elements that don't steal focus
-                        if self.window_manager.window_accepts_focus(win_id) {
+                        if accepts_focus {
                             self.window_manager.set_focus(win_id);
 
                             // Broadcast focus change event to all clients
@@ -3255,6 +3486,12 @@ impl Compositor {
     }
 
     fn clear_interaction_state_for_removed_windows(&mut self, window_ids: &[u32]) {
+        if self
+            .pointer_lock
+            .is_some_and(|state| Self::window_id_in(window_ids, state.window_id))
+        {
+            self.release_pointer_lock();
+        }
         if let Some(window_id) = self.pointer_focus_window_id
             && Self::window_id_in(window_ids, window_id)
         {
@@ -4408,6 +4645,12 @@ impl Compositor {
             }
             IpcEvent::MinimizeWindow { window_id } => {
                 println!("[Compositor] Minimizing window #{}", window_id);
+                if self
+                    .pointer_lock
+                    .is_some_and(|state| state.window_id == window_id)
+                {
+                    self.release_pointer_lock();
+                }
                 let old_rect = self
                     .window_manager
                     .get_window(window_id)
@@ -4657,6 +4900,56 @@ impl Compositor {
                 }
                 self.full_redraw_needed = true;
             }
+            IpcEvent::SetPointerLock {
+                client_id,
+                request_id,
+                window_id,
+                locked,
+            } => match self.set_pointer_lock(client_id, window_id, locked) {
+                Ok(changed) => {
+                    if !changed {
+                        self.send_pointer_lock_changed(
+                            PointerLockState::new(client_id, window_id),
+                            locked,
+                        );
+                    }
+                    if let CorrelatedReply::State { request_id, locked } =
+                        correlated_reply(request_id, locked, true)
+                    {
+                        send_response_to_client(
+                            client_id,
+                            sws_protocol::server_msg::POINTER_LOCK_CHANGED,
+                            request_id,
+                            sws_protocol::payload_pointer_lock_changed(window_id, locked).to_vec(),
+                        );
+                    }
+                }
+                Err(code) => {
+                    let denial = if code == sws_protocol::error_codes::POINTER_LOCK_NOT_OWNED {
+                        PointerLockDenial::NotOwned
+                    } else {
+                        PointerLockDenial::Denied
+                    };
+                    self.send_pointer_lock_changed(
+                        PointerLockState::new(client_id, window_id),
+                        confirmed_lock_state(locked, &Err(denial)),
+                    );
+                    match correlated_reply(request_id, locked, false) {
+                        CorrelatedReply::None => super::ipc::send_message_to_client(
+                            client_id,
+                            sws_protocol::server_msg::ERROR,
+                            sws_protocol::payload_error(code).to_vec(),
+                        ),
+                        CorrelatedReply::Error { request_id } => send_response_to_client(
+                            client_id,
+                            sws_protocol::server_msg::ERROR,
+                            request_id,
+                            sws_protocol::payload_error(code).to_vec(),
+                        ),
+                        CorrelatedReply::State { .. } => {}
+                    }
+                }
+            },
             IpcEvent::FocusWindow { window_id } => {
                 if let Some(fullscreen_id) = self
                     .window_manager
@@ -5168,6 +5461,7 @@ impl Compositor {
                 }
             }
         }
+        self.release_invalid_pointer_lock();
         Ok(false)
     }
 }

--- a/user/bin/src/sws/gpu_compositor.rs
+++ b/user/bin/src/sws/gpu_compositor.rs
@@ -421,6 +421,7 @@ impl GpuCompositor {
         cursor: &Cursor,
         background: [u8; 4],
         resize_outline: Option<(i32, i32, u32, u32)>,
+        cursor_visible: bool,
     ) -> Result<Vec<SgfxCommitToken>, &'static str> {
         super::trace::set_compositor_stage(super::trace::STAGE_GPU_SYNC_WINDOWS);
         for window in windows {
@@ -526,14 +527,16 @@ impl GpuCompositor {
                 self.target.height(),
             )?;
         }
-        if let Some((destination, source)) = clipped_rect(
-            cursor.x,
-            cursor.y,
-            self.cursor_width,
-            self.cursor_height,
-            self.target.width(),
-            self.target.height(),
-        ) {
+        if cursor_visible
+            && let Some((destination, source)) = clipped_rect(
+                cursor.x,
+                cursor.y,
+                self.cursor_width,
+                self.cursor_height,
+                self.target.width(),
+                self.target.height(),
+            )
+        {
             composition
                 .draw_textured_rect(
                     &self.cursor_texture,

--- a/user/bin/src/sws/ipc.rs
+++ b/user/bin/src/sws/ipc.rs
@@ -1,6 +1,9 @@
 //! IPC Server module - handles client connections and messages
 
 use super::config;
+use super::pointer_lock::{
+    InputRoute, enqueue_routed_event, take_extension_events, take_window_events,
+};
 use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 use std::collections::BTreeMap;
 use std::env;
@@ -586,11 +589,11 @@ pub fn set_sgfx_shared_images_available(available: bool) {
 }
 
 fn sws_capabilities() -> u64 {
+    let mut capabilities = protocol::capabilities::POINTER_LOCK;
     if SGFX_SHARED_IMAGES_AVAILABLE.load(Ordering::Acquire) {
-        protocol::capabilities::SGFX_SHARED_IMAGE
-    } else {
-        0
+        capabilities |= protocol::capabilities::SGFX_SHARED_IMAGE;
     }
+    capabilities
 }
 
 fn compositor_epoch() -> u32 {
@@ -912,6 +915,46 @@ pub fn send_extension_input_event(
             value,
         },
     );
+    drop(pending);
+    wake_window_owner(window_id);
+}
+
+/// Queue locked input through the normal or extension consumer boundary.
+///
+/// # Arguments
+///
+/// * `route` - Destination queue selected from the target window metadata.
+/// * `time` - Input timestamp.
+/// * `type_` - Linux input event type.
+/// * `code` - Linux input event code.
+/// * `value` - Linux input event value.
+pub fn send_pointer_lock_input_event(
+    route: InputRoute,
+    time: u64,
+    type_: u16,
+    code: u16,
+    value: i32,
+) {
+    let window_id = match route {
+        InputRoute::Window { window_id } | InputRoute::Extension { window_id, .. } => window_id,
+    };
+    let mut normal = PENDING_INPUT_EVENTS.lock();
+    let mut extension = PENDING_EXTENSION_INPUT_EVENTS.lock();
+    enqueue_routed_event(
+        &mut normal,
+        &mut extension,
+        route,
+        PendingInputEvent {
+            time,
+            type_,
+            code,
+            value,
+        },
+        push_input_event_coalesced,
+    );
+    drop(extension);
+    drop(normal);
+    wake_window_owner(window_id);
 }
 
 /// Get and clear pending extension input events for a specific extension client
@@ -921,15 +964,7 @@ pub fn pop_extension_input_events(
 ) -> Vec<PendingInputEvent> {
     let mut pending = PENDING_EXTENSION_INPUT_EVENTS.lock();
 
-    if let Some(events) = pending.get_mut(&(extension_id, external_client_id)) {
-        if events.is_empty() {
-            Vec::new()
-        } else {
-            core::mem::take(events)
-        }
-    } else {
-        Vec::new()
-    }
+    take_extension_events(&mut pending, extension_id, external_client_id)
 }
 
 fn cleanup_extension_input_events(extension_id: u32, external_client_id: u32) {
@@ -1809,16 +1844,7 @@ fn pop_pending_server_frames(window_id: u32) -> Vec<PendingServerFrame> {
 /// Get pending input events for a window (called by client thread, O(log n) lookup)
 fn pop_pending_input_events(window_id: u32) -> Vec<PendingInputEvent> {
     let mut pending = PENDING_INPUT_EVENTS.lock();
-
-    if let Some(events) = pending.get_mut(&window_id) {
-        if events.is_empty() {
-            Vec::new() // Already empty, no reallocation needed
-        } else {
-            core::mem::take(events)
-        }
-    } else {
-        Vec::new()
-    }
+    take_window_events(&mut pending, window_id)
 }
 
 /// Pop pending server responses for a specific client (by client_id)
@@ -2723,6 +2749,27 @@ fn client_thread_main(client_id: usize, mut socket: Socket, wake_read: Option<Ha
                 push_ipc_event(IpcEvent::UnsetFullscreen {
                     client_id,
                     window_id,
+                });
+            }
+            Ok(ClientMessageRef::SetPointerLock { window_id, locked }) => {
+                if !managed_windows.contains(&window_id) {
+                    let _ = write_frame(
+                        &mut stream_writer,
+                        protocol::server_msg::POINTER_LOCK_CHANGED,
+                        &protocol::payload_pointer_lock_changed(window_id, false),
+                    );
+                    let _ = write_protocol_error(
+                        &mut stream_writer,
+                        request_id,
+                        protocol::error_codes::POINTER_LOCK_NOT_OWNED,
+                    );
+                    continue;
+                }
+                push_ipc_event(IpcEvent::SetPointerLock {
+                    client_id,
+                    request_id,
+                    window_id,
+                    locked,
                 });
             }
             Ok(ClientMessageRef::FocusWindow { window_id }) => {
@@ -3688,6 +3735,14 @@ pub enum IpcEvent {
     UnsetFullscreen {
         client_id: usize,
         window_id: u32,
+    },
+
+    /// Capture or release raw relative pointer motion for an owned window.
+    SetPointerLock {
+        client_id: usize,
+        request_id: u8,
+        window_id: u32,
+        locked: bool,
     },
 
     /// Focus and raise a window

--- a/user/bin/src/sws/main.rs
+++ b/user/bin/src/sws/main.rs
@@ -13,6 +13,7 @@ mod cursor;
 mod gpu_compositor;
 mod input;
 mod ipc;
+mod pointer_lock;
 mod trace;
 mod window;
 

--- a/user/bin/src/sws/pointer_lock.rs
+++ b/user/bin/src/sws/pointer_lock.rs
@@ -1,0 +1,375 @@
+//! Pointer-lock policy and device-independent capture state.
+
+use std::collections::BTreeMap;
+use std::vec::Vec;
+
+/// Reason a pointer-lock request cannot be granted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointerLockDenial {
+    /// The requesting connection does not own the target window.
+    NotOwned,
+    /// The target is ineligible or compositor interaction owns the pointer.
+    Denied,
+}
+
+/// Active client-owned pointer capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PointerLockState {
+    pub client_id: usize,
+    pub window_id: u32,
+    last_absolute: Option<(i32, i32)>,
+}
+
+/// Pointer ownership fields shared by click focus and lock request handlers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PointerInteractionState {
+    pub focused_window_id: Option<u32>,
+    pub implicit_grab_window_id: Option<u32>,
+    pub locked_window_id: Option<u32>,
+}
+
+impl PointerInteractionState {
+    /// Apply the focus/grab portion of a compositor button-press transition.
+    pub fn button_pressed(&mut self, window_id: u32, accepts_focus: bool) {
+        self.implicit_grab_window_id = Some(window_id);
+        if accepts_focus {
+            self.focused_window_id = Some(window_id);
+        }
+    }
+
+    /// Transfer a focused same-window implicit grab into explicit pointer lock.
+    pub fn request_lock(&mut self, window_id: u32) -> bool {
+        if self.focused_window_id != Some(window_id)
+            || implicit_grab_conflicts(self.implicit_grab_window_id, window_id)
+            || self
+                .locked_window_id
+                .is_some_and(|locked| locked != window_id)
+        {
+            return false;
+        }
+        self.implicit_grab_window_id = None;
+        self.locked_window_id = Some(window_id);
+        true
+    }
+}
+
+/// Destination for one locked input packet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputRoute {
+    /// Ordinary SWS client window.
+    Window { window_id: u32 },
+    /// Window represented by an extension client.
+    Extension {
+        extension_id: u32,
+        external_client_id: u32,
+        window_id: u32,
+    },
+}
+
+/// Correlated response required by a nonzero routed request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorrelatedReply {
+    /// One-way request; only the asynchronous state event is sent.
+    None,
+    /// Successful or idempotent request response.
+    State { request_id: u8, locked: bool },
+    /// Rejected request response.
+    Error { request_id: u8 },
+}
+
+/// Preserve request routing for compositor-mediated pointer-lock outcomes.
+pub const fn correlated_reply(
+    request_id: u8,
+    requested_locked: bool,
+    accepted: bool,
+) -> CorrelatedReply {
+    if request_id == 0 {
+        CorrelatedReply::None
+    } else if accepted {
+        CorrelatedReply::State {
+            request_id,
+            locked: requested_locked,
+        }
+    } else {
+        CorrelatedReply::Error { request_id }
+    }
+}
+
+/// Select the queue consumed by the target window's owning connection.
+pub const fn input_route(window_id: u32, extension_owner: Option<(u32, u32)>) -> InputRoute {
+    match extension_owner {
+        Some((extension_id, external_client_id)) => InputRoute::Extension {
+            extension_id,
+            external_client_id,
+            window_id,
+        },
+        None => InputRoute::Window { window_id },
+    }
+}
+
+/// Enqueue through the same normal/extension queue boundary used by SWS IPC.
+pub fn enqueue_routed_event<T, F>(
+    normal: &mut BTreeMap<u32, Vec<T>>,
+    extension: &mut BTreeMap<(u32, u32), Vec<T>>,
+    route: InputRoute,
+    event: T,
+    push: F,
+) where
+    F: FnOnce(&mut Vec<T>, T),
+{
+    let events = match route {
+        InputRoute::Window { window_id } => normal.entry(window_id).or_insert_with(Vec::new),
+        InputRoute::Extension {
+            extension_id,
+            external_client_id,
+            ..
+        } => extension
+            .entry((extension_id, external_client_id))
+            .or_insert_with(Vec::new),
+    };
+    push(events, event);
+}
+
+/// Consume queued input for an ordinary window.
+pub fn take_window_events<T>(normal: &mut BTreeMap<u32, Vec<T>>, window_id: u32) -> Vec<T> {
+    normal
+        .get_mut(&window_id)
+        .map(core::mem::take)
+        .unwrap_or_default()
+}
+
+/// Consume queued input for an extension-managed client.
+pub fn take_extension_events<T>(
+    extension: &mut BTreeMap<(u32, u32), Vec<T>>,
+    extension_id: u32,
+    external_client_id: u32,
+) -> Vec<T> {
+    extension
+        .get_mut(&(extension_id, external_client_id))
+        .map(core::mem::take)
+        .unwrap_or_default()
+}
+
+/// Whether an implicit button grab belongs to a different window.
+pub const fn implicit_grab_conflicts(
+    grab_window_id: Option<u32>,
+    requested_window_id: u32,
+) -> bool {
+    match grab_window_id {
+        Some(grab_window_id) => grab_window_id != requested_window_id,
+        None => false,
+    }
+}
+
+/// Return the captured window, or `None` for ordinary hit-tested routing.
+pub const fn captured_window(state: Option<PointerLockState>) -> Option<u32> {
+    match state {
+        Some(state) => Some(state.window_id),
+        None => None,
+    }
+}
+
+/// Whether the compositor cursor layer should be rendered.
+pub const fn cursor_visible(state: Option<PointerLockState>) -> bool {
+    state.is_none()
+}
+
+/// State reported for a request result.
+///
+/// Every denial is confirmed as unlocked so clients can clear in-flight state.
+pub fn confirmed_lock_state(
+    requested_locked: bool,
+    result: &Result<(), PointerLockDenial>,
+) -> bool {
+    requested_locked && result.is_ok()
+}
+
+impl PointerLockState {
+    /// Create capture state with absolute-device jump suppression armed.
+    pub const fn new(client_id: usize, window_id: u32) -> Self {
+        Self {
+            client_id,
+            window_id,
+            last_absolute: None,
+        }
+    }
+
+    /// Convert an absolute sample to relative motion.
+    ///
+    /// The first sample establishes the device baseline and returns `None`.
+    pub fn absolute_delta(&mut self, x: i32, y: i32) -> Option<(i32, i32)> {
+        let delta = self
+            .last_absolute
+            .map(|(last_x, last_y)| (x.saturating_sub(last_x), y.saturating_sub(last_y)));
+        self.last_absolute = Some((x, y));
+        delta
+    }
+
+    /// Whether a window lifecycle/focus snapshot requires forced release.
+    pub fn must_release(
+        self,
+        owner_client_id: Option<usize>,
+        visible: bool,
+        minimized: bool,
+        focused: bool,
+        is_keyboard_focus: bool,
+    ) -> bool {
+        owner_client_id != Some(self.client_id)
+            || !visible
+            || minimized
+            || !focused
+            || !is_keyboard_focus
+    }
+}
+
+/// Validate a request against connection, presentation, focus, and grab state.
+pub fn validate_request(
+    owner_client_id: Option<usize>,
+    requesting_client_id: usize,
+    visible: bool,
+    minimized: bool,
+    focused: bool,
+    is_keyboard_focus: bool,
+    compositor_grab_active: bool,
+) -> Result<(), PointerLockDenial> {
+    if owner_client_id != Some(requesting_client_id) {
+        return Err(PointerLockDenial::NotOwned);
+    }
+    if !visible || minimized || !focused || !is_keyboard_focus || compositor_grab_active {
+        return Err(PointerLockDenial::Denied);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_foreign_unfocused_hidden_minimized_and_grabbed_windows() {
+        assert_eq!(
+            validate_request(Some(4), 9, true, false, true, true, false),
+            Err(PointerLockDenial::NotOwned)
+        );
+        for denied in [
+            (false, false, true, true, false),
+            (true, true, true, true, false),
+            (true, false, false, true, false),
+            (true, false, true, false, false),
+            (true, false, true, true, true),
+        ] {
+            assert_eq!(
+                validate_request(Some(4), 4, denied.0, denied.1, denied.2, denied.3, denied.4,),
+                Err(PointerLockDenial::Denied)
+            );
+        }
+        assert_eq!(
+            validate_request(Some(4), 4, true, false, true, true, false),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn absolute_motion_suppresses_first_jump_and_then_reports_delta() {
+        let mut state = PointerLockState::new(4, 27);
+        assert_eq!(state.absolute_delta(800, 600), None);
+        assert_eq!(state.absolute_delta(797, 608), Some((-3, 8)));
+    }
+
+    #[test]
+    fn focus_visibility_lifetime_changes_force_release() {
+        let state = PointerLockState::new(4, 27);
+        assert!(!state.must_release(Some(4), true, false, true, true));
+        assert!(state.must_release(Some(5), true, false, true, true));
+        assert!(state.must_release(Some(4), false, false, true, true));
+        assert!(state.must_release(Some(4), true, true, true, true));
+        assert!(state.must_release(Some(4), true, false, false, true));
+        assert!(state.must_release(Some(4), true, false, true, false));
+        assert!(state.must_release(None, true, false, true, true));
+    }
+
+    #[test]
+    fn capture_hides_cursor_routes_owner_and_denial_confirms_unlocked() {
+        let state = PointerLockState::new(4, 27);
+        assert!(cursor_visible(None));
+        assert_eq!(captured_window(None), None);
+        assert!(!cursor_visible(Some(state)));
+        assert_eq!(captured_window(Some(state)), Some(27));
+
+        let denied = Err(PointerLockDenial::Denied);
+        assert!(!confirmed_lock_state(true, &denied));
+        assert!(confirmed_lock_state(true, &Ok(())));
+        assert!(!confirmed_lock_state(false, &Ok(())));
+    }
+
+    #[test]
+    fn locked_input_uses_extension_queue_when_present() {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        enum Event {
+            RelativeX(i32),
+            RelativeY(i32),
+            Button(bool),
+        }
+
+        let mut normal = BTreeMap::new();
+        let mut extension = BTreeMap::new();
+        let route = input_route(27, Some((8, 19)));
+        for event in [
+            Event::RelativeX(4),
+            Event::RelativeY(-2),
+            Event::Button(true),
+        ] {
+            enqueue_routed_event(&mut normal, &mut extension, route, event, Vec::push);
+        }
+
+        assert!(take_window_events(&mut normal, 27).is_empty());
+        assert_eq!(
+            take_extension_events(&mut extension, 8, 19),
+            [
+                Event::RelativeX(4),
+                Event::RelativeY(-2),
+                Event::Button(true),
+            ]
+        );
+        assert!(take_extension_events(&mut extension, 8, 19).is_empty());
+    }
+
+    #[test]
+    fn same_window_implicit_grab_can_transfer_to_pointer_lock() {
+        assert!(!implicit_grab_conflicts(None, 27));
+        assert!(!implicit_grab_conflicts(Some(27), 27));
+        assert!(implicit_grab_conflicts(Some(28), 27));
+    }
+
+    #[test]
+    fn button_focus_grab_then_request_transitions_to_locked() {
+        let mut state = PointerInteractionState {
+            focused_window_id: None,
+            implicit_grab_window_id: None,
+            locked_window_id: None,
+        };
+        state.button_pressed(27, true);
+        assert_eq!(state.focused_window_id, Some(27));
+        assert_eq!(state.implicit_grab_window_id, Some(27));
+
+        assert!(state.request_lock(27));
+        assert_eq!(state.focused_window_id, Some(27));
+        assert_eq!(state.implicit_grab_window_id, None);
+        assert_eq!(state.locked_window_id, Some(27));
+    }
+
+    #[test]
+    fn nonzero_request_ids_receive_success_duplicate_and_denial_responses() {
+        assert_eq!(correlated_reply(0, true, true), CorrelatedReply::None);
+        let accepted = CorrelatedReply::State {
+            request_id: 7,
+            locked: true,
+        };
+        assert_eq!(correlated_reply(7, true, true), accepted);
+        assert_eq!(correlated_reply(7, true, true), accepted); // idempotent duplicate
+        assert_eq!(
+            correlated_reply(9, true, false),
+            CorrelatedReply::Error { request_id: 9 }
+        );
+    }
+}

--- a/user/lib/gpu-raw/src/lib.rs
+++ b/user/lib/gpu-raw/src/lib.rs
@@ -107,6 +107,8 @@ pub const GPU_BUFFER_FLAGS_VALID: u32 = GPU_BUFFER_FLAG_CPU_VISIBLE;
 
 /// Generic BGRA8 normalized unsigned image format.
 pub const GPU_IMAGE_FORMAT_BGRA8_UNORM: u32 = 1;
+/// Generic 32-bit floating-point depth image format.
+pub const GPU_IMAGE_FORMAT_DEPTH32_FLOAT: u32 = 2;
 /// Image usage permitting the image to be bound as a render target.
 pub const GPU_IMAGE_USAGE_RENDER_TARGET: u32 = 1 << 0;
 /// Image usage permitting the image to be selected for display scanout.
@@ -115,11 +117,14 @@ pub const GPU_IMAGE_USAGE_PRESENTABLE: u32 = 1 << 1;
 pub const GPU_IMAGE_USAGE_SAMPLED: u32 = 1 << 2;
 /// Image usage permitting BGRA pixel transfers into the image.
 pub const GPU_IMAGE_USAGE_TRANSFER_DST: u32 = 1 << 3;
+/// Image usage permitting binding as a depth-stencil attachment.
+pub const GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT: u32 = 1 << 4;
 /// All currently defined GPU image usage flags.
 pub const GPU_IMAGE_USAGE_VALID: u32 = GPU_IMAGE_USAGE_RENDER_TARGET
     | GPU_IMAGE_USAGE_PRESENTABLE
     | GPU_IMAGE_USAGE_SAMPLED
-    | GPU_IMAGE_USAGE_TRANSFER_DST;
+    | GPU_IMAGE_USAGE_TRANSFER_DST
+    | GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT;
 
 /// The GPU backend is not available for control.
 pub const GPU_DEVICE_STATE_UNAVAILABLE: u32 = 0;
@@ -142,6 +147,8 @@ pub const GPU_EXECUTION_SUPPORT_TIMELINE: u32 = 1 << 3;
 pub const GPU_EXECUTION_SUPPORT_PRESENTATION: u32 = 1 << 4;
 /// Generic image upload operations are available.
 pub const GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD: u32 = 1 << 5;
+/// Generic depth attachment and depth-test operations are available.
+pub const GPU_EXECUTION_SUPPORT_DEPTH: u32 = 1 << 6;
 
 /// Fixed byte capacity of an opaque backend or dialect identifier.
 pub const GPU_BACKEND_ID_BYTES: usize = 32;
@@ -1344,6 +1351,30 @@ impl Gpu {
         usage: u32,
     ) -> HandleResult<GpuImage> {
         let mut request = GpuCreateImage::new_with_usage(width, height, usage);
+        self.create_image_request(&mut request)
+    }
+
+    /// Create a GPU image with an explicit generic format and usage flags.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - A `GPU_IMAGE_FORMAT_*` value.
+    /// * `width` - Requested non-zero image width in pixels.
+    /// * `height` - Requested non-zero image height in pixels.
+    /// * `usage` - `GPU_IMAGE_USAGE_*` flags for the image.
+    ///
+    /// # Returns
+    ///
+    /// An owning image capability wrapper or a handle error.
+    pub fn create_image_with_format_and_usage(
+        &self,
+        format: u32,
+        width: u32,
+        height: u32,
+        usage: u32,
+    ) -> HandleResult<GpuImage> {
+        let mut request = GpuCreateImage::new_with_usage(width, height, usage);
+        request.format = format;
         self.create_image_request(&mut request)
     }
 

--- a/user/lib/sgfx/src/driver.rs
+++ b/user/lib/sgfx/src/driver.rs
@@ -407,6 +407,26 @@ pub(crate) enum IrFrontFace {
     CounterClockwise,
 }
 
+/// Portable depth comparison used by the IR executor.
+#[derive(Clone, Copy)]
+pub(crate) enum IrCompareFunction {
+    Never,
+    Less,
+    Equal,
+    LessEqual,
+    Greater,
+    NotEqual,
+    GreaterEqual,
+    Always,
+}
+
+/// Portable depth-test state used by the IR executor.
+#[derive(Clone, Copy)]
+pub(crate) struct IrDepthState {
+    pub(crate) compare: IrCompareFunction,
+    pub(crate) write_enabled: bool,
+}
+
 /// Persistent pipeline slot and its immutable portable state.
 #[derive(Clone, Copy)]
 pub(crate) struct IrPipelineState {
@@ -415,6 +435,7 @@ pub(crate) struct IrPipelineState {
     pub(crate) blend: IrBlendState,
     pub(crate) cull_mode: IrCullMode,
     pub(crate) front_face: IrFrontFace,
+    pub(crate) depth: Option<IrDepthState>,
 }
 
 /// Portable sampler filtering mode.
@@ -485,6 +506,7 @@ pub(crate) enum IrTextureFormat {
     Bgra8,
     Rgba8,
     R8,
+    Depth32Float,
 }
 
 /// One validated texture copy request without backend identifiers.
@@ -499,6 +521,8 @@ pub(crate) struct IrTextureCopy {
 /// Complete backend-neutral render submission for one mapped presentation target.
 pub(crate) struct IrSubmission {
     pub(crate) clear_color: Option<[f32; 4]>,
+    pub(crate) depth_attachment: Option<IrTextureSpec>,
+    pub(crate) clear_depth: Option<f32>,
     pub(crate) render_area: IrRect,
     pub(crate) vertices: Vec<IrVertex>,
     pub(crate) draws: Vec<IrDraw>,

--- a/user/lib/sgfx/src/ir/command.rs
+++ b/user/lib/sgfx/src/ir/command.rs
@@ -4,7 +4,8 @@ use alloc::vec::Vec;
 
 use super::{
     BufferRef, BufferUsage, Color, DrawUniforms, Error, FragmentProgram, IndexFormat, PixelRect,
-    RenderPipelineRef, ResourceTable, Result, SamplerRef, TextureRef, TextureUsage, TextureWrite,
+    RenderPipelineRef, ResourceTable, Result, SamplerRef, TextureFormat, TextureRef, TextureUsage,
+    TextureWrite,
 };
 
 /// Maximum commands retained by one logical command buffer.
@@ -30,6 +31,51 @@ pub enum StoreOp {
     DontCare,
 }
 
+/// Depth attachment initialization operation for a render pass.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DepthLoadOp {
+    /// Preserve the attachment contents in the render area.
+    Load,
+    /// Clear the render area to the finite depth value before drawing.
+    Clear(f32),
+    /// Permit a backend to discard prior attachment contents.
+    DontCare,
+}
+
+/// Validated depth attachment configuration for one render pass.
+#[derive(Clone, Copy)]
+pub struct DepthAttachment<'r> {
+    pub(crate) target: TextureRef<'r>,
+    pub(crate) load: DepthLoadOp,
+    pub(crate) store: StoreOp,
+}
+
+impl<'r> DepthAttachment<'r> {
+    /// Return the depth attachment reference.
+    ///
+    /// # Returns
+    /// The lifetime-branded depth texture reference.
+    pub const fn target(self) -> TextureRef<'r> {
+        self.target
+    }
+
+    /// Return the depth attachment initialization operation.
+    ///
+    /// # Returns
+    /// The configured depth load operation.
+    pub const fn load(self) -> DepthLoadOp {
+        self.load
+    }
+
+    /// Return the depth attachment finalization operation.
+    ///
+    /// # Returns
+    /// The configured store operation.
+    pub const fn store(self) -> StoreOp {
+        self.store
+    }
+}
+
 /// Validated configuration for one logical color render pass.
 #[derive(Clone, Copy)]
 pub struct RenderPassDesc<'r> {
@@ -37,6 +83,7 @@ pub struct RenderPassDesc<'r> {
     pub(crate) area: PixelRect,
     pub(crate) load: LoadOp,
     pub(crate) store: StoreOp,
+    pub(crate) depth: Option<DepthAttachment<'r>>,
 }
 
 impl<'r> RenderPassDesc<'r> {
@@ -60,6 +107,9 @@ impl<'r> RenderPassDesc<'r> {
         store: StoreOp,
     ) -> Result<Self> {
         let texture = resources.texture(target)?;
+        if texture.format() == TextureFormat::Depth32Float {
+            return Err(Error::InvalidDescriptor);
+        }
         if !texture.usage().contains(TextureUsage::RENDER_ATTACHMENT) {
             return Err(Error::InvalidUsage);
         }
@@ -71,7 +121,50 @@ impl<'r> RenderPassDesc<'r> {
             area,
             load,
             store,
+            depth: None,
         })
+    }
+
+    /// Add a validated depth attachment to this color render pass.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Table that owns `target` and the color attachment.
+    /// * `target` - `Depth32Float` `RENDER_ATTACHMENT` texture.
+    /// * `load` - Depth attachment initialization operation.
+    /// * `store` - Depth attachment finalization operation.
+    ///
+    /// # Returns
+    /// The updated descriptor, or an error for table mismatch, format, usage,
+    /// bounds, or a non-finite/out-of-range clear value.
+    pub fn with_depth_attachment(
+        mut self,
+        resources: &'r ResourceTable,
+        target: TextureRef<'r>,
+        load: DepthLoadOp,
+        store: StoreOp,
+    ) -> Result<Self> {
+        let texture = resources.texture(target)?;
+        let color_texture = resources.texture(self.target)?;
+        if texture.format() != TextureFormat::Depth32Float {
+            return Err(Error::InvalidDescriptor);
+        }
+        if !texture.usage().contains(TextureUsage::RENDER_ATTACHMENT) {
+            return Err(Error::InvalidUsage);
+        }
+        if texture.extent() != color_texture.extent() || !self.area.is_within(texture.extent()) {
+            return Err(Error::OutOfBounds);
+        }
+        if matches!(load, DepthLoadOp::Clear(value) if !value.is_finite() || !(0.0..=1.0).contains(&value))
+        {
+            return Err(Error::InvalidDescriptor);
+        }
+        self.depth = Some(DepthAttachment {
+            target,
+            load,
+            store,
+        });
+        Ok(self)
     }
 
     /// Return the color attachment reference.
@@ -104,6 +197,14 @@ impl<'r> RenderPassDesc<'r> {
     /// The configured store operation.
     pub const fn store(self) -> StoreOp {
         self.store
+    }
+
+    /// Return the optional depth attachment configuration.
+    ///
+    /// # Returns
+    /// The depth attachment when depth testing is available for this pass.
+    pub const fn depth_attachment(self) -> Option<DepthAttachment<'r>> {
+        self.depth
     }
 }
 
@@ -522,7 +623,7 @@ impl<'encoder, 'r, 'data> RenderPassEncoder<'encoder, 'r, 'data> {
         if offset > desc.size() {
             return Err(Error::OutOfBounds);
         }
-        if offset % format.byte_size() != 0 {
+        if !offset.is_multiple_of(format.byte_size()) {
             return Err(Error::InvalidValue);
         }
         self.encoder.push(Command::SetIndexBuffer {
@@ -591,14 +692,13 @@ impl<'encoder, 'r, 'data> RenderPassEncoder<'encoder, 'r, 'data> {
     /// # Returns
     /// Success, or [`Error::OutOfBounds`] for a scissor outside the render area. `None` never permits drawing outside that area.
     pub fn set_scissor(&mut self, scissor: Option<PixelRect>) -> Result<()> {
-        if let Some(scissor) = scissor {
-            if scissor.x() < self.area.x()
+        if let Some(scissor) = scissor
+            && (scissor.x() < self.area.x()
                 || scissor.y() < self.area.y()
                 || scissor.x() + scissor.width() > self.area.x() + self.area.width()
-                || scissor.y() + scissor.height() > self.area.y() + self.area.height()
-            {
-                return Err(Error::OutOfBounds);
-            }
+                || scissor.y() + scissor.height() > self.area.y() + self.area.height())
+        {
+            return Err(Error::OutOfBounds);
         }
         self.encoder.push(Command::SetScissor(scissor))
     }
@@ -692,7 +792,7 @@ impl<'encoder, 'r, 'data> RenderPassEncoder<'encoder, 'r, 'data> {
     }
 
     fn validate_draw(&self, count: u32) -> Result<()> {
-        if count == 0 || count % 3 != 0 {
+        if count == 0 || !count.is_multiple_of(3) {
             return Err(Error::InvalidValue);
         }
         let pipeline = self.pipeline.ok_or(Error::PipelineNotSet)?;

--- a/user/lib/sgfx/src/ir/mod.rs
+++ b/user/lib/sgfx/src/ir/mod.rs
@@ -11,13 +11,14 @@ pub(crate) mod resource;
 mod types;
 
 pub use command::{
-    Command, CommandBuffer, CommandEncoder, LoadOp, MAX_COMMANDS, RenderPassDesc,
-    RenderPassEncoder, StoreOp,
+    Command, CommandBuffer, CommandEncoder, DepthAttachment, DepthLoadOp, LoadOp, MAX_COMMANDS,
+    RenderPassDesc, RenderPassEncoder, StoreOp,
 };
 pub use pipeline::{
-    BlendComponent, BlendFactor, BlendOp, BlendState, CullMode, DrawUniforms, FragmentProgram,
-    FrontFace, IndexFormat, MAX_VERTEX_ATTRIBUTES, PrimitiveTopology, RasterState,
-    RenderPipelineDesc, TextureSampleMode, VertexAttribute, VertexBufferLayout, VertexFormat,
+    BlendComponent, BlendFactor, BlendOp, BlendState, CompareFunction, CullMode, DepthState,
+    DrawUniforms, FragmentProgram, FrontFace, IndexFormat, MAX_VERTEX_ATTRIBUTES,
+    PrimitiveTopology, RasterState, RenderPipelineDesc, TextureSampleMode, VertexAttribute,
+    VertexBufferLayout, VertexFormat,
 };
 pub use resource::{
     AddressMode, BufferDesc, BufferId, BufferRef, BufferUsage, FilterMode, MAX_BUFFERS,

--- a/user/lib/sgfx/src/ir/pipeline.rs
+++ b/user/lib/sgfx/src/ir/pipeline.rs
@@ -7,6 +7,79 @@ use super::{Color, Error, Result, TextureFormat, Transform};
 /// Maximum attributes accepted by one portable vertex-buffer layout.
 pub const MAX_VERTEX_ATTRIBUTES: usize = 16;
 
+/// Comparison applied between an incoming fragment depth and stored depth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompareFunction {
+    /// Never pass the comparison.
+    Never,
+    /// Pass when the incoming value is less than the stored value.
+    Less,
+    /// Pass when both values are equal.
+    Equal,
+    /// Pass when the incoming value is less than or equal to the stored value.
+    LessEqual,
+    /// Pass when the incoming value is greater than the stored value.
+    Greater,
+    /// Pass when the values are not equal.
+    NotEqual,
+    /// Pass when the incoming value is greater than or equal to the stored value.
+    GreaterEqual,
+    /// Always pass the comparison.
+    Always,
+}
+
+/// Portable depth-test and depth-write pipeline state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DepthState {
+    format: TextureFormat,
+    compare: CompareFunction,
+    write_enabled: bool,
+}
+
+impl DepthState {
+    /// Construct depth-test and depth-write state.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - Required render-pass depth attachment format.
+    /// * `compare` - Comparison applied to incoming fragment depth.
+    /// * `write_enabled` - Whether passing fragments update stored depth.
+    ///
+    /// # Returns
+    /// The requested portable depth state.
+    pub const fn new(format: TextureFormat, compare: CompareFunction, write_enabled: bool) -> Self {
+        Self {
+            format,
+            compare,
+            write_enabled,
+        }
+    }
+
+    /// Return the required depth attachment format.
+    ///
+    /// # Returns
+    /// The configured depth texture format.
+    pub const fn format(self) -> TextureFormat {
+        self.format
+    }
+
+    /// Return the depth comparison function.
+    ///
+    /// # Returns
+    /// The configured comparison.
+    pub const fn compare(self) -> CompareFunction {
+        self.compare
+    }
+
+    /// Return whether passing fragments write depth.
+    ///
+    /// # Returns
+    /// `true` when depth writes are enabled.
+    pub const fn write_enabled(self) -> bool {
+        self.write_enabled
+    }
+}
+
 /// Format of one vertex attribute.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VertexFormat {
@@ -435,6 +508,7 @@ pub struct RenderPipelineDesc {
     fragment: FragmentProgram,
     blend: BlendState,
     raster: RasterState,
+    depth: Option<DepthState>,
 }
 
 impl RenderPipelineDesc {
@@ -497,7 +571,41 @@ impl RenderPipelineDesc {
             fragment,
             blend,
             raster,
+            depth: None,
         })
+    }
+
+    /// Configure depth testing for this pipeline.
+    ///
+    /// # Arguments
+    ///
+    /// * `depth` - Depth attachment format, comparison, and write state.
+    ///
+    /// # Returns
+    /// The updated pipeline descriptor, or [`Error::InvalidDescriptor`] when
+    /// the requested format is not a depth format.
+    pub fn with_depth_state(mut self, depth: DepthState) -> Result<Self> {
+        if depth.format() != TextureFormat::Depth32Float {
+            return Err(Error::InvalidDescriptor);
+        }
+        self.depth = Some(depth);
+        Ok(self)
+    }
+
+    /// Configure depth testing through the depth-stencil pipeline slot.
+    ///
+    /// Scarlet currently exposes depth without stencil; this discoverable
+    /// alias leaves room for stencil state in a future compatible API.
+    ///
+    /// # Arguments
+    ///
+    /// * `depth` - Depth attachment format, comparison, and write state.
+    ///
+    /// # Returns
+    /// The updated pipeline descriptor, or [`Error::InvalidDescriptor`] when
+    /// the requested format is not a depth format.
+    pub fn with_depth_stencil(self, depth: DepthState) -> Result<Self> {
+        self.with_depth_state(depth)
     }
     /// Return the required color attachment format.
     ///
@@ -540,5 +648,13 @@ impl RenderPipelineDesc {
     /// The configured raster state.
     pub const fn raster(&self) -> RasterState {
         self.raster
+    }
+
+    /// Return optional depth-test and depth-write state.
+    ///
+    /// # Returns
+    /// The configured depth state, or `None` when depth testing is disabled.
+    pub const fn depth_state(&self) -> Option<DepthState> {
+        self.depth
     }
 }

--- a/user/lib/sgfx/src/ir/resource.rs
+++ b/user/lib/sgfx/src/ir/resource.rs
@@ -29,6 +29,8 @@ pub enum TextureFormat {
     Rgba8Unorm,
     /// One eight-bit normalized red channel.
     R8Unorm,
+    /// One 32-bit floating-point depth component.
+    Depth32Float,
 }
 
 impl TextureFormat {
@@ -39,7 +41,7 @@ impl TextureFormat {
     /// The portable byte size for this format.
     pub const fn bytes_per_pixel(self) -> u32 {
         match self {
-            Self::Bgra8Unorm | Self::Rgba8Unorm => 4,
+            Self::Bgra8Unorm | Self::Rgba8Unorm | Self::Depth32Float => 4,
             Self::R8Unorm => 1,
         }
     }
@@ -52,7 +54,7 @@ pub struct TextureUsage(u8);
 impl TextureUsage {
     /// Allow shader sampling.
     pub const SAMPLED: Self = Self(1 << 0);
-    /// Allow use as a render-pass color attachment.
+    /// Allow use as a render-pass color or depth attachment.
     pub const RENDER_ATTACHMENT: Self = Self(1 << 1);
     /// Allow use as a texture copy source.
     pub const COPY_SRC: Self = Self(1 << 2);
@@ -128,9 +130,13 @@ impl TextureDesc {
     ///
     /// # Returns
     ///
-    /// A descriptor, or [`Error::InvalidDescriptor`] for empty usage.
+    /// A descriptor, or [`Error::InvalidDescriptor`] for empty usage or a
+    /// depth format carrying anything except `RENDER_ATTACHMENT` usage.
     pub const fn new(format: TextureFormat, extent: Extent2D, usage: TextureUsage) -> Result<Self> {
-        if usage.0 == 0 {
+        if usage.0 == 0
+            || (matches!(format, TextureFormat::Depth32Float)
+                && usage.0 != TextureUsage::RENDER_ATTACHMENT.0)
+        {
             Err(Error::InvalidDescriptor)
         } else {
             Ok(Self {

--- a/user/lib/sgfx/src/ir_execute.rs
+++ b/user/lib/sgfx/src/ir_execute.rs
@@ -3,16 +3,18 @@
 use alloc::{rc::Rc, vec::Vec};
 
 use crate::driver::{
-    self, IrAddressMode, IrBlendComponent, IrBlendFactor, IrBlendOp, IrBlendState, IrCullMode,
-    IrDraw, IrFilterMode, IrFragmentProgram, IrFrontFace, IrPipelineState, IrRect, IrSamplerState,
-    IrSubmission, IrTextureFormat, IrTextureUpload, IrUniforms, IrVertex, MAX_IR_VERTICES,
+    self, IrAddressMode, IrBlendComponent, IrBlendFactor, IrBlendOp, IrBlendState,
+    IrCompareFunction, IrCullMode, IrDepthState, IrDraw, IrFilterMode, IrFragmentProgram,
+    IrFrontFace, IrPipelineState, IrRect, IrSamplerState, IrSubmission, IrTextureFormat,
+    IrTextureUpload, IrUniforms, IrVertex, MAX_IR_VERTICES,
 };
 use crate::ir::{
     self, AddressMode, BlendComponent, BlendFactor, BlendOp, BlendState, BufferRef, BufferUsage,
-    Command, CommandBuffer, DrawUniforms, FilterMode, FragmentProgram, IndexFormat, LoadOp,
-    MAX_BUFFERS, MAX_TEXTURES, PrimitiveTopology, RenderPipelineRef, ResourceTable, SamplerDesc,
-    SamplerRef, TextureDesc, TextureFormat, TextureId, TextureRef, TextureSampleMode, TextureUsage,
-    TextureWrite, VertexAttribute, VertexFormat,
+    Command, CommandBuffer, CompareFunction, DepthLoadOp, DrawUniforms, FilterMode,
+    FragmentProgram, IndexFormat, LoadOp, MAX_BUFFERS, MAX_TEXTURES, PrimitiveTopology,
+    RenderPipelineRef, ResourceTable, SamplerDesc, SamplerRef, TextureDesc, TextureFormat,
+    TextureId, TextureRef, TextureSampleMode, TextureUsage, TextureWrite, VertexAttribute,
+    VertexFormat,
 };
 use crate::{Context, HandleError, Image, Queue};
 
@@ -377,6 +379,7 @@ enum ExecutionTarget {
 struct ActivePass<'r> {
     attachment: TextureRef<'r>,
     target: ExecutionTarget,
+    depth_attachment: Option<TextureRef<'r>>,
     submission: IrSubmission,
     pipeline: Option<RenderPipelineRef<'r>>,
     vertex_buffer: Option<(BufferRef<'r>, u64)>,
@@ -608,14 +611,27 @@ impl ExecutionPlan {
                     if !desc.area().is_within(descriptor.extent()) {
                         return Err(IrSubmitError::InvalidIr(ir::Error::OutOfBounds));
                     }
+                    let depth_attachment = desc.depth_attachment();
+                    let depth_spec = if let Some(depth) = depth_attachment {
+                        let depth_descriptor = resources.resources().texture(depth.target())?;
+                        Some(texture_spec(depth.target(), depth_descriptor))
+                    } else {
+                        None
+                    };
                     active = Some(ActivePass {
                         attachment: desc.target(),
                         target,
+                        depth_attachment: depth_attachment.map(|depth| depth.target()),
                         submission: IrSubmission {
                             clear_color: match desc.load() {
                                 LoadOp::Clear(color) => Some(color.components()),
                                 LoadOp::Load | LoadOp::DontCare => None,
                             },
+                            depth_attachment: depth_spec,
+                            clear_depth: depth_attachment.and_then(|depth| match depth.load() {
+                                DepthLoadOp::Clear(value) => Some(value),
+                                DepthLoadOp::Load | DepthLoadOp::DontCare => None,
+                            }),
                             render_area: IrRect {
                                 x: desc.area().x(),
                                 y: desc.area().y(),
@@ -677,10 +693,10 @@ impl ExecutionPlan {
                 }
                 Command::SetScissor(value) => {
                     let pass = active_pass_mut(&mut active)?;
-                    if let Some(rectangle) = value {
-                        if !rect_within(*rectangle, pass.submission.render_area) {
-                            return Err(IrSubmitError::InvalidIr(ir::Error::OutOfBounds));
-                        }
+                    if let Some(rectangle) = value
+                        && !rect_within(*rectangle, pass.submission.render_area)
+                    {
+                        return Err(IrSubmitError::InvalidIr(ir::Error::OutOfBounds));
                     }
                     pass.scissor = *value;
                 }
@@ -796,7 +812,7 @@ fn decode_indexed_draw_vertices(
     index_count: u32,
     base_vertex: i32,
 ) -> Result<DecodedDraw, IrSubmitError> {
-    if index_count == 0 || index_count % 3 != 0 {
+    if index_count == 0 || !index_count.is_multiple_of(3) {
         return Err(IrSubmitError::InvalidVertexData);
     }
     let (info, vertex_buffer, vertex_offset, uniforms, texture, sampler) =
@@ -870,6 +886,7 @@ fn decode_indexed_draw_vertices(
     })
 }
 
+#[allow(clippy::type_complexity)]
 fn draw_state<'r>(
     resources: &IrResources,
     pass: &ActivePass<'r>,
@@ -888,6 +905,9 @@ fn draw_state<'r>(
         .pipeline
         .ok_or(IrSubmitError::InvalidIr(ir::Error::PipelineNotSet))?;
     let info = pipeline_info(resources.resources(), pipeline)?;
+    if info.state.depth.is_some() != pass.depth_attachment.is_some() {
+        return Err(IrSubmitError::InvalidIr(ir::Error::InvalidDescriptor));
+    }
     let (buffer, offset) = pass
         .vertex_buffer
         .ok_or(IrSubmitError::InvalidIr(ir::Error::VertexBufferNotSet))?;
@@ -962,7 +982,7 @@ fn pipeline_info(
     resources: &ResourceTable,
     reference: RenderPipelineRef<'_>,
 ) -> Result<PipelineInfo, IrSubmitError> {
-    let (target, topology, fragment, blend, raster, stride, position, secondary) = resources
+    let (target, topology, fragment, blend, raster, depth, stride, position, secondary) = resources
         .with_pipeline(reference, |descriptor| {
             let layout = descriptor.vertex_buffer();
             let position = layout
@@ -981,6 +1001,7 @@ fn pipeline_info(
                 descriptor.fragment(),
                 descriptor.blend(),
                 descriptor.raster(),
+                descriptor.depth_state(),
                 layout.stride(),
                 position,
                 secondary,
@@ -1037,6 +1058,19 @@ fn pipeline_info(
                 ir::FrontFace::Clockwise => IrFrontFace::Clockwise,
                 ir::FrontFace::CounterClockwise => IrFrontFace::CounterClockwise,
             },
+            depth: depth.map(|depth| IrDepthState {
+                compare: match depth.compare() {
+                    CompareFunction::Never => IrCompareFunction::Never,
+                    CompareFunction::Less => IrCompareFunction::Less,
+                    CompareFunction::Equal => IrCompareFunction::Equal,
+                    CompareFunction::LessEqual => IrCompareFunction::LessEqual,
+                    CompareFunction::Greater => IrCompareFunction::Greater,
+                    CompareFunction::NotEqual => IrCompareFunction::NotEqual,
+                    CompareFunction::GreaterEqual => IrCompareFunction::GreaterEqual,
+                    CompareFunction::Always => IrCompareFunction::Always,
+                },
+                write_enabled: depth.write_enabled(),
+            }),
         },
         stride,
         position,
@@ -1113,7 +1147,7 @@ fn decode_vertices(
 ) -> Result<Vec<IrVertex>, IrSubmitError> {
     let count = usize::try_from(vertex_count).map_err(|_| IrSubmitError::InvalidVertexData)?;
     let first = usize::try_from(first_vertex).map_err(|_| IrSubmitError::InvalidVertexData)?;
-    if vertex_count == 0 || vertex_count % 3 != 0 {
+    if vertex_count == 0 || !vertex_count.is_multiple_of(3) {
         return Err(IrSubmitError::InvalidVertexData);
     }
     let mut vertices = Vec::new();
@@ -1308,6 +1342,11 @@ fn convert_texture_upload(
     texture: driver::IrTextureSpec,
     write: TextureWrite<'_>,
 ) -> Result<IrTextureUpload, IrSubmitError> {
+    if matches!(texture.format, IrTextureFormat::Depth32Float) {
+        return Err(IrSubmitError::Unsupported(
+            UnsupportedIrFeature::TextureUpload,
+        ));
+    }
     let destination = write.destination();
     let tight = usize::try_from(destination.width())
         .ok()
@@ -1315,6 +1354,7 @@ fn convert_texture_upload(
             width.checked_mul(match texture.format {
                 IrTextureFormat::R8 => 1,
                 IrTextureFormat::Bgra8 | IrTextureFormat::Rgba8 => 4,
+                IrTextureFormat::Depth32Float => unreachable!(),
             })
         })
         .ok_or(IrSubmitError::InvalidVertexData)?;
@@ -1362,6 +1402,7 @@ fn convert_texture_upload(
                     pixels.extend_from_slice(&[0, 0, 0, *value]);
                 }
             }
+            IrTextureFormat::Depth32Float => unreachable!(),
         }
     }
     Ok(IrTextureUpload {
@@ -1467,6 +1508,7 @@ fn texture_spec(texture: TextureRef<'_>, descriptor: TextureDesc) -> driver::IrT
             TextureFormat::Bgra8Unorm => IrTextureFormat::Bgra8,
             TextureFormat::Rgba8Unorm => IrTextureFormat::Rgba8,
             TextureFormat::R8Unorm => IrTextureFormat::R8,
+            TextureFormat::Depth32Float => IrTextureFormat::Depth32Float,
         },
     }
 }

--- a/user/lib/sgfx/src/lib.rs
+++ b/user/lib/sgfx/src/lib.rs
@@ -40,6 +40,7 @@ pub struct Capabilities {
     rendering: bool,
     presentation: bool,
     image_upload: bool,
+    depth: bool,
 }
 
 impl Capabilities {
@@ -68,6 +69,15 @@ impl Capabilities {
     /// `true` when sampled texture upload and composition are available.
     pub const fn supports_image_upload(&self) -> bool {
         self.image_upload
+    }
+
+    /// Return whether depth attachments and depth testing are available.
+    ///
+    /// # Returns
+    ///
+    /// `true` when `Depth32Float` render attachments can be used.
+    pub const fn supports_depth(&self) -> bool {
+        self.depth
     }
 }
 

--- a/user/lib/sgfx/src/virgl.rs
+++ b/user/lib/sgfx/src/virgl.rs
@@ -5,11 +5,13 @@ use core::cell::Cell;
 
 use framebuffer::DisplaySurface;
 use gpu_raw::{
-    GPU_DEVICE_STATE_READY, GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD, GPU_EXECUTION_SUPPORT_PRESENTATION,
-    GPU_EXECUTION_SUPPORT_QUEUE, GPU_IMAGE_USAGE_PRESENTABLE, GPU_IMAGE_USAGE_RENDER_TARGET,
-    GPU_IMAGE_USAGE_SAMPLED, GPU_IMAGE_USAGE_TRANSFER_DST, GPU_RESULT_SUCCESS, Gpu as RawGpu,
-    GpuBuffer as RawBuffer, GpuContext as RawContext, GpuDialect as RawDialect,
-    GpuImage as RawImage, GpuImageBgraRect, GpuQueue as RawQueue,
+    GPU_DEVICE_STATE_READY, GPU_EXECUTION_SUPPORT_DEPTH, GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD,
+    GPU_EXECUTION_SUPPORT_PRESENTATION, GPU_EXECUTION_SUPPORT_QUEUE, GPU_IMAGE_FORMAT_BGRA8_UNORM,
+    GPU_IMAGE_FORMAT_DEPTH32_FLOAT, GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT,
+    GPU_IMAGE_USAGE_PRESENTABLE, GPU_IMAGE_USAGE_RENDER_TARGET, GPU_IMAGE_USAGE_SAMPLED,
+    GPU_IMAGE_USAGE_TRANSFER_DST, GPU_RESULT_SUCCESS, Gpu as RawGpu, GpuBuffer as RawBuffer,
+    GpuContext as RawContext, GpuDialect as RawDialect, GpuImage as RawImage, GpuImageBgraRect,
+    GpuQueue as RawQueue,
 };
 #[cfg(feature = "std")]
 use scarlet_os::handle::{Handle, HandleError, HandleResult};
@@ -22,9 +24,9 @@ use std::{
 };
 
 use crate::driver::{
-    IrAddressMode, IrBlendFactor, IrBlendOp, IrBlendState, IrCullMode, IrDraw, IrFilterMode,
-    IrFragmentProgram, IrFrontFace, IrPipelineState, IrSamplerState, IrSubmission, IrTextureCopy,
-    IrTextureSpec, IrTextureUpload, IrVertex, MAX_IR_VERTICES,
+    IrAddressMode, IrBlendFactor, IrBlendOp, IrBlendState, IrCompareFunction, IrCullMode, IrDraw,
+    IrFilterMode, IrFragmentProgram, IrFrontFace, IrPipelineState, IrSamplerState, IrSubmission,
+    IrTextureCopy, IrTextureFormat, IrTextureSpec, IrTextureUpload, IrVertex, MAX_IR_VERTICES,
 };
 use crate::{
     Capabilities, Color, CullMode, FrontFace, MAX_COMPOSITION_OPERATIONS, PipelineDesc,
@@ -49,6 +51,7 @@ const VIRGL_CCMD_CLEAR_SURFACE: u32 = 62;
 
 const VIRGL_OBJECT_BLEND: u32 = 1;
 const VIRGL_OBJECT_RASTERIZER: u32 = 2;
+const VIRGL_OBJECT_DSA: u32 = 3;
 const VIRGL_OBJECT_SHADER: u32 = 4;
 const VIRGL_OBJECT_VERTEX_ELEMENTS: u32 = 5;
 const VIRGL_OBJECT_SAMPLER_VIEW: u32 = 6;
@@ -56,6 +59,7 @@ const VIRGL_OBJECT_SAMPLER_STATE: u32 = 7;
 const VIRGL_OBJECT_SURFACE: u32 = 8;
 
 const VIRGL_FORMAT_B8G8R8A8_UNORM: u32 = 1;
+const VIRGL_FORMAT_Z32_FLOAT: u32 = 18;
 const VIRGL_FORMAT_R32G32B32A32_FLOAT: u32 = 31;
 const VIRGL_FORMAT_R32G32B32_FLOAT: u32 = 30;
 const VIRGL_FORMAT_R32G32_FLOAT: u32 = 29;
@@ -64,6 +68,7 @@ const PIPE_SHADER_FRAGMENT: u32 = 1;
 const VIRGL_SHADER_TOKEN_COUNT_HINT: u32 = 300;
 const PIPE_PRIM_TRIANGLES: u32 = 4;
 const PIPE_CLEAR_COLOR0: u32 = 1 << 2;
+const PIPE_CLEAR_DEPTH: u32 = 1 << 0;
 
 const SURFACE_HANDLE: u32 = 1;
 const VERTEX_SHADER_HANDLE: u32 = 2;
@@ -282,6 +287,7 @@ impl Device {
             rendering: info.execution_support & GPU_EXECUTION_SUPPORT_QUEUE != 0,
             presentation: info.execution_support & GPU_EXECUTION_SUPPORT_PRESENTATION != 0,
             image_upload: info.execution_support & GPU_EXECUTION_SUPPORT_IMAGE_UPLOAD != 0,
+            depth: info.execution_support & GPU_EXECUTION_SUPPORT_DEPTH != 0,
         };
         if !capabilities.supports_rendering() {
             return Err(HandleError::Unsupported);
@@ -486,13 +492,23 @@ impl Context {
         if spec.copy_destination {
             usage |= GPU_IMAGE_USAGE_TRANSFER_DST;
         }
+        if matches!(spec.format, IrTextureFormat::Depth32Float) {
+            usage = GPU_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT;
+        }
         if usage == 0 {
             return Err(HandleError::InvalidParameter);
         }
-        let raw = self
-            .device
-            .raw
-            .create_image_with_usage(spec.width, spec.height, usage)?;
+        let format = if matches!(spec.format, IrTextureFormat::Depth32Float) {
+            GPU_IMAGE_FORMAT_DEPTH32_FLOAT
+        } else {
+            GPU_IMAGE_FORMAT_BGRA8_UNORM
+        };
+        let raw = self.device.raw.create_image_with_format_and_usage(
+            format,
+            spec.width,
+            spec.height,
+            usage,
+        )?;
         let resource_id = resource_id_from_token(self.raw.attach_image(&raw)?)?;
         Ok(Texture {
             raw,
@@ -721,6 +737,7 @@ struct IrSampler {
 struct IrPipeline {
     blend_handle: u32,
     rasterizer_handle: u32,
+    dsa_handle: u32,
     state: IrPipelineState,
     initialized: Cell<bool>,
 }
@@ -747,6 +764,11 @@ struct IrPassTarget {
     width: u32,
     height: u32,
     orientation: FramebufferOrientation,
+}
+
+struct IrPassDepthTarget {
+    surface_handle: u32,
+    surface_initialized: bool,
 }
 
 impl IrTexture {
@@ -1002,6 +1024,28 @@ impl Queue {
             return Err(HandleError::InvalidParameter);
         }
 
+        let depth_target = if let Some(spec) = submission.depth_attachment {
+            if !matches!(spec.format, IrTextureFormat::Depth32Float)
+                || spec.width != target.width
+                || spec.height != target.height
+                || submission
+                    .clear_depth
+                    .is_some_and(|depth| !depth.is_finite() || !(0.0..=1.0).contains(&depth))
+            {
+                return Err(HandleError::InvalidParameter);
+            }
+            let texture = ir_texture(context, resources, spec)?;
+            Some(IrPassDepthTarget {
+                surface_handle: texture.surface_handle(),
+                surface_initialized: texture.surface_initialized(),
+            })
+        } else {
+            if submission.clear_depth.is_some() {
+                return Err(HandleError::InvalidParameter);
+            }
+            None
+        };
+
         let mut commands = Vec::new();
         commands
             .try_reserve(16 * 1024)
@@ -1015,11 +1059,24 @@ impl Queue {
         if !target.surface_initialized {
             push_surface(&mut commands, target.surface_handle, target.resource_id);
         }
+        if let (Some(depth_spec), Some(depth_target)) =
+            (submission.depth_attachment, depth_target.as_ref())
+            && !depth_target.surface_initialized
+        {
+            let texture = resources
+                .textures
+                .get(depth_spec.slot)
+                .and_then(Option::as_ref)
+                .ok_or(HandleError::InvalidParameter)?;
+            push_depth_surface(
+                &mut commands,
+                depth_target.surface_handle,
+                texture.resource_id(),
+            );
+        }
         for upload in &submission.texture_uploads {
             let texture = ir_texture(context, resources, IrTextureSpec { ..upload.texture })?;
-            let view_is_pending = initialized_views
-                .iter()
-                .any(|slot| *slot == upload.texture.slot);
+            let view_is_pending = initialized_views.contains(&upload.texture.slot);
             if !texture.sampler_view_initialized() && !view_is_pending {
                 push_sampler_view(
                     &mut commands,
@@ -1038,18 +1095,14 @@ impl Queue {
                 submission.vertices.len(),
             )?;
             let pipeline = ir_pipeline(context, resources, draw.pipeline)?;
-            let pipeline_is_pending = initialized_pipelines
-                .iter()
-                .any(|slot| *slot == draw.pipeline.slot);
+            let pipeline_is_pending = initialized_pipelines.contains(&draw.pipeline.slot);
             if !pipeline.initialized.get() && !pipeline_is_pending {
                 push_ir_pipeline(&mut commands, pipeline);
                 initialized_pipelines.push(draw.pipeline.slot);
             }
             if let (Some(texture_spec), Some(sampler)) = (draw.texture, draw.sampler) {
                 let texture = ir_texture(context, resources, texture_spec)?;
-                let view_is_pending = initialized_views
-                    .iter()
-                    .any(|pending| *pending == texture_spec.slot);
+                let view_is_pending = initialized_views.contains(&texture_spec.slot);
                 if !texture.sampler_view_initialized() && !view_is_pending {
                     push_sampler_view(
                         &mut commands,
@@ -1059,9 +1112,7 @@ impl Queue {
                     initialized_views.push(texture_spec.slot);
                 }
                 let sampler = ir_sampler(context, resources, sampler)?;
-                let sampler_is_pending = initialized_samplers
-                    .iter()
-                    .any(|slot| *slot == sampler.state.slot);
+                let sampler_is_pending = initialized_samplers.contains(&sampler.state.slot);
                 if !sampler.initialized.get() && !sampler_is_pending {
                     push_ir_sampler(&mut commands, sampler);
                     initialized_samplers.push(sampler.state.slot);
@@ -1072,6 +1123,9 @@ impl Queue {
         push_ir_bind_pass_state(
             &mut commands,
             target.surface_handle,
+            depth_target
+                .as_ref()
+                .map_or(0, |depth| depth.surface_handle),
             resources.vertex_resource_id,
             target.width,
             target.height,
@@ -1083,19 +1137,33 @@ impl Queue {
             &mut commands,
             ir_rect_to_pixel_rect(submission.render_area)?,
         )?;
-        if let Some(clear_color) = submission.clear_color {
-            if submission.render_area.x == 0
-                && submission.render_area.y == 0
-                && submission.render_area.width == target.width
-                && submission.render_area.height == target.height
-            {
-                push_ir_clear(&mut commands, clear_color);
-            } else {
+        let full_area = submission.render_area.x == 0
+            && submission.render_area.y == 0
+            && submission.render_area.width == target.width
+            && submission.render_area.height == target.height;
+        if full_area && (submission.clear_color.is_some() || submission.clear_depth.is_some()) {
+            push_ir_clear(
+                &mut commands,
+                submission.clear_color,
+                submission.clear_depth,
+            );
+        } else {
+            if let Some(clear_color) = submission.clear_color {
                 push_ir_clear_surface(
                     &mut commands,
                     target.surface_handle,
                     submission.render_area,
                     clear_color,
+                )?;
+            }
+            if let (Some(clear_depth), Some(depth_target)) =
+                (submission.clear_depth, depth_target.as_ref())
+            {
+                push_ir_clear_depth_surface(
+                    &mut commands,
+                    depth_target.surface_handle,
+                    submission.render_area,
+                    clear_depth,
                 )?;
             }
         }
@@ -1116,6 +1184,7 @@ impl Queue {
                 VIRGL_OBJECT_RASTERIZER,
                 pipeline.rasterizer_handle,
             );
+            push_bind_object(&mut commands, VIRGL_OBJECT_DSA, pipeline.dsa_handle);
             push_fragment_shader(
                 &mut commands,
                 ir_fragment_shader_handle(resources, draw.pipeline.fragment),
@@ -1182,6 +1251,11 @@ impl Queue {
                 texture.set_sampler_view_initialized();
             }
         }
+        if let Some(depth) = submission.depth_attachment
+            && let Some(Some(texture)) = resources.textures.get(depth.slot)
+        {
+            texture.set_surface_initialized();
+        }
         Ok(())
     }
 
@@ -1200,7 +1274,7 @@ impl Queue {
             || viewport.height() == 0
             || vertices.is_empty()
             || vertices.len() > pipeline.max_vertices
-            || vertices.len() % 3 != 0
+            || !vertices.len().is_multiple_of(3)
         {
             return Err(HandleError::InvalidParameter);
         }
@@ -1572,6 +1646,7 @@ fn ir_pipeline<'resources>(
         *pipeline_slot = Some(IrPipeline {
             blend_handle: context.allocate_object_handle()?,
             rasterizer_handle: context.allocate_object_handle()?,
+            dsa_handle: context.allocate_object_handle()?,
             state,
             initialized: Cell::new(false),
         });
@@ -1599,6 +1674,15 @@ fn ir_pipeline_states_equal(left: IrPipelineState, right: IrPipelineState) -> bo
         && ir_blend_states_equal(left.blend, right.blend)
         && ir_cull_modes_equal(left.cull_mode, right.cull_mode)
         && ir_front_faces_equal(left.front_face, right.front_face)
+        && match (left.depth, right.depth) {
+            (None, None) => true,
+            (Some(left), Some(right)) => {
+                left.write_enabled == right.write_enabled
+                    && core::mem::discriminant(&left.compare)
+                        == core::mem::discriminant(&right.compare)
+            }
+            _ => false,
+        }
 }
 
 fn ir_fragment_programs_equal(left: IrFragmentProgram, right: IrFragmentProgram) -> bool {
@@ -1679,7 +1763,7 @@ fn validate_ir_draw(
         .checked_add(draw.vertex_count)
         .ok_or(HandleError::InvalidParameter)?;
     if draw.vertex_count == 0
-        || draw.vertex_count % 3 != 0
+        || !draw.vertex_count.is_multiple_of(3)
         || end > vertices_len
         || !ir_rect_is_within(draw.scissor, target_width, target_height)
         || !draw
@@ -1858,6 +1942,18 @@ fn push_surface(commands: &mut Vec<u8>, handle: u32, resource_id: u32) {
     push_dword(commands, handle);
     push_dword(commands, resource_id);
     push_dword(commands, VIRGL_FORMAT_B8G8R8A8_UNORM);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+}
+
+fn push_depth_surface(commands: &mut Vec<u8>, handle: u32, resource_id: u32) {
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_SURFACE, 5),
+    );
+    push_dword(commands, handle);
+    push_dword(commands, resource_id);
+    push_dword(commands, VIRGL_FORMAT_Z32_FLOAT);
     push_dword(commands, 0);
     push_dword(commands, 0);
 }
@@ -2207,6 +2303,22 @@ fn push_ir_pipeline(commands: &mut Vec<u8>, pipeline: &IrPipeline) {
     push_float(commands, 0.0);
     push_float(commands, 0.0);
     push_float(commands, 0.0);
+    push_ir_dsa(commands, pipeline.dsa_handle, pipeline.state.depth);
+}
+
+fn push_ir_dsa(commands: &mut Vec<u8>, handle: u32, depth: Option<crate::driver::IrDepthState>) {
+    push_dword(
+        commands,
+        command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_DSA, 5),
+    );
+    push_dword(commands, handle);
+    let flags = depth.map_or(0, |depth| {
+        1 | (u32::from(depth.write_enabled) << 1) | (ir_compare_function(depth.compare) << 2)
+    });
+    push_dword(commands, flags);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+    push_float(commands, 0.0);
 }
 
 fn push_ir_sampler(commands: &mut Vec<u8>, sampler: &IrSampler) {
@@ -2233,9 +2345,11 @@ fn push_ir_sampler(commands: &mut Vec<u8>, sampler: &IrSampler) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_ir_bind_pass_state(
     commands: &mut Vec<u8>,
     surface_handle: u32,
+    depth_surface_handle: u32,
     vertex_resource_id: u32,
     width: u32,
     height: u32,
@@ -2256,7 +2370,7 @@ fn push_ir_bind_pass_state(
         command_header(VIRGL_CCMD_SET_FRAMEBUFFER_STATE, 0, 3),
     );
     push_dword(commands, 1);
-    push_dword(commands, 0);
+    push_dword(commands, depth_surface_handle);
     push_dword(commands, surface_handle);
     push_dword(
         commands,
@@ -2268,16 +2382,44 @@ fn push_ir_bind_pass_state(
     push_viewport(commands, Viewport::new(width, height), orientation);
 }
 
-fn push_ir_clear(commands: &mut Vec<u8>, color: [f32; 4]) {
+fn push_ir_clear(commands: &mut Vec<u8>, color: Option<[f32; 4]>, depth: Option<f32>) {
     push_dword(commands, command_header(VIRGL_CCMD_CLEAR, 0, 8));
-    push_dword(commands, PIPE_CLEAR_COLOR0);
-    for component in color {
+    push_dword(
+        commands,
+        if color.is_some() {
+            PIPE_CLEAR_COLOR0
+        } else {
+            0
+        } | if depth.is_some() { PIPE_CLEAR_DEPTH } else { 0 },
+    );
+    for component in color.unwrap_or([0.0; 4]) {
         push_float(commands, component);
     }
-    let depth = 1.0f64.to_bits();
+    let depth = f64::from(depth.unwrap_or(1.0)).to_bits();
     push_dword(commands, depth as u32);
     push_dword(commands, (depth >> 32) as u32);
     push_dword(commands, 0);
+}
+
+fn push_ir_clear_depth_surface(
+    commands: &mut Vec<u8>,
+    surface_handle: u32,
+    area: crate::driver::IrRect,
+    depth: f32,
+) -> HandleResult<()> {
+    push_dword(commands, command_header(VIRGL_CCMD_CLEAR_SURFACE, 0, 10));
+    push_dword(commands, PIPE_CLEAR_DEPTH << 1);
+    push_dword(commands, surface_handle);
+    let depth = f64::from(depth).to_bits();
+    push_dword(commands, depth as u32);
+    push_dword(commands, (depth >> 32) as u32);
+    push_dword(commands, 0);
+    push_dword(commands, 0);
+    push_dword(commands, area.x);
+    push_dword(commands, area.y);
+    push_dword(commands, area.width);
+    push_dword(commands, area.height);
+    Ok(())
 }
 
 fn push_ir_clear_surface(
@@ -2369,6 +2511,19 @@ fn ir_blend_op(operation: IrBlendOp) -> u32 {
         IrBlendOp::Add => PIPE_BLEND_ADD,
         IrBlendOp::Subtract => PIPE_BLEND_SUBTRACT,
         IrBlendOp::ReverseSubtract => PIPE_BLEND_REVERSE_SUBTRACT,
+    }
+}
+
+fn ir_compare_function(compare: IrCompareFunction) -> u32 {
+    match compare {
+        IrCompareFunction::Never => 0,
+        IrCompareFunction::Less => 1,
+        IrCompareFunction::Equal => 2,
+        IrCompareFunction::LessEqual => 3,
+        IrCompareFunction::Greater => 4,
+        IrCompareFunction::NotEqual => 5,
+        IrCompareFunction::GreaterEqual => 6,
+        IrCompareFunction::Always => 7,
     }
 }
 
@@ -2539,10 +2694,7 @@ fn push_inline_write(commands: &mut Vec<u8>, resource_id: u32, vertices: &[Verte
     push_dword(commands, 0);
     push_dword(commands, 0);
     push_dword(commands, 0);
-    push_dword(
-        commands,
-        (vertices.len() * core::mem::size_of::<VertexClip4Color3>()) as u32,
-    );
+    push_dword(commands, core::mem::size_of_val(vertices) as u32);
     push_dword(commands, 1);
     push_dword(commands, 1);
     for vertex in vertices {
@@ -2720,4 +2872,120 @@ fn rasterizer_flags(cull_mode: CullMode, front_face: FrontFace) -> u32 {
         0
     };
     VIRGL_RASTERIZER_DEPTH_CLIP | cull_face | front_ccw
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::IrDepthState;
+
+    fn dwords(bytes: &[u8]) -> Vec<u32> {
+        bytes
+            .chunks_exact(4)
+            .map(|word| u32::from_le_bytes(word.try_into().expect("four-byte command word")))
+            .collect()
+    }
+
+    #[test]
+    fn ir_color_only_packets_keep_depth_unbound_and_disabled() {
+        let mut commands = Vec::new();
+        push_ir_bind_pass_state(
+            &mut commands,
+            11,
+            0,
+            12,
+            640,
+            480,
+            FramebufferOrientation::UPPER_LEFT,
+            13,
+            14,
+        );
+        push_ir_dsa(&mut commands, 15, None);
+        push_ir_clear(&mut commands, Some([0.1, 0.2, 0.3, 1.0]), None);
+        let words = dwords(&commands);
+        let framebuffer = words
+            .windows(4)
+            .find(|packet| packet[0] == command_header(VIRGL_CCMD_SET_FRAMEBUFFER_STATE, 0, 3))
+            .expect("framebuffer packet");
+        assert_eq!(
+            framebuffer,
+            [
+                command_header(VIRGL_CCMD_SET_FRAMEBUFFER_STATE, 0, 3),
+                1,
+                0,
+                11
+            ]
+        );
+        let dsa = words
+            .windows(6)
+            .find(|packet| {
+                packet[0] == command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_DSA, 5)
+            })
+            .expect("DSA packet");
+        assert_eq!(dsa[2], 0);
+        let clear = words
+            .windows(9)
+            .find(|packet| packet[0] == command_header(VIRGL_CCMD_CLEAR, 0, 8))
+            .expect("clear packet");
+        assert_eq!(clear[1], PIPE_CLEAR_COLOR0);
+    }
+
+    #[test]
+    fn ir_depth_packets_create_bind_test_write_and_clear_z32() {
+        let mut commands = Vec::new();
+        push_depth_surface(&mut commands, 21, 22);
+        push_ir_bind_pass_state(
+            &mut commands,
+            11,
+            21,
+            12,
+            640,
+            480,
+            FramebufferOrientation::UPPER_LEFT,
+            13,
+            14,
+        );
+        push_ir_dsa(
+            &mut commands,
+            15,
+            Some(IrDepthState {
+                compare: IrCompareFunction::Less,
+                write_enabled: true,
+            }),
+        );
+        push_ir_clear(&mut commands, Some([0.0; 4]), Some(1.0));
+        let words = dwords(&commands);
+        assert_eq!(
+            &words[..6],
+            &[
+                command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_SURFACE, 5),
+                21,
+                22,
+                VIRGL_FORMAT_Z32_FLOAT,
+                0,
+                0,
+            ]
+        );
+        let framebuffer = words
+            .windows(4)
+            .find(|packet| packet[0] == command_header(VIRGL_CCMD_SET_FRAMEBUFFER_STATE, 0, 3))
+            .expect("framebuffer packet");
+        assert_eq!(framebuffer[2], 21);
+        let dsa = words
+            .windows(6)
+            .find(|packet| {
+                packet[0] == command_header(VIRGL_CCMD_CREATE_OBJECT, VIRGL_OBJECT_DSA, 5)
+            })
+            .expect("DSA packet");
+        assert_eq!(dsa[2], 1 | (1 << 1) | (1 << 2));
+        let clear = words
+            .windows(9)
+            .find(|packet| packet[0] == command_header(VIRGL_CCMD_CLEAR, 0, 8))
+            .expect("clear packet");
+        assert_eq!(clear[1], PIPE_CLEAR_COLOR0 | PIPE_CLEAR_DEPTH);
+        assert_eq!(
+            u64::from(clear[6]) | (u64::from(clear[7]) << 32),
+            1.0f64.to_bits()
+        );
+    }
 }

--- a/user/lib/sws-client/src/connection.rs
+++ b/user/lib/sws-client/src/connection.rs
@@ -60,6 +60,17 @@ pub struct Capabilities {
     pub compositor_backend: u32,
 }
 
+impl Capabilities {
+    /// Whether the server supports explicit pointer lock and relative motion.
+    ///
+    /// # Returns
+    ///
+    /// `true` when [`Connection::set_pointer_lock`] may be requested.
+    pub const fn supports_pointer_lock(self) -> bool {
+        self.capabilities & protocol::capabilities::POINTER_LOCK != 0
+    }
+}
+
 /// Stable identity for one registered shared SGFX buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SgfxBufferIdentity {
@@ -842,6 +853,7 @@ impl TransportState {
             | Event::SurfaceStateChanged { surface_id, .. }
             | Event::SurfaceDestroyed { surface_id } => Some(*surface_id),
             Event::MenuItemActivated { window_id, .. }
+            | Event::PointerLockChanged { window_id, .. }
             | Event::SgfxFrameRejected { window_id, .. }
             | Event::SgfxBufferReleased { window_id, .. } => Some(*window_id),
             Event::ScreenSizeChanged { .. }
@@ -2018,6 +2030,31 @@ impl Connection {
             .map_err(|_| Error::SendFailed)
     }
 
+    /// Capture or release raw relative pointer motion for a surface.
+    ///
+    /// Lock requests are accepted by SWS only while the surface is visible,
+    /// not minimized, keyboard-focused, and owned by this connection. The
+    /// authoritative result is delivered as [`Event::PointerLockChanged`].
+    /// While locked, motion arrives through [`Event::Input`] as `EV_REL`
+    /// `REL_X`/`REL_Y` followed by `EV_SYN`.
+    ///
+    /// # Arguments
+    ///
+    /// * `surface_id` - Surface that should capture or release the pointer.
+    /// * `locked` - `true` to request capture, `false` to release it.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` after the request is sent, or a connection/surface error.
+    pub fn set_pointer_lock(&self, surface_id: u32, locked: bool) -> Result<(), Error> {
+        if !mutex_lock(&self.surfaces).contains_key(&surface_id) {
+            return Err(Error::SurfaceNotFound);
+        }
+        let payload = protocol::payload_set_pointer_lock(surface_id, locked);
+        self.send_message(protocol::client_msg::SET_POINTER_LOCK, &payload)
+            .map_err(|_| Error::SendFailed)
+    }
+
     /// Focus and raise a window to the top of the Z-order.
     ///
     /// This only works for surfaces created by this client connection.
@@ -2481,6 +2518,10 @@ impl TransportState {
                 });
                 true
             }
+            ServerMessage::PointerLockChanged { window_id, locked } => {
+                self.push_event(pointer_lock_event(window_id, locked));
+                true
+            }
             ServerMessage::ScreenSizeChanged { width, height } => {
                 self.push_event(Event::ScreenSizeChanged { width, height });
                 true
@@ -2561,6 +2602,39 @@ impl TransportState {
             }
             _ => false,
         }
+    }
+}
+
+fn pointer_lock_event(window_id: u32, locked: bool) -> Event {
+    Event::PointerLockChanged { window_id, locked }
+}
+
+#[cfg(test)]
+mod pointer_lock_tests {
+    use super::*;
+
+    #[test]
+    fn converts_pointer_lock_server_event() {
+        assert_eq!(
+            pointer_lock_event(27, true),
+            Event::PointerLockChanged {
+                window_id: 27,
+                locked: true,
+            }
+        );
+    }
+
+    #[test]
+    fn capability_reports_pointer_lock_support() {
+        let mut capabilities = Capabilities {
+            protocol_version: protocol::SWS_PROTOCOL_VERSION,
+            capabilities: 0,
+            compositor_epoch: 1,
+            compositor_backend: protocol::compositor_backends::CPU,
+        };
+        assert!(!capabilities.supports_pointer_lock());
+        capabilities.capabilities |= protocol::capabilities::POINTER_LOCK;
+        assert!(capabilities.supports_pointer_lock());
     }
 }
 

--- a/user/lib/sws-client/src/event.rs
+++ b/user/lib/sws-client/src/event.rs
@@ -110,6 +110,11 @@ pub enum Event {
     ///
     /// `state_flags` is a bitset of constants from [`crate::window_state`].
     SurfaceStateChanged { surface_id: u32, state_flags: u32 },
+    /// Compositor-confirmed pointer lock state.
+    ///
+    /// A `locked: false` event can be caused by an explicit request or by the
+    /// compositor releasing capture after focus/visibility/lifetime changes.
+    PointerLockChanged { window_id: u32, locked: bool },
     /// Display size changed.
     ScreenSizeChanged { width: u32, height: u32 },
     /// Output scale changed.

--- a/user/lib/sws-protocol/src/lib.rs
+++ b/user/lib/sws-protocol/src/lib.rs
@@ -37,6 +37,8 @@ pub const SGFX_MAX_DAMAGE_RECTS: usize = 16;
 pub mod capabilities {
     /// Shared SGFX images may be registered and committed without CPU copies.
     pub const SGFX_SHARED_IMAGE: u64 = 1 << 0;
+    /// Focused windows may capture raw relative pointer motion.
+    pub const POINTER_LOCK: u64 = 1 << 1;
 }
 
 /// SWS compositor backend identifiers reported by capability negotiation.
@@ -65,6 +67,10 @@ pub mod error_codes {
     pub const ACTIVATION_DENIED: u32 = 106;
     /// Another window already owns fullscreen state on the requested output.
     pub const FULLSCREEN_OCCUPIED: u32 = 107;
+    /// Pointer lock was requested for a window not owned by the connection.
+    pub const POINTER_LOCK_NOT_OWNED: u32 = 108;
+    /// Pointer lock requires a visible, non-minimized, keyboard-focused window.
+    pub const POINTER_LOCK_DENIED: u32 = 109;
 }
 
 /// Message type IDs (client -> server).
@@ -118,6 +124,8 @@ pub mod client_msg {
     // Fullscreen window state (40-41)
     pub const SET_FULLSCREEN: u32 = 40;
     pub const UNSET_FULLSCREEN: u32 = 41;
+    /// Capture or release raw relative pointer motion for an owned window.
+    pub const SET_POINTER_LOCK: u32 = 42;
 
     // Text input client API messages (200-219)
     pub const TEXT_INPUT_CREATE: u32 = 200;
@@ -178,6 +186,8 @@ pub mod server_msg {
     pub const SGFX_BUFFER_DESTROYED: u32 = 30;
     pub const ACTIVATION_TOKEN: u32 = 31;
     pub const WINDOW_STATE_CHANGED: u32 = 32;
+    /// Pointer lock state changed, including compositor-forced release.
+    pub const POINTER_LOCK_CHANGED: u32 = 33;
 
     // Text input client events (200-219)
     pub const TEXT_INPUT_CREATED: u32 = 200;
@@ -801,6 +811,12 @@ pub enum ClientMessageRef<'a> {
         window_id: u32,
     },
 
+    /// Capture or release raw relative pointer motion.
+    SetPointerLock {
+        window_id: u32,
+        locked: bool,
+    },
+
     /// Set window type for Z-order management
     /// Type: 0 = Normal, 1 = AlwaysOnTop, 2 = Taskbar, 3 = Desktop
     SetWindowType {
@@ -1069,6 +1085,11 @@ pub enum ServerMessage {
     WindowStateChanged {
         window_id: u32,
         state_flags: u32,
+    },
+    /// Compositor-confirmed pointer lock state.
+    PointerLockChanged {
+        window_id: u32,
+        locked: bool,
     },
     InputEvent {
         window_id: u32,
@@ -1627,6 +1648,18 @@ pub fn parse_client_message<'a>(
             }
             let window_id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
             Ok(ClientMessageRef::UnsetFullscreen { window_id })
+        }
+        client_msg::SET_POINTER_LOCK => {
+            if payload.len() != 8 {
+                return Err(ProtocolError::MalformedPayload);
+            }
+            let window_id = read_u32(payload, 0)?;
+            let locked = match read_u32(payload, 4)? {
+                0 => false,
+                1 => true,
+                _ => return Err(ProtocolError::MalformedPayload),
+            };
+            Ok(ClientMessageRef::SetPointerLock { window_id, locked })
         }
         client_msg::SET_WINDOW_TYPE => {
             if payload.len() != 8 {
@@ -2285,6 +2318,18 @@ pub fn parse_server_message(msg_type: u32, payload: &[u8]) -> Result<ServerMessa
                 window_id,
                 state_flags,
             })
+        }
+        server_msg::POINTER_LOCK_CHANGED => {
+            if payload.len() != 8 {
+                return Err(ProtocolError::MalformedPayload);
+            }
+            let window_id = read_u32(payload, 0)?;
+            let locked = match read_u32(payload, 4)? {
+                0 => false,
+                1 => true,
+                _ => return Err(ProtocolError::MalformedPayload),
+            };
+            Ok(ServerMessage::PointerLockChanged { window_id, locked })
         }
         server_msg::INPUT_EVENT => {
             if payload.len() != 20 {
@@ -3725,6 +3770,37 @@ pub fn payload_unset_fullscreen(window_id: u32) -> [u8; 4] {
     window_id.to_le_bytes()
 }
 
+/// Build payload for client->server `SET_POINTER_LOCK`.
+///
+/// # Arguments
+///
+/// * `window_id` - Window that should capture or release pointer motion.
+/// * `locked` - `true` to capture the pointer, `false` to release it.
+///
+/// # Returns
+///
+/// The fixed-width pointer lock request payload.
+pub fn payload_set_pointer_lock(window_id: u32, locked: bool) -> [u8; 8] {
+    let mut payload = [0u8; 8];
+    payload[0..4].copy_from_slice(&window_id.to_le_bytes());
+    payload[4..8].copy_from_slice(&(locked as u32).to_le_bytes());
+    payload
+}
+
+/// Build payload for server->client `POINTER_LOCK_CHANGED`.
+///
+/// # Arguments
+///
+/// * `window_id` - Window whose pointer lock state changed.
+/// * `locked` - Current compositor-confirmed lock state.
+///
+/// # Returns
+///
+/// The fixed-width pointer lock event payload.
+pub fn payload_pointer_lock_changed(window_id: u32, locked: bool) -> [u8; 8] {
+    payload_set_pointer_lock(window_id, locked)
+}
+
 /// Build payload for client->server `SET_WINDOW_TYPE`.
 pub fn payload_set_window_type(window_id: u32, window_type: u32) -> [u8; 8] {
     let mut payload = [0u8; 8];
@@ -4316,12 +4392,14 @@ pub fn payload_set_window_has_alpha_content(window_id: u32, has_alpha: bool) -> 
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::{
-        ClientMessageRef, ServerMessage, WindowPlacement, client_msg, parse_client_message,
-        parse_server_message, payload_activation_token, payload_create_window_with_placement,
+        ClientMessageRef, MessageHeader, ProtocolError, ServerMessage, WindowPlacement, client_msg,
+        encode_routed_frame, error_codes, parse_client_message, parse_server_message,
+        payload_activation_token, payload_create_window_with_placement,
         payload_create_window_with_placement_and_activation_token,
-        payload_create_window_with_position, payload_request_activation_token,
-        payload_set_fullscreen, payload_unset_fullscreen, payload_window_state_changed, server_msg,
-        window_placement, window_state,
+        payload_create_window_with_position, payload_error, payload_pointer_lock_changed,
+        payload_request_activation_token, payload_set_fullscreen, payload_set_pointer_lock,
+        payload_unset_fullscreen, payload_window_state_changed, server_msg, window_placement,
+        window_state,
     };
 
     #[test]
@@ -4473,5 +4551,83 @@ mod tests {
                 state_flags: flags,
             }
         );
+    }
+
+    #[test]
+    fn pointer_lock_request_and_event_round_trip() {
+        for locked in [false, true] {
+            let request = payload_set_pointer_lock(91, locked);
+            assert_eq!(
+                parse_client_message(client_msg::SET_POINTER_LOCK, &request).unwrap(),
+                ClientMessageRef::SetPointerLock {
+                    window_id: 91,
+                    locked,
+                }
+            );
+
+            let event = payload_pointer_lock_changed(91, locked);
+            assert_eq!(
+                parse_server_message(server_msg::POINTER_LOCK_CHANGED, &event).unwrap(),
+                ServerMessage::PointerLockChanged {
+                    window_id: 91,
+                    locked,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn pointer_lock_rejects_malformed_payloads() {
+        assert_eq!(
+            parse_client_message(client_msg::SET_POINTER_LOCK, &[0; 7]),
+            Err(ProtocolError::MalformedPayload)
+        );
+        let mut invalid_bool = payload_set_pointer_lock(91, false);
+        invalid_bool[4..8].copy_from_slice(&2u32.to_le_bytes());
+        assert_eq!(
+            parse_client_message(client_msg::SET_POINTER_LOCK, &invalid_bool),
+            Err(ProtocolError::MalformedPayload)
+        );
+        assert_eq!(
+            parse_server_message(server_msg::POINTER_LOCK_CHANGED, &invalid_bool),
+            Err(ProtocolError::MalformedPayload)
+        );
+    }
+
+    #[test]
+    fn pointer_lock_correlated_frames_preserve_response_header() {
+        let cases = [
+            (
+                server_msg::POINTER_LOCK_CHANGED,
+                7,
+                payload_pointer_lock_changed(91, true).to_vec(),
+            ),
+            (
+                server_msg::POINTER_LOCK_CHANGED,
+                8,
+                payload_pointer_lock_changed(91, true).to_vec(),
+            ),
+            (
+                server_msg::ERROR,
+                9,
+                payload_error(error_codes::POINTER_LOCK_DENIED).to_vec(),
+            ),
+        ];
+
+        for (msg_type, request_id, payload) in cases {
+            let frame = encode_routed_frame(
+                msg_type,
+                MessageHeader::FLAG_IS_RESPONSE,
+                request_id,
+                &payload,
+            );
+            let header =
+                MessageHeader::from_le_bytes(frame[..MessageHeader::SIZE].try_into().unwrap());
+            assert!(header.is_response());
+            assert_eq!(header.request_id, request_id);
+            assert_eq!(header.msg_type_u32(), msg_type);
+            assert_eq!(&frame[MessageHeader::SIZE..], payload.as_slice());
+            parse_server_message(msg_type, &frame[MessageHeader::SIZE..]).unwrap();
+        }
     }
 }


### PR DESCRIPTION
## What changed

- add SGFX `Depth32Float` attachments, depth-test pipeline state, capability reporting, and VirGL/kernel backing
- add SWS pointer lock with hidden/confined cursor, relative motion, ownership, focus/lifecycle revocation, and correlated request responses
- preserve existing color-only SGFX and normal pointer paths

## Why

ScarletUI applications such as Boxcraft need depth-tested 3D canvas rendering and first-person relative pointer input without bypassing Scarlet's compositor.

## Validation

- `cargo make fmt-check`
- `cargo make build-riscv64`
- `cargo make build-aarch64`
- SGFX/gpu-raw host tests and VirGL packet tests
- SWS protocol tests: 10 passed
- SWS pointer-lock integration tests: 8 passed
- `cargo check --locked --bin sws`

Both independent code reviews completed with CLEAR status. Runtime QEMU coverage will follow once the dependent ScarletUI and Boxcraft Git revisions are published.
