### PR TITLE
Add a WGPU backend to SGFX

### DIFF
--- a/user/lib/sgfx/Cargo.lock
+++ b/user/lib/sgfx/Cargo.lock
@@ -9,6 +9,156 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,11 +171,145 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "framebuffer"
 version = "0.16.0"
 dependencies = [
  "scarlet-os",
  "scarlet-std",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45cf04b2726f02df5508c6de726acdc90cdf97ac771a9a0ffd8ba10a6e696bf9"
+dependencies = [
+ "bitflags 2.13.1",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bbed164dd10ed526c2e4fe3e721ca4a71c61730e5aafac6844b417b3227058"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.13.1",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -48,6 +332,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +445,216 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+dependencies = [
+ "bitflags 2.13.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "naga"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "rustc-hash",
+ "spirv",
+ "strum",
+ "termcolor",
+ "thiserror 2.0.20",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scarlet-abi"
@@ -83,7 +683,7 @@ dependencies = [
 name = "scarlet-std"
 version = "0.16.0"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
  "scarlet-abi",
  "scarlet-os",
  "scarlet-rt",
@@ -105,14 +705,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "sgfx"
 version = "0.16.0"
 dependencies = [
+ "bytemuck",
  "framebuffer",
  "gpu-raw",
+ "pollster",
  "scarlet-os",
  "scarlet-std",
+ "wgpu",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spin"
@@ -124,6 +768,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "talc"
 version = "4.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,3 +834,408 @@ checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wgpu"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "document-features",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.20",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "24.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.13.1",
+ "block",
+ "bytemuck",
+ "cfg_aliases",
+ "core-graphics-types",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys",
+ "objc",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.20",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+dependencies = [
+ "bitflags 2.13.1",
+ "js-sys",
+ "log",
+ "web-sys",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"

--- a/user/lib/sgfx/Cargo.toml
+++ b/user/lib/sgfx/Cargo.toml
@@ -7,12 +7,18 @@ edition = "2024"
 default = ["scarlet-std"]
 std = ["dep:scarlet-os", "framebuffer/std", "gpu-raw/std"]
 scarlet-std = ["dep:scarlet-std", "framebuffer/scarlet-std", "gpu-raw/scarlet-std"]
+wgpu = ["std", "dep:bytemuck", "dep:wgpu"]
 
 [dependencies]
 scarlet-os = { path = "../scarlet-os", default-features = false, features = ["std"], optional = true }
 scarlet-std = { path = "../std", optional = true }
 framebuffer = { path = "../framebuffer", default-features = false }
 gpu-raw = { path = "../gpu-raw", default-features = false }
+bytemuck = { version = "1", features = ["derive"], optional = true }
+wgpu = { version = "24", optional = true }
+
+[dev-dependencies]
+pollster = "0.4"
 
 [lib]
 name = "sgfx"

--- a/user/lib/sgfx/src/ir/resource.rs
+++ b/user/lib/sgfx/src/ir/resource.rs
@@ -575,7 +575,17 @@ impl ResourceTable {
         }
         Ok(())
     }
-    pub(crate) fn texture(&self, reference: TextureRef<'_>) -> Result<TextureDesc> {
+    /// Return the validated descriptor for a texture reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - Texture reference branded by this resource table.
+    ///
+    /// # Returns
+    ///
+    /// The texture descriptor, or an error when the reference belongs to a
+    /// different table or no longer identifies a defined resource.
+    pub fn texture(&self, reference: TextureRef<'_>) -> Result<TextureDesc> {
         if !core::ptr::eq(reference.owner, self) {
             return Err(Error::ResourceTableMismatch);
         }
@@ -585,7 +595,17 @@ impl ResourceTable {
             .copied()
             .ok_or(Error::InvalidDescriptor)
     }
-    pub(crate) fn buffer(&self, reference: BufferRef<'_>) -> Result<BufferDesc> {
+    /// Return the validated descriptor for a buffer reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - Buffer reference branded by this resource table.
+    ///
+    /// # Returns
+    ///
+    /// The buffer descriptor, or an error when the reference belongs to a
+    /// different table or no longer identifies a defined resource.
+    pub fn buffer(&self, reference: BufferRef<'_>) -> Result<BufferDesc> {
         if !core::ptr::eq(reference.owner, self) {
             return Err(Error::ResourceTableMismatch);
         }
@@ -595,7 +615,17 @@ impl ResourceTable {
             .copied()
             .ok_or(Error::InvalidDescriptor)
     }
-    pub(crate) fn sampler(&self, reference: SamplerRef<'_>) -> Result<SamplerDesc> {
+    /// Return the validated descriptor for a sampler reference.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - Sampler reference branded by this resource table.
+    ///
+    /// # Returns
+    ///
+    /// The sampler descriptor, or an error when the reference belongs to a
+    /// different table or no longer identifies a defined resource.
+    pub fn sampler(&self, reference: SamplerRef<'_>) -> Result<SamplerDesc> {
         if !core::ptr::eq(reference.owner, self) {
             return Err(Error::ResourceTableMismatch);
         }
@@ -619,6 +649,20 @@ impl ResourceTable {
             .get(reference.index)
             .ok_or(Error::InvalidDescriptor)?;
         Ok(access(descriptor))
+    }
+
+    /// Return a cloned render-pipeline descriptor for a backend lowerer.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - Render-pipeline reference branded by this resource table.
+    ///
+    /// # Returns
+    ///
+    /// The owned pipeline descriptor, or an error when the reference belongs
+    /// to another table or no longer identifies a defined resource.
+    pub fn render_pipeline(&self, reference: RenderPipelineRef<'_>) -> Result<RenderPipelineDesc> {
+        self.with_pipeline(reference, Clone::clone)
     }
     pub(crate) fn same_texture(&self, left: TextureRef<'_>, right: TextureRef<'_>) -> Result<bool> {
         self.texture(left)?;

--- a/user/lib/sgfx/src/lib.rs
+++ b/user/lib/sgfx/src/lib.rs
@@ -28,6 +28,10 @@ use std::{
 /// Supported command subsets can be lowered through [`Queue::submit_ir`].
 pub mod ir;
 
+/// WGPU execution backend for native desktop targets.
+#[cfg(feature = "wgpu")]
+pub mod wgpu;
+
 mod driver;
 mod ir_execute;
 mod virgl;

--- a/user/lib/sgfx/src/wgpu.rs
+++ b/user/lib/sgfx/src/wgpu.rs
@@ -1,0 +1,2239 @@
+//! WGPU execution backend for the portable SGFX IR.
+//!
+//! This module intentionally does not use Scarlet GPU handles, display
+//! surfaces, or shared-memory capabilities. A caller supplies a WGPU device
+//! and queue, maps a logical presentation texture to an owned WGPU image, and
+//! submits the same validated IR command buffers used by the native backend.
+//! A persistent resource cache can rebind that logical presentation texture to
+//! each newly acquired WGPU surface frame.
+
+use alloc::{borrow::Cow, format, rc::Rc, string::String, sync::Arc, vec::Vec};
+use core::fmt;
+
+use bytemuck::{Pod, Zeroable};
+use wgpu as raw;
+
+use crate::ir::{
+    self, AddressMode, BlendComponent, BlendFactor, BlendOp, BufferId, BufferRef, BufferUsage,
+    Command, CommandBuffer, CompareFunction, DepthLoadOp, DrawUniforms, FilterMode,
+    FragmentProgram, IndexFormat, LoadOp, RenderPassDesc, RenderPipelineDesc, RenderPipelineId,
+    ResourceTable, SamplerId, SamplerRef, StoreOp, TextureDesc, TextureFormat, TextureId,
+    TextureRef, TextureSampleMode, TextureUsage, VertexAttribute, VertexFormat,
+};
+
+/// Result returned by the WGPU backend.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Failure returned while translating or submitting SGFX commands through WGPU.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// A logical IR descriptor or command failed validation.
+    InvalidIr(ir::Error),
+    /// A command buffer belongs to a different resource table than the cache.
+    ResourceTableMismatch,
+    /// A presentation texture was submitted without a physical image mapping.
+    ImageNotMapped,
+    /// A physical image was mapped to more than one logical texture.
+    ImageAlreadyMapped,
+    /// The backend cannot represent a valid logical IR feature yet.
+    Unsupported(UnsupportedFeature),
+    /// The command stream or persistent backend state is inconsistent.
+    InvalidState,
+    /// Acquiring a WGPU surface frame failed.
+    Surface(raw::SurfaceError),
+}
+
+impl From<ir::Error> for Error {
+    fn from(error: ir::Error) -> Self {
+        Self::InvalidIr(error)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidIr(error) => write!(formatter, "invalid SGFX IR: {error:?}"),
+            Self::ResourceTableMismatch => formatter.write_str("resource table mismatch"),
+            Self::ImageNotMapped => formatter.write_str("presentation image is not mapped"),
+            Self::ImageAlreadyMapped => formatter.write_str("image is already mapped"),
+            Self::Unsupported(feature) => {
+                write!(formatter, "unsupported SGFX feature: {feature:?}")
+            }
+            Self::InvalidState => formatter.write_str("invalid WGPU backend state"),
+            Self::Surface(error) => {
+                write!(formatter, "failed to acquire WGPU surface frame: {error}")
+            }
+        }
+    }
+}
+
+/// Logical SGFX features that are not yet represented by this backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedFeature {
+    /// A write command appeared after a copy or render pass had been encoded.
+    LateUpload,
+    /// A render pipeline uses a format or vertex convention outside WGPU's
+    /// current portable lowering.
+    Pipeline,
+    /// A sampled texture format is incompatible with the selected fragment
+    /// program.
+    TextureFormat,
+    /// WGPU cannot express a depth clear restricted to a rectangular render
+    /// area without an explicit clear draw.
+    PartialDepthClear,
+    /// The physical surface format cannot be represented by SGFX.
+    SurfaceFormat,
+}
+
+/// WGPU device and queue pair used by the SGFX backend.
+#[derive(Clone)]
+pub struct Device {
+    device: Arc<raw::Device>,
+    queue: Arc<raw::Queue>,
+    identity: Arc<()>,
+}
+
+impl Device {
+    /// Wrap an existing WGPU device and queue.
+    ///
+    /// # Arguments
+    ///
+    /// * `device` - WGPU device used to create resources and command encoders.
+    /// * `queue` - WGPU queue used to upload data and submit command buffers.
+    ///
+    /// # Returns
+    ///
+    /// A reusable SGFX WGPU device.
+    pub fn new(device: raw::Device, queue: raw::Queue) -> Self {
+        Self {
+            device: Arc::new(device),
+            queue: Arc::new(queue),
+            identity: Arc::new(()),
+        }
+    }
+
+    /// Create a rendering context sharing this device and queue.
+    ///
+    /// # Returns
+    ///
+    /// A context for images, IR resource caches, and queues.
+    pub fn create_context(&self) -> Context {
+        Context {
+            device: self.clone(),
+        }
+    }
+
+    /// Borrow the underlying WGPU device.
+    ///
+    /// # Returns
+    ///
+    /// The wrapped WGPU device.
+    pub fn raw_device(&self) -> &raw::Device {
+        self.device.as_ref()
+    }
+
+    /// Borrow the underlying WGPU queue.
+    ///
+    /// # Returns
+    ///
+    /// The wrapped WGPU queue.
+    pub fn raw_queue(&self) -> &raw::Queue {
+        self.queue.as_ref()
+    }
+}
+
+/// WGPU rendering context used to create SGFX resources.
+#[derive(Clone)]
+pub struct Context {
+    device: Device,
+}
+
+impl Context {
+    /// Borrow the wrapped WGPU device for platform presentation work.
+    ///
+    /// # Returns
+    ///
+    /// The WGPU device paired with this context.
+    pub fn raw_device(&self) -> &raw::Device {
+        self.device.raw_device()
+    }
+
+    /// Borrow the wrapped WGPU queue for platform presentation work.
+    ///
+    /// # Returns
+    ///
+    /// The WGPU queue paired with this context.
+    pub fn raw_queue(&self) -> &raw::Queue {
+        self.device.raw_queue()
+    }
+
+    /// Create an offscreen render-target image.
+    ///
+    /// # Arguments
+    ///
+    /// * `width` - Non-zero image width in pixels.
+    /// * `height` - Non-zero image height in pixels.
+    /// * `format` - Portable SGFX color format.
+    ///
+    /// # Returns
+    ///
+    /// A WGPU-backed image or an invalid-state error for unsupported formats.
+    pub fn create_image(
+        &self,
+        width: u32,
+        height: u32,
+        format: TextureFormat,
+    ) -> Result<Arc<Image>> {
+        if width == 0
+            || height == 0
+            || !matches!(
+                format,
+                TextureFormat::Bgra8Unorm | TextureFormat::Rgba8Unorm | TextureFormat::R8Unorm
+            )
+        {
+            return Err(Error::InvalidState);
+        }
+        let gpu = create_gpu_texture(
+            self.device.raw_device(),
+            width,
+            height,
+            format,
+            raw::TextureUsages::TEXTURE_BINDING
+                | raw::TextureUsages::RENDER_ATTACHMENT
+                | raw::TextureUsages::COPY_SRC
+                | raw::TextureUsages::COPY_DST,
+        )?;
+        Ok(Arc::new(Image {
+            device_identity: Arc::clone(&self.device.identity),
+            gpu,
+        }))
+    }
+
+    /// Acquire the current WGPU surface frame as an SGFX image.
+    ///
+    /// The returned frame must be presented after all commands targeting its
+    /// image have been submitted. WGPU surface acquisition and presentation
+    /// remain platform responsibilities and are deliberately outside the
+    /// portable SGFX IR.
+    ///
+    /// # Arguments
+    ///
+    /// * `surface` - Configured WGPU surface to acquire from.
+    ///
+    /// # Returns
+    ///
+    /// An acquired surface frame or the WGPU surface error.
+    pub fn acquire_surface_frame<'surface>(
+        &self,
+        surface: &raw::Surface<'surface>,
+    ) -> Result<SurfaceFrame> {
+        let frame = surface.get_current_texture().map_err(Error::Surface)?;
+        let format = logical_format(frame.texture.format())
+            .ok_or(Error::Unsupported(UnsupportedFeature::SurfaceFormat))?;
+        let gpu = Arc::new(GpuTexture {
+            view: frame
+                .texture
+                .create_view(&raw::TextureViewDescriptor::default()),
+            texture: frame.texture.clone(),
+            format: frame.texture.format(),
+            logical_format: format,
+            width: frame.texture.width(),
+            height: frame.texture.height(),
+        });
+        Ok(SurfaceFrame {
+            frame,
+            image: Arc::new(Image {
+                device_identity: Arc::clone(&self.device.identity),
+                gpu,
+            }),
+        })
+    }
+
+    /// Create a persistent logical-resource cache for this context.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Resource table whose references will be submitted.
+    ///
+    /// # Returns
+    ///
+    /// An empty WGPU materialization cache.
+    pub fn create_resources(&self, resources: Rc<ResourceTable>) -> Resources {
+        Resources {
+            context: self.clone(),
+            resources,
+            textures: Vec::new(),
+            buffers: Vec::new(),
+            samplers: Vec::new(),
+            pipelines: Vec::new(),
+            clear_pipelines: Vec::new(),
+            mapped_images: Vec::new(),
+        }
+    }
+
+    /// Create a command queue for this context.
+    ///
+    /// # Returns
+    ///
+    /// A queue that translates and submits SGFX IR command buffers.
+    pub fn create_queue(&self) -> Queue {
+        Queue {
+            context: self.clone(),
+        }
+    }
+}
+
+/// WGPU-backed SGFX image.
+#[derive(Clone)]
+pub struct Image {
+    device_identity: Arc<()>,
+    gpu: Arc<GpuTexture>,
+}
+
+impl Image {
+    /// Return the image width in pixels.
+    ///
+    /// # Returns
+    ///
+    /// The image width.
+    pub fn width(&self) -> u32 {
+        self.gpu.width
+    }
+
+    /// Return the image height in pixels.
+    ///
+    /// # Returns
+    ///
+    /// The image height.
+    pub fn height(&self) -> u32 {
+        self.gpu.height
+    }
+
+    /// Return the portable logical image format.
+    ///
+    /// # Returns
+    ///
+    /// The image format used by SGFX IR descriptors.
+    pub fn format(&self) -> TextureFormat {
+        self.gpu.logical_format
+    }
+
+    /// Borrow the underlying WGPU texture for platform presentation or copy.
+    ///
+    /// # Returns
+    ///
+    /// The WGPU texture owned by this SGFX image.
+    pub fn raw_texture(&self) -> &raw::Texture {
+        &self.gpu.texture
+    }
+
+    /// Borrow the default view of the underlying WGPU texture.
+    ///
+    /// # Returns
+    ///
+    /// The WGPU texture view used by SGFX render passes.
+    pub fn raw_view(&self) -> &raw::TextureView {
+        &self.gpu.view
+    }
+}
+
+/// Acquired WGPU surface frame and its SGFX image view.
+pub struct SurfaceFrame {
+    frame: raw::SurfaceTexture,
+    image: Arc<Image>,
+}
+
+impl SurfaceFrame {
+    /// Borrow the acquired image for resource mapping.
+    ///
+    /// # Returns
+    ///
+    /// The WGPU-backed image associated with this surface frame.
+    pub fn image(&self) -> Arc<Image> {
+        Arc::clone(&self.image)
+    }
+
+    /// Present the acquired surface frame.
+    ///
+    /// Consumes the frame so it cannot be presented twice.
+    pub fn present(self) {
+        self.frame.present();
+    }
+}
+
+/// Persistent logical-resource materialization cache for one WGPU context.
+pub struct Resources {
+    context: Context,
+    resources: Rc<ResourceTable>,
+    textures: Vec<(TextureId, Arc<GpuTexture>)>,
+    buffers: Vec<(BufferId, Arc<GpuBuffer>)>,
+    samplers: Vec<(SamplerId, Arc<raw::Sampler>)>,
+    pipelines: Vec<(
+        RenderPipelineId,
+        raw::TextureFormat,
+        Option<TextureFormat>,
+        Arc<GpuPipeline>,
+    )>,
+    clear_pipelines: Vec<(raw::TextureFormat, bool, Arc<GpuClearPipeline>)>,
+    mapped_images: Vec<(TextureId, Arc<GpuTexture>)>,
+}
+
+impl Resources {
+    /// Return the logical resource table retained by this cache.
+    ///
+    /// # Returns
+    ///
+    /// The resource table used to brand submitted references.
+    pub fn resource_table(&self) -> &ResourceTable {
+        self.resources.as_ref()
+    }
+
+    /// Map a logical presentation texture to a physical WGPU image.
+    ///
+    /// # Arguments
+    ///
+    /// * `texture` - Logical texture with `RENDER_ATTACHMENT | PRESENT` usage.
+    /// * `image` - Physical image with matching dimensions, format, and device.
+    ///
+    /// # Returns
+    ///
+    /// Success or a resource/table/format mapping error. Mapping the same
+    /// logical texture again replaces its previous physical image, which is
+    /// required when presenting a newly acquired WGPU surface frame.
+    pub fn map_image(&mut self, texture: TextureId, image: Arc<Image>) -> Result<()> {
+        if !Arc::ptr_eq(&self.context.device.identity, &image.device_identity) {
+            return Err(Error::InvalidState);
+        }
+        let reference = self.resources.texture_ref(texture)?;
+        let descriptor = self.resources.texture(reference)?;
+        let required = TextureUsage::RENDER_ATTACHMENT | TextureUsage::PRESENT;
+        if !descriptor.usage().contains(required)
+            || descriptor.extent().width() != image.width()
+            || descriptor.extent().height() != image.height()
+            || descriptor.format() != image.format()
+        {
+            return Err(Error::InvalidState);
+        }
+        if self
+            .mapped_images
+            .iter()
+            .any(|(candidate, mapped)| *candidate != texture && Arc::ptr_eq(mapped, &image.gpu))
+        {
+            return Err(Error::ImageAlreadyMapped);
+        }
+        if let Some((_, mapped)) = self
+            .mapped_images
+            .iter_mut()
+            .find(|(candidate, _)| *candidate == texture)
+        {
+            *mapped = Arc::clone(&image.gpu);
+        } else {
+            self.mapped_images.push((texture, Arc::clone(&image.gpu)));
+        }
+        Ok(())
+    }
+
+    fn texture(&mut self, reference: TextureRef<'_>) -> Result<Arc<GpuTexture>> {
+        let descriptor = self.resources.texture(reference)?;
+        let id = reference.id();
+        if let Some((_, image)) = self
+            .mapped_images
+            .iter()
+            .find(|(candidate, _)| *candidate == id)
+        {
+            return Ok(Arc::clone(image));
+        }
+        if descriptor.usage().contains(TextureUsage::PRESENT) {
+            return Err(Error::ImageNotMapped);
+        }
+        if let Some((_, texture)) = self.textures.iter().find(|(candidate, _)| *candidate == id) {
+            return Ok(Arc::clone(texture));
+        }
+        let usage = texture_usage(descriptor)?;
+        let texture = create_gpu_texture(
+            self.context.device.raw_device(),
+            descriptor.extent().width(),
+            descriptor.extent().height(),
+            descriptor.format(),
+            usage,
+        )?;
+        self.textures.push((id, Arc::clone(&texture)));
+        Ok(texture)
+    }
+
+    fn buffer(&mut self, reference: BufferRef<'_>) -> Result<Arc<GpuBuffer>> {
+        let descriptor = self.resources.buffer(reference)?;
+        let id = reference.id();
+        if let Some((_, buffer)) = self.buffers.iter().find(|(candidate, _)| *candidate == id) {
+            return Ok(Arc::clone(buffer));
+        }
+        let mut usage = raw::BufferUsages::empty();
+        if descriptor.usage().contains(BufferUsage::VERTEX) {
+            usage |= raw::BufferUsages::VERTEX;
+        }
+        if descriptor.usage().contains(BufferUsage::INDEX) {
+            usage |= raw::BufferUsages::INDEX;
+        }
+        if descriptor.usage().contains(BufferUsage::COPY_SRC) {
+            usage |= raw::BufferUsages::COPY_SRC;
+        }
+        if descriptor.usage().contains(BufferUsage::COPY_DST) {
+            usage |= raw::BufferUsages::COPY_DST;
+        }
+        let buffer = Arc::new(GpuBuffer {
+            buffer: self
+                .context
+                .device
+                .raw_device()
+                .create_buffer(&raw::BufferDescriptor {
+                    label: Some("sgfx wgpu buffer"),
+                    size: descriptor.size(),
+                    usage,
+                    mapped_at_creation: false,
+                }),
+        });
+        self.buffers.push((id, Arc::clone(&buffer)));
+        Ok(buffer)
+    }
+
+    fn sampler(&mut self, reference: SamplerRef<'_>) -> Result<Arc<raw::Sampler>> {
+        let descriptor = self.resources.sampler(reference)?;
+        let id = reference.id();
+        if let Some((_, sampler)) = self.samplers.iter().find(|(candidate, _)| *candidate == id) {
+            return Ok(Arc::clone(sampler));
+        }
+        let sampler = Arc::new(self.context.device.raw_device().create_sampler(
+            &raw::SamplerDescriptor {
+                label: Some("sgfx wgpu sampler"),
+                address_mode_u: address_mode(descriptor.address_u()),
+                address_mode_v: address_mode(descriptor.address_v()),
+                address_mode_w: raw::AddressMode::ClampToEdge,
+                mag_filter: filter_mode(descriptor.mag_filter()),
+                min_filter: filter_mode(descriptor.min_filter()),
+                mipmap_filter: raw::FilterMode::Nearest,
+                ..raw::SamplerDescriptor::default()
+            },
+        ));
+        self.samplers.push((id, Arc::clone(&sampler)));
+        Ok(sampler)
+    }
+
+    fn pipeline(
+        &mut self,
+        id: RenderPipelineId,
+        target_format: raw::TextureFormat,
+        sample_format: Option<TextureFormat>,
+    ) -> Result<Arc<GpuPipeline>> {
+        let reference = self.resources.render_pipeline_ref(id)?;
+        let descriptor = self.resources.render_pipeline(reference)?;
+        let sample_format = match descriptor.fragment() {
+            FragmentProgram::Texture(_) | FragmentProgram::TextureVertexColor(_) => sample_format,
+            FragmentProgram::Solid | FragmentProgram::VertexColor => None,
+        };
+        if let Some((_, _, _, pipeline)) =
+            self.pipelines
+                .iter()
+                .find(|(candidate, format, sampled, _)| {
+                    *candidate == id && *format == target_format && *sampled == sample_format
+                })
+        {
+            return Ok(Arc::clone(pipeline));
+        }
+        let pipeline = Arc::new(create_pipeline(
+            self.context.device.raw_device(),
+            &descriptor,
+            target_format,
+            sample_format,
+        )?);
+        self.pipelines
+            .push((id, target_format, sample_format, Arc::clone(&pipeline)));
+        Ok(pipeline)
+    }
+
+    fn pipeline_for_id(
+        &mut self,
+        id: RenderPipelineId,
+        target_format: raw::TextureFormat,
+        sample_format: Option<TextureFormat>,
+    ) -> Result<Arc<GpuPipeline>> {
+        self.pipeline(id, target_format, sample_format)
+    }
+
+    fn clear_pipeline(
+        &mut self,
+        target_format: raw::TextureFormat,
+        has_depth: bool,
+    ) -> Arc<GpuClearPipeline> {
+        if let Some((_, _, pipeline)) = self
+            .clear_pipelines
+            .iter()
+            .find(|(format, depth, _)| *format == target_format && *depth == has_depth)
+        {
+            return Arc::clone(pipeline);
+        }
+        let pipeline = Arc::new(create_clear_pipeline(
+            self.context.device.raw_device(),
+            target_format,
+            has_depth,
+        ));
+        self.clear_pipelines
+            .push((target_format, has_depth, Arc::clone(&pipeline)));
+        pipeline
+    }
+}
+
+/// Queue that lowers and submits validated SGFX IR through WGPU.
+#[derive(Clone)]
+pub struct Queue {
+    context: Context,
+}
+
+impl Queue {
+    /// Submit one validated SGFX command buffer.
+    ///
+    /// Upload commands are expected before the first texture copy or render
+    /// pass. The command buffer is translated into one WGPU submission, and
+    /// this method returns after it has been queued; WGPU GPU completion
+    /// remains asynchronous.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Persistent resource cache created by this queue's context.
+    /// * `commands` - Finished command buffer using the same resource table.
+    ///
+    /// # Returns
+    ///
+    /// Success after queue submission, or a translation/backend error.
+    pub fn submit<'r, 'data>(
+        &self,
+        resources: &mut Resources,
+        commands: &CommandBuffer<'r, 'data>,
+    ) -> Result<()> {
+        if !Arc::ptr_eq(
+            &self.context.device.identity,
+            &resources.context.device.identity,
+        ) {
+            return Err(Error::InvalidState);
+        }
+        if !core::ptr::eq(resources.resources.as_ref(), commands.resources()) {
+            return Err(Error::ResourceTableMismatch);
+        }
+        let mut encoder = self.context.device.raw_device().create_command_encoder(
+            &raw::CommandEncoderDescriptor {
+                label: Some("sgfx wgpu command encoder"),
+            },
+        );
+        let mut buffer_writes = Vec::new();
+        let mut texture_writes = Vec::new();
+        let mut upload_phase = true;
+        let mut index = 0;
+        while index < commands.commands().len() {
+            match commands.commands().get(index).ok_or(Error::InvalidState)? {
+                Command::WriteBuffer {
+                    buffer,
+                    offset,
+                    data,
+                } => {
+                    if !upload_phase {
+                        return Err(Error::Unsupported(UnsupportedFeature::LateUpload));
+                    }
+                    let buffer = resources.buffer(*buffer)?;
+                    buffer_writes.push((buffer, *offset, *data));
+                }
+                Command::WriteTexture { texture, write } => {
+                    if !upload_phase {
+                        return Err(Error::Unsupported(UnsupportedFeature::LateUpload));
+                    }
+                    let texture_resource = resources.texture(*texture)?;
+                    texture_writes.push((
+                        texture_resource,
+                        write.destination(),
+                        write.bytes_per_row(),
+                        write.data(),
+                    ));
+                }
+                Command::CopyTextureToTexture {
+                    source,
+                    source_rect,
+                    destination,
+                    destination_rect,
+                } => {
+                    upload_phase = false;
+                    let source = resources.texture(*source)?;
+                    let destination = resources.texture(*destination)?;
+                    encoder.copy_texture_to_texture(
+                        raw::TexelCopyTextureInfo {
+                            texture: &source.texture,
+                            mip_level: 0,
+                            origin: raw::Origin3d {
+                                x: source_rect.x(),
+                                y: source_rect.y(),
+                                z: 0,
+                            },
+                            aspect: raw::TextureAspect::All,
+                        },
+                        raw::TexelCopyTextureInfo {
+                            texture: &destination.texture,
+                            mip_level: 0,
+                            origin: raw::Origin3d {
+                                x: destination_rect.x(),
+                                y: destination_rect.y(),
+                                z: 0,
+                            },
+                            aspect: raw::TextureAspect::All,
+                        },
+                        raw::Extent3d {
+                            width: source_rect.width(),
+                            height: source_rect.height(),
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                }
+                Command::BeginRenderPass(desc) => {
+                    upload_phase = false;
+                    let end = commands.commands()[index + 1..]
+                        .iter()
+                        .position(|command| matches!(command, Command::EndRenderPass))
+                        .map(|relative| index + 1 + relative)
+                        .ok_or(Error::InvalidState)?;
+                    self.encode_render_pass(
+                        resources,
+                        &mut encoder,
+                        *desc,
+                        &commands.commands()[index + 1..end],
+                    )?;
+                    index = end;
+                }
+                Command::EndRenderPass => return Err(Error::InvalidState),
+                _ => return Err(Error::InvalidState),
+            }
+            index += 1;
+        }
+        for (buffer, offset, data) in buffer_writes {
+            self.context
+                .device
+                .raw_queue()
+                .write_buffer(&buffer.buffer, offset, data);
+        }
+        for (texture, destination, bytes_per_row, data) in texture_writes {
+            self.context.device.raw_queue().write_texture(
+                raw::TexelCopyTextureInfo {
+                    texture: &texture.texture,
+                    mip_level: 0,
+                    origin: raw::Origin3d {
+                        x: destination.x(),
+                        y: destination.y(),
+                        z: 0,
+                    },
+                    aspect: raw::TextureAspect::All,
+                },
+                data,
+                raw::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(bytes_per_row),
+                    rows_per_image: Some(destination.height()),
+                },
+                raw::Extent3d {
+                    width: destination.width(),
+                    height: destination.height(),
+                    depth_or_array_layers: 1,
+                },
+            );
+        }
+        self.context
+            .device
+            .raw_queue()
+            .submit(core::iter::once(encoder.finish()));
+        Ok(())
+    }
+
+    fn encode_render_pass<'r, 'data>(
+        &self,
+        resources: &mut Resources,
+        encoder: &mut raw::CommandEncoder,
+        desc: RenderPassDesc<'r>,
+        commands: &[Command<'r, 'data>],
+    ) -> Result<()> {
+        let target = resources.texture(desc.target())?;
+        let depth = desc
+            .depth_attachment()
+            .map(|attachment| resources.texture(attachment.target()))
+            .transpose()?;
+        let full_area = render_area_is_full(desc.area(), target.width, target.height);
+        let partial_clear_color = if full_area {
+            None
+        } else {
+            match desc.load() {
+                LoadOp::Clear(color) => Some(color),
+                LoadOp::Load | LoadOp::DontCare => None,
+            }
+        };
+        let color_load = if full_area {
+            color_load_op(desc.load())
+        } else {
+            raw::LoadOp::Load
+        };
+        let color_attachment = raw::RenderPassColorAttachment {
+            view: &target.view,
+            resolve_target: None,
+            ops: raw::Operations {
+                load: color_load,
+                store: store_op(desc.store()),
+            },
+        };
+        let color_attachments = [Some(color_attachment)];
+        let depth_load = desc.depth_attachment().map(|attachment| attachment.load());
+        let depth_store = desc.depth_attachment().map(|attachment| attachment.store());
+        let depth_ops = match (depth_load, depth_store) {
+            (Some(load), Some(store)) => {
+                let load = if full_area {
+                    depth_load_op(load)
+                } else {
+                    match load {
+                        DepthLoadOp::Clear(_) => {
+                            return Err(Error::Unsupported(UnsupportedFeature::PartialDepthClear));
+                        }
+                        DepthLoadOp::Load | DepthLoadOp::DontCare => raw::LoadOp::Load,
+                    }
+                };
+                Some(raw::Operations {
+                    load,
+                    store: store_op(store),
+                })
+            }
+            (None, None) => None,
+            _ => return Err(Error::InvalidState),
+        };
+        let clear_pipeline =
+            partial_clear_color.map(|_| resources.clear_pipeline(target.format, depth.is_some()));
+        let depth_attachment = depth
+            .as_ref()
+            .map(|depth| raw::RenderPassDepthStencilAttachment {
+                view: &depth.view,
+                depth_ops,
+                stencil_ops: None,
+            });
+        let mut render_pass = encoder.begin_render_pass(&raw::RenderPassDescriptor {
+            label: Some("sgfx wgpu render pass"),
+            color_attachments: &color_attachments,
+            depth_stencil_attachment: depth_attachment,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        render_pass.set_scissor_rect(
+            desc.area().x(),
+            desc.area().y(),
+            desc.area().width(),
+            desc.area().height(),
+        );
+        if let (Some(color), Some(pipeline)) = (partial_clear_color, clear_pipeline.as_ref()) {
+            self.encode_color_clear(&mut render_pass, pipeline, color);
+        }
+        let mut state = PassState {
+            pipeline: None,
+            pipeline_id: None,
+            vertex_buffer: None,
+            index_buffer: None,
+            texture: None,
+            sampler: None,
+            uniforms: None,
+            has_depth_attachment: depth.is_some(),
+        };
+        for command in commands {
+            match command {
+                Command::SetPipeline(pipeline) => {
+                    let sample_format =
+                        state.texture.as_ref().map(|texture| texture.logical_format);
+                    state.pipeline_id = Some(pipeline.id());
+                    state.pipeline =
+                        Some(resources.pipeline(pipeline.id(), target.format, sample_format)?);
+                    let pipeline = state.pipeline.as_ref().ok_or(Error::InvalidState)?;
+                    if pipeline.has_depth != state.has_depth_attachment {
+                        return Err(Error::InvalidState);
+                    }
+                    render_pass.set_pipeline(&pipeline.pipeline);
+                }
+                Command::SetVertexBuffer { buffer, offset } => {
+                    state.vertex_buffer = Some((resources.buffer(*buffer)?, *offset));
+                }
+                Command::SetIndexBuffer {
+                    buffer,
+                    offset,
+                    format,
+                } => {
+                    state.index_buffer = Some((resources.buffer(*buffer)?, *offset, *format));
+                }
+                Command::SetTexture(texture) => {
+                    let texture = resources.texture(*texture)?;
+                    state.texture = Some(Arc::clone(&texture));
+                    if state
+                        .pipeline
+                        .as_ref()
+                        .is_some_and(|pipeline| pipeline.requires_texture)
+                    {
+                        let pipeline_id = state.pipeline_id.ok_or(Error::InvalidState)?;
+                        let pipeline = resources.pipeline_for_id(
+                            pipeline_id,
+                            target.format,
+                            Some(texture.logical_format),
+                        )?;
+                        if pipeline.has_depth != state.has_depth_attachment {
+                            return Err(Error::InvalidState);
+                        }
+                        state.pipeline = Some(pipeline);
+                        let pipeline = state.pipeline.as_ref().ok_or(Error::InvalidState)?;
+                        render_pass.set_pipeline(&pipeline.pipeline);
+                    }
+                }
+                Command::SetSampler(sampler) => {
+                    state.sampler = Some(resources.sampler(*sampler)?);
+                }
+                Command::SetUniforms(uniforms) => state.uniforms = Some(*uniforms),
+                Command::SetScissor(scissor) => {
+                    let rectangle = scissor.unwrap_or(desc.area());
+                    render_pass.set_scissor_rect(
+                        rectangle.x(),
+                        rectangle.y(),
+                        rectangle.width(),
+                        rectangle.height(),
+                    );
+                }
+                Command::Draw {
+                    vertex_count,
+                    first_vertex,
+                } => {
+                    self.encode_draw(&mut render_pass, &state, *vertex_count, *first_vertex)?;
+                }
+                Command::DrawIndexed {
+                    index_count,
+                    first_index,
+                    base_vertex,
+                } => {
+                    self.encode_indexed_draw(
+                        &mut render_pass,
+                        &state,
+                        *index_count,
+                        *first_index,
+                        *base_vertex,
+                    )?;
+                }
+                Command::BeginRenderPass(_)
+                | Command::EndRenderPass
+                | Command::WriteBuffer { .. }
+                | Command::WriteTexture { .. }
+                | Command::CopyTextureToTexture { .. } => return Err(Error::InvalidState),
+            }
+        }
+        Ok(())
+    }
+
+    fn encode_color_clear(
+        &self,
+        render_pass: &mut raw::RenderPass<'_>,
+        pipeline: &GpuClearPipeline,
+        color: ir::Color,
+    ) {
+        let uniform_buffer =
+            self.context
+                .device
+                .raw_device()
+                .create_buffer(&raw::BufferDescriptor {
+                    label: Some("sgfx wgpu partial clear uniforms"),
+                    size: core::mem::size_of::<ClearUniforms>() as u64,
+                    usage: raw::BufferUsages::UNIFORM | raw::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                });
+        let uniforms = ClearUniforms {
+            color: color.components(),
+        };
+        self.context.device.raw_queue().write_buffer(
+            &uniform_buffer,
+            0,
+            bytemuck::bytes_of(&uniforms),
+        );
+        let bind_group =
+            self.context
+                .device
+                .raw_device()
+                .create_bind_group(&raw::BindGroupDescriptor {
+                    label: Some("sgfx wgpu partial clear bind group"),
+                    layout: &pipeline.bind_group_layout,
+                    entries: &[raw::BindGroupEntry {
+                        binding: 0,
+                        resource: raw::BindingResource::Buffer(raw::BufferBinding {
+                            buffer: &uniform_buffer,
+                            offset: 0,
+                            size: None,
+                        }),
+                    }],
+                });
+        render_pass.set_pipeline(&pipeline.pipeline);
+        render_pass.set_bind_group(0, &bind_group, &[]);
+        render_pass.draw(0..3, 0..1);
+    }
+
+    fn encode_draw(
+        &self,
+        render_pass: &mut raw::RenderPass<'_>,
+        state: &PassState,
+        vertex_count: u32,
+        first_vertex: u32,
+    ) -> Result<()> {
+        let pipeline = state.pipeline.as_ref().ok_or(Error::InvalidState)?;
+        let (vertex_buffer, offset) = state.vertex_buffer.as_ref().ok_or(Error::InvalidState)?;
+        let uniforms = state.uniforms.ok_or(Error::InvalidState)?;
+        let bind_group = self.create_bind_group(pipeline, uniforms, state)?;
+        render_pass.set_bind_group(0, &bind_group, &[]);
+        render_pass.set_vertex_buffer(0, vertex_buffer.buffer.slice(*offset..));
+        render_pass.draw(first_vertex..first_vertex + vertex_count, 0..1);
+        Ok(())
+    }
+
+    fn encode_indexed_draw(
+        &self,
+        render_pass: &mut raw::RenderPass<'_>,
+        state: &PassState,
+        index_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+    ) -> Result<()> {
+        let pipeline = state.pipeline.as_ref().ok_or(Error::InvalidState)?;
+        let (vertex_buffer, vertex_offset) =
+            state.vertex_buffer.as_ref().ok_or(Error::InvalidState)?;
+        let (index_buffer, index_offset, index_kind) =
+            state.index_buffer.as_ref().ok_or(Error::InvalidState)?;
+        let uniforms = state.uniforms.ok_or(Error::InvalidState)?;
+        let bind_group = self.create_bind_group(pipeline, uniforms, state)?;
+        render_pass.set_bind_group(0, &bind_group, &[]);
+        render_pass.set_vertex_buffer(0, vertex_buffer.buffer.slice(*vertex_offset..));
+        render_pass.set_index_buffer(
+            index_buffer.buffer.slice(*index_offset..),
+            index_format(*index_kind),
+        );
+        render_pass.draw_indexed(first_index..first_index + index_count, base_vertex, 0..1);
+        Ok(())
+    }
+
+    fn create_bind_group(
+        &self,
+        pipeline: &GpuPipeline,
+        uniforms: DrawUniforms,
+        state: &PassState,
+    ) -> Result<raw::BindGroup> {
+        let sampled = if pipeline.requires_texture {
+            let texture = state.texture.as_ref().ok_or(Error::InvalidState)?;
+            let sampler = state.sampler.as_ref().ok_or(Error::InvalidState)?;
+            if texture.logical_format == TextureFormat::R8Unorm
+                && pipeline.sample_mode != Some(TextureSampleMode::AlphaMask)
+            {
+                return Err(Error::Unsupported(UnsupportedFeature::TextureFormat));
+            }
+            Some((texture, sampler))
+        } else {
+            None
+        };
+        let uniform_buffer =
+            self.context
+                .device
+                .raw_device()
+                .create_buffer(&raw::BufferDescriptor {
+                    label: Some("sgfx wgpu draw uniforms"),
+                    size: core::mem::size_of::<Uniforms>() as u64,
+                    usage: raw::BufferUsages::UNIFORM | raw::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                });
+        let bytes = Uniforms::from(uniforms);
+        self.context.device.raw_queue().write_buffer(
+            &uniform_buffer,
+            0,
+            bytemuck::bytes_of(&bytes),
+        );
+        let mut entries = Vec::with_capacity(if pipeline.requires_texture { 3 } else { 1 });
+        entries.push(raw::BindGroupEntry {
+            binding: 0,
+            resource: raw::BindingResource::Buffer(raw::BufferBinding {
+                buffer: &uniform_buffer,
+                offset: 0,
+                size: None,
+            }),
+        });
+        if let Some((texture, sampler)) = sampled {
+            entries.push(raw::BindGroupEntry {
+                binding: 1,
+                resource: raw::BindingResource::TextureView(&texture.view),
+            });
+            entries.push(raw::BindGroupEntry {
+                binding: 2,
+                resource: raw::BindingResource::Sampler(sampler.as_ref()),
+            });
+        }
+        Ok(self
+            .context
+            .device
+            .raw_device()
+            .create_bind_group(&raw::BindGroupDescriptor {
+                label: Some("sgfx wgpu draw bind group"),
+                layout: &pipeline.bind_group_layout,
+                entries: &entries,
+            }))
+    }
+}
+
+struct PassState {
+    pipeline: Option<Arc<GpuPipeline>>,
+    pipeline_id: Option<RenderPipelineId>,
+    vertex_buffer: Option<(Arc<GpuBuffer>, u64)>,
+    index_buffer: Option<(Arc<GpuBuffer>, u64, IndexFormat)>,
+    texture: Option<Arc<GpuTexture>>,
+    sampler: Option<Arc<raw::Sampler>>,
+    uniforms: Option<DrawUniforms>,
+    has_depth_attachment: bool,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct Uniforms {
+    transform: [[f32; 4]; 4],
+    color: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct ClearUniforms {
+    color: [f32; 4],
+}
+
+impl From<DrawUniforms> for Uniforms {
+    fn from(uniforms: DrawUniforms) -> Self {
+        let columns = uniforms.transform().columns();
+        Self {
+            transform: [
+                [columns[0], columns[1], columns[2], columns[3]],
+                [columns[4], columns[5], columns[6], columns[7]],
+                [columns[8], columns[9], columns[10], columns[11]],
+                [columns[12], columns[13], columns[14], columns[15]],
+            ],
+            color: uniforms.color().components(),
+        }
+    }
+}
+
+struct GpuTexture {
+    texture: raw::Texture,
+    view: raw::TextureView,
+    format: raw::TextureFormat,
+    logical_format: TextureFormat,
+    width: u32,
+    height: u32,
+}
+
+struct GpuBuffer {
+    buffer: raw::Buffer,
+}
+
+struct GpuPipeline {
+    pipeline: raw::RenderPipeline,
+    bind_group_layout: raw::BindGroupLayout,
+    requires_texture: bool,
+    has_depth: bool,
+    sample_mode: Option<TextureSampleMode>,
+}
+
+struct GpuClearPipeline {
+    pipeline: raw::RenderPipeline,
+    bind_group_layout: raw::BindGroupLayout,
+}
+
+fn create_gpu_texture(
+    device: &raw::Device,
+    width: u32,
+    height: u32,
+    format: TextureFormat,
+    usage: raw::TextureUsages,
+) -> Result<Arc<GpuTexture>> {
+    let raw_format =
+        raw_format(format).ok_or(Error::Unsupported(UnsupportedFeature::SurfaceFormat))?;
+    let texture = device.create_texture(&raw::TextureDescriptor {
+        label: Some("sgfx wgpu texture"),
+        size: raw::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: raw::TextureDimension::D2,
+        format: raw_format,
+        usage,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&raw::TextureViewDescriptor::default());
+    Ok(Arc::new(GpuTexture {
+        texture,
+        view,
+        format: raw_format,
+        logical_format: format,
+        width,
+        height,
+    }))
+}
+
+fn texture_usage(descriptor: TextureDesc) -> Result<raw::TextureUsages> {
+    let mut usage = raw::TextureUsages::empty();
+    if descriptor.usage().contains(TextureUsage::SAMPLED) {
+        usage |= raw::TextureUsages::TEXTURE_BINDING;
+    }
+    if descriptor.usage().contains(TextureUsage::RENDER_ATTACHMENT) {
+        usage |= raw::TextureUsages::RENDER_ATTACHMENT;
+    }
+    if descriptor.usage().contains(TextureUsage::COPY_SRC) {
+        usage |= raw::TextureUsages::COPY_SRC;
+    }
+    if descriptor.usage().contains(TextureUsage::COPY_DST) {
+        usage |= raw::TextureUsages::COPY_DST;
+    }
+    if usage.is_empty() {
+        Err(Error::InvalidState)
+    } else {
+        Ok(usage)
+    }
+}
+
+fn raw_format(format: TextureFormat) -> Option<raw::TextureFormat> {
+    match format {
+        TextureFormat::Bgra8Unorm => Some(raw::TextureFormat::Bgra8Unorm),
+        TextureFormat::Rgba8Unorm => Some(raw::TextureFormat::Rgba8Unorm),
+        TextureFormat::R8Unorm => Some(raw::TextureFormat::R8Unorm),
+        TextureFormat::Depth32Float => Some(raw::TextureFormat::Depth32Float),
+    }
+}
+
+fn logical_format(format: raw::TextureFormat) -> Option<TextureFormat> {
+    match format {
+        raw::TextureFormat::Bgra8Unorm | raw::TextureFormat::Bgra8UnormSrgb => {
+            Some(TextureFormat::Bgra8Unorm)
+        }
+        raw::TextureFormat::Rgba8Unorm | raw::TextureFormat::Rgba8UnormSrgb => {
+            Some(TextureFormat::Rgba8Unorm)
+        }
+        _ => None,
+    }
+}
+
+fn filter_mode(filter: FilterMode) -> raw::FilterMode {
+    match filter {
+        FilterMode::Nearest => raw::FilterMode::Nearest,
+        FilterMode::Linear => raw::FilterMode::Linear,
+    }
+}
+
+fn address_mode(address: AddressMode) -> raw::AddressMode {
+    match address {
+        AddressMode::ClampToEdge => raw::AddressMode::ClampToEdge,
+        AddressMode::Repeat => raw::AddressMode::Repeat,
+        AddressMode::MirrorRepeat => raw::AddressMode::MirrorRepeat,
+    }
+}
+
+fn index_format(format: IndexFormat) -> raw::IndexFormat {
+    match format {
+        IndexFormat::Uint16 => raw::IndexFormat::Uint16,
+        IndexFormat::Uint32 => raw::IndexFormat::Uint32,
+    }
+}
+
+fn color_load_op(load: LoadOp) -> raw::LoadOp<raw::Color> {
+    match load {
+        LoadOp::Load => raw::LoadOp::Load,
+        LoadOp::Clear(color) => {
+            let [r, g, b, a] = color.components();
+            raw::LoadOp::Clear(raw::Color {
+                r: f64::from(r),
+                g: f64::from(g),
+                b: f64::from(b),
+                a: f64::from(a),
+            })
+        }
+        LoadOp::DontCare => raw::LoadOp::Clear(raw::Color::TRANSPARENT),
+    }
+}
+
+fn depth_load_op(load: DepthLoadOp) -> raw::LoadOp<f32> {
+    match load {
+        DepthLoadOp::Load => raw::LoadOp::Load,
+        DepthLoadOp::Clear(value) => raw::LoadOp::Clear(value),
+        DepthLoadOp::DontCare => raw::LoadOp::Clear(1.0),
+    }
+}
+
+fn store_op(store: StoreOp) -> raw::StoreOp {
+    match store {
+        StoreOp::Store => raw::StoreOp::Store,
+        StoreOp::DontCare => raw::StoreOp::Discard,
+    }
+}
+
+fn render_area_is_full(area: ir::PixelRect, width: u32, height: u32) -> bool {
+    area.x() == 0 && area.y() == 0 && area.width() == width && area.height() == height
+}
+
+fn create_clear_pipeline(
+    device: &raw::Device,
+    target_format: raw::TextureFormat,
+    has_depth: bool,
+) -> GpuClearPipeline {
+    let shader = device.create_shader_module(raw::ShaderModuleDescriptor {
+        label: Some("sgfx wgpu partial clear shader"),
+        source: raw::ShaderSource::Wgsl(Cow::Borrowed(PARTIAL_CLEAR_SHADER)),
+    });
+    let bind_group_layout = device.create_bind_group_layout(&raw::BindGroupLayoutDescriptor {
+        label: Some("sgfx wgpu partial clear bind group layout"),
+        entries: &[raw::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: raw::ShaderStages::FRAGMENT,
+            ty: raw::BindingType::Buffer {
+                ty: raw::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }],
+    });
+    let pipeline_layout = device.create_pipeline_layout(&raw::PipelineLayoutDescriptor {
+        label: Some("sgfx wgpu partial clear pipeline layout"),
+        bind_group_layouts: &[&bind_group_layout],
+        push_constant_ranges: &[],
+    });
+    let depth_stencil = has_depth.then_some(raw::DepthStencilState {
+        format: raw::TextureFormat::Depth32Float,
+        depth_write_enabled: false,
+        depth_compare: raw::CompareFunction::Always,
+        stencil: raw::StencilState::default(),
+        bias: raw::DepthBiasState::default(),
+    });
+    let pipeline = device.create_render_pipeline(&raw::RenderPipelineDescriptor {
+        label: Some("sgfx wgpu partial clear pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: raw::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            compilation_options: raw::PipelineCompilationOptions::default(),
+            buffers: &[],
+        },
+        primitive: raw::PrimitiveState::default(),
+        depth_stencil,
+        multisample: raw::MultisampleState::default(),
+        fragment: Some(raw::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            compilation_options: raw::PipelineCompilationOptions::default(),
+            targets: &[Some(raw::ColorTargetState {
+                format: target_format,
+                blend: None,
+                write_mask: raw::ColorWrites::ALL,
+            })],
+        }),
+        multiview: None,
+        cache: None,
+    });
+    GpuClearPipeline {
+        pipeline,
+        bind_group_layout,
+    }
+}
+
+const PARTIAL_CLEAR_SHADER: &str = r#"
+struct ClearUniforms {
+    color: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> clear_uniforms: ClearUniforms;
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 3.0, -1.0),
+        vec2<f32>(-1.0,  3.0),
+    );
+    return vec4<f32>(positions[vertex_index], 0.0, 1.0);
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return clear_uniforms.color;
+}
+"#;
+
+fn create_pipeline(
+    device: &raw::Device,
+    descriptor: &RenderPipelineDesc,
+    target_format: raw::TextureFormat,
+    sample_format: Option<TextureFormat>,
+) -> Result<GpuPipeline> {
+    if descriptor.target_format() == TextureFormat::Depth32Float
+        || descriptor.topology() != ir::PrimitiveTopology::TriangleList
+    {
+        return Err(Error::Unsupported(UnsupportedFeature::Pipeline));
+    }
+    let requires_texture = matches!(
+        descriptor.fragment(),
+        FragmentProgram::Texture(_) | FragmentProgram::TextureVertexColor(_)
+    );
+    let sample_mode = match descriptor.fragment() {
+        FragmentProgram::Texture(mode) | FragmentProgram::TextureVertexColor(mode) => Some(mode),
+        FragmentProgram::Solid | FragmentProgram::VertexColor => None,
+    };
+    let sample_format = requires_texture.then_some(sample_format).flatten();
+    let shader_source = shader_source(descriptor, sample_format)?;
+    let shader = device.create_shader_module(raw::ShaderModuleDescriptor {
+        label: Some("sgfx wgpu generated shader"),
+        source: raw::ShaderSource::Wgsl(Cow::Owned(shader_source)),
+    });
+    let bind_group_layout = device.create_bind_group_layout(&raw::BindGroupLayoutDescriptor {
+        label: Some("sgfx wgpu pipeline bind group layout"),
+        entries: &bind_group_entries(requires_texture),
+    });
+    let pipeline_layout = device.create_pipeline_layout(&raw::PipelineLayoutDescriptor {
+        label: Some("sgfx wgpu pipeline layout"),
+        bind_group_layouts: &[&bind_group_layout],
+        push_constant_ranges: &[],
+    });
+    let attributes = descriptor
+        .vertex_buffer()
+        .attributes()
+        .iter()
+        .map(raw_vertex_attribute)
+        .collect::<Vec<_>>();
+    let vertex_layout = raw::VertexBufferLayout {
+        array_stride: u64::from(descriptor.vertex_buffer().stride()),
+        step_mode: raw::VertexStepMode::Vertex,
+        attributes: &attributes,
+    };
+    let color_target = raw::ColorTargetState {
+        format: target_format,
+        blend: Some(raw::BlendState {
+            color: blend_component(descriptor.blend().color()),
+            alpha: blend_component(descriptor.blend().alpha()),
+        }),
+        write_mask: raw::ColorWrites::ALL,
+    };
+    let depth_stencil = descriptor
+        .depth_state()
+        .map(|depth| raw::DepthStencilState {
+            format: raw::TextureFormat::Depth32Float,
+            depth_write_enabled: depth.write_enabled(),
+            depth_compare: compare_function(depth.compare()),
+            stencil: raw::StencilState::default(),
+            bias: raw::DepthBiasState::default(),
+        });
+    let pipeline = device.create_render_pipeline(&raw::RenderPipelineDescriptor {
+        label: Some("sgfx wgpu render pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: raw::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            compilation_options: raw::PipelineCompilationOptions::default(),
+            buffers: &[vertex_layout],
+        },
+        primitive: raw::PrimitiveState {
+            topology: raw::PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: match descriptor.raster().front_face() {
+                ir::FrontFace::Clockwise => raw::FrontFace::Cw,
+                ir::FrontFace::CounterClockwise => raw::FrontFace::Ccw,
+            },
+            cull_mode: match descriptor.raster().cull_mode() {
+                ir::CullMode::None => None,
+                ir::CullMode::Front => Some(raw::Face::Front),
+                ir::CullMode::Back => Some(raw::Face::Back),
+            },
+            unclipped_depth: false,
+            polygon_mode: raw::PolygonMode::Fill,
+            conservative: false,
+        },
+        depth_stencil,
+        multisample: raw::MultisampleState::default(),
+        fragment: Some(raw::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            compilation_options: raw::PipelineCompilationOptions::default(),
+            targets: &[Some(color_target)],
+        }),
+        multiview: None,
+        cache: None,
+    });
+    Ok(GpuPipeline {
+        pipeline,
+        bind_group_layout,
+        requires_texture,
+        has_depth: descriptor.depth_state().is_some(),
+        sample_mode,
+    })
+}
+
+fn bind_group_entries(texture: bool) -> Vec<raw::BindGroupLayoutEntry> {
+    let mut entries = vec![raw::BindGroupLayoutEntry {
+        binding: 0,
+        visibility: raw::ShaderStages::VERTEX | raw::ShaderStages::FRAGMENT,
+        ty: raw::BindingType::Buffer {
+            ty: raw::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }];
+    if texture {
+        entries.push(raw::BindGroupLayoutEntry {
+            binding: 1,
+            visibility: raw::ShaderStages::FRAGMENT,
+            ty: raw::BindingType::Texture {
+                sample_type: raw::TextureSampleType::Float { filterable: true },
+                view_dimension: raw::TextureViewDimension::D2,
+                multisampled: false,
+            },
+            count: None,
+        });
+        entries.push(raw::BindGroupLayoutEntry {
+            binding: 2,
+            visibility: raw::ShaderStages::FRAGMENT,
+            ty: raw::BindingType::Sampler(raw::SamplerBindingType::Filtering),
+            count: None,
+        });
+    }
+    entries
+}
+
+fn raw_vertex_attribute(attribute: &VertexAttribute) -> raw::VertexAttribute {
+    raw::VertexAttribute {
+        format: match attribute.format() {
+            VertexFormat::Float32x2 => raw::VertexFormat::Float32x2,
+            VertexFormat::Float32x3 => raw::VertexFormat::Float32x3,
+            VertexFormat::Float32x4 => raw::VertexFormat::Float32x4,
+            VertexFormat::Unorm8x4 => raw::VertexFormat::Unorm8x4,
+        },
+        offset: u64::from(attribute.offset()),
+        shader_location: attribute.location(),
+    }
+}
+
+fn blend_component(component: BlendComponent) -> raw::BlendComponent {
+    raw::BlendComponent {
+        src_factor: blend_factor(component.source_factor()),
+        dst_factor: blend_factor(component.destination_factor()),
+        operation: blend_operation(component.operation()),
+    }
+}
+
+fn blend_factor(factor: BlendFactor) -> raw::BlendFactor {
+    match factor {
+        BlendFactor::Zero => raw::BlendFactor::Zero,
+        BlendFactor::One => raw::BlendFactor::One,
+        BlendFactor::SourceAlpha => raw::BlendFactor::SrcAlpha,
+        BlendFactor::OneMinusSourceAlpha => raw::BlendFactor::OneMinusSrcAlpha,
+        BlendFactor::DestinationAlpha => raw::BlendFactor::DstAlpha,
+        BlendFactor::OneMinusDestinationAlpha => raw::BlendFactor::OneMinusDstAlpha,
+    }
+}
+
+fn blend_operation(operation: BlendOp) -> raw::BlendOperation {
+    match operation {
+        BlendOp::Add => raw::BlendOperation::Add,
+        BlendOp::Subtract => raw::BlendOperation::Subtract,
+        BlendOp::ReverseSubtract => raw::BlendOperation::ReverseSubtract,
+    }
+}
+
+fn compare_function(compare: CompareFunction) -> raw::CompareFunction {
+    match compare {
+        CompareFunction::Never => raw::CompareFunction::Never,
+        CompareFunction::Less => raw::CompareFunction::Less,
+        CompareFunction::Equal => raw::CompareFunction::Equal,
+        CompareFunction::LessEqual => raw::CompareFunction::LessEqual,
+        CompareFunction::Greater => raw::CompareFunction::Greater,
+        CompareFunction::NotEqual => raw::CompareFunction::NotEqual,
+        CompareFunction::GreaterEqual => raw::CompareFunction::GreaterEqual,
+        CompareFunction::Always => raw::CompareFunction::Always,
+    }
+}
+
+fn shader_source(
+    descriptor: &RenderPipelineDesc,
+    sample_format: Option<TextureFormat>,
+) -> Result<String> {
+    let attributes = descriptor.vertex_buffer().attributes();
+    let position =
+        find_attribute(attributes, 0).ok_or(Error::Unsupported(UnsupportedFeature::Pipeline))?;
+    let needs_color = matches!(
+        descriptor.fragment(),
+        FragmentProgram::VertexColor | FragmentProgram::TextureVertexColor(_)
+    );
+    let needs_texture = matches!(
+        descriptor.fragment(),
+        FragmentProgram::Texture(_) | FragmentProgram::TextureVertexColor(_)
+    );
+    let color = needs_color.then(|| find_attribute(attributes, 1));
+    let uv_location = if matches!(
+        descriptor.fragment(),
+        FragmentProgram::TextureVertexColor(_)
+    ) {
+        2
+    } else {
+        1
+    };
+    let uv = needs_texture.then(|| find_attribute(attributes, uv_location));
+    if (needs_color && color.flatten().is_none()) || (needs_texture && uv.flatten().is_none()) {
+        return Err(Error::Unsupported(UnsupportedFeature::Pipeline));
+    }
+    let mut source = String::new();
+    source.push_str(
+        "struct Uniforms { transform: mat4x4<f32>, color: vec4<f32>, };\n\
+         @group(0) @binding(0) var<uniform> uniforms: Uniforms;\n",
+    );
+    if needs_texture {
+        source.push_str(
+            "@group(0) @binding(1) var sampled_texture: texture_2d<f32>;\n\
+             @group(0) @binding(2) var texture_sampler: sampler;\n",
+        );
+    }
+    source.push_str("struct VertexInput {\n");
+    for attribute in attributes {
+        source.push_str(&format!(
+            "  @location({}) attr{}: {},\n",
+            attribute.location(),
+            attribute.location(),
+            wgsl_vertex_type(attribute.format()),
+        ));
+    }
+    source.push_str("};\nstruct VertexOutput {\n  @builtin(position) position: vec4<f32>,\n  @location(0) color: vec4<f32>,\n  @location(1) uv: vec2<f32>,\n};\n");
+    source.push_str(
+        "@vertex fn vs_main(input: VertexInput) -> VertexOutput {\n  var output: VertexOutput;\n",
+    );
+    source.push_str(&format!(
+        "  output.position = uniforms.transform * {};\n",
+        position_expression(position),
+    ));
+    source.push_str(&format!(
+        "  output.color = {};\n",
+        color
+            .flatten()
+            .map(color_expression)
+            .unwrap_or_else(|| String::from("vec4<f32>(1.0)")),
+    ));
+    source.push_str(&format!(
+        "  output.uv = {};\n  return output;\n}}\n",
+        uv.flatten()
+            .map(|attribute| format!("input.attr{}", attribute.location()))
+            .unwrap_or_else(|| String::from("vec2<f32>(0.0)")),
+    ));
+    source.push_str("@fragment fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {\n");
+    match descriptor.fragment() {
+        FragmentProgram::Solid => source.push_str("  return uniforms.color;\n"),
+        FragmentProgram::VertexColor => source.push_str("  return input.color * uniforms.color;\n"),
+        FragmentProgram::Texture(mode) => {
+            source.push_str(
+                "  let sampled = textureSample(sampled_texture, texture_sampler, input.uv);\n",
+            );
+            source.push_str(&format!(
+                "  return {};\n",
+                texture_expression(mode, "sampled", "uniforms.color", sample_format)
+            ));
+        }
+        FragmentProgram::TextureVertexColor(mode) => {
+            source.push_str(
+                "  let sampled = textureSample(sampled_texture, texture_sampler, input.uv);\n",
+            );
+            source.push_str(&format!(
+                "  return {};\n",
+                texture_vertex_color_expression(
+                    mode,
+                    "sampled",
+                    "input.color",
+                    "uniforms.color",
+                    sample_format,
+                ),
+            ));
+        }
+    }
+    source.push_str("}\n");
+    Ok(source)
+}
+
+fn find_attribute(attributes: &[VertexAttribute], location: u32) -> Option<VertexAttribute> {
+    attributes
+        .iter()
+        .copied()
+        .find(|attribute| attribute.location() == location)
+}
+
+fn wgsl_vertex_type(format: VertexFormat) -> &'static str {
+    match format {
+        VertexFormat::Float32x2 => "vec2<f32>",
+        VertexFormat::Float32x3 => "vec3<f32>",
+        VertexFormat::Float32x4 | VertexFormat::Unorm8x4 => "vec4<f32>",
+    }
+}
+
+fn position_expression(attribute: VertexAttribute) -> String {
+    match attribute.format() {
+        VertexFormat::Float32x2 => {
+            format!("vec4<f32>(input.attr{}, 0.0, 1.0)", attribute.location())
+        }
+        VertexFormat::Float32x3 => format!("vec4<f32>(input.attr{}, 1.0)", attribute.location()),
+        VertexFormat::Float32x4 | VertexFormat::Unorm8x4 => {
+            format!("input.attr{}", attribute.location())
+        }
+    }
+}
+
+fn color_expression(attribute: VertexAttribute) -> String {
+    match attribute.format() {
+        VertexFormat::Float32x3 => format!("vec4<f32>(input.attr{}, 1.0)", attribute.location()),
+        VertexFormat::Float32x2 => {
+            format!("vec4<f32>(input.attr{}, 0.0, 1.0)", attribute.location())
+        }
+        VertexFormat::Float32x4 | VertexFormat::Unorm8x4 => {
+            format!("input.attr{}", attribute.location())
+        }
+    }
+}
+
+fn texture_expression(
+    mode: TextureSampleMode,
+    sample: &str,
+    color: &str,
+    sample_format: Option<TextureFormat>,
+) -> String {
+    match mode {
+        TextureSampleMode::Rgba => format!("{} * {}", sample, color),
+        TextureSampleMode::RgbIgnoreAlpha => format!("vec4<f32>({}.rgb, 1.0) * {}", sample, color),
+        TextureSampleMode::AlphaMask => {
+            format!(
+                "vec4<f32>({}.rgb, {} * {}.a)",
+                color,
+                sampled_alpha(sample, sample_format),
+                color
+            )
+        }
+    }
+}
+
+fn texture_vertex_color_expression(
+    mode: TextureSampleMode,
+    sample: &str,
+    vertex_color: &str,
+    color: &str,
+    sample_format: Option<TextureFormat>,
+) -> String {
+    match mode {
+        TextureSampleMode::Rgba => format!("{} * {} * {}", sample, vertex_color, color),
+        TextureSampleMode::RgbIgnoreAlpha => {
+            format!(
+                "vec4<f32>({}.rgb, 1.0) * {} * {}",
+                sample, vertex_color, color
+            )
+        }
+        TextureSampleMode::AlphaMask => format!(
+            "vec4<f32>({}.rgb * {}.rgb, {} * {}.a * {}.a)",
+            color,
+            vertex_color,
+            sampled_alpha(sample, sample_format),
+            vertex_color,
+            color
+        ),
+    }
+}
+
+fn sampled_alpha(sample: &str, sample_format: Option<TextureFormat>) -> String {
+    match sample_format {
+        Some(TextureFormat::R8Unorm) => format!("{}.r", sample),
+        _ => format!("{}.a", sample),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::rc::Rc;
+    use alloc::vec;
+
+    use super::*;
+    use crate::ir::{
+        AddressMode, BlendState, BufferDesc, Color, CommandEncoder, DrawUniforms, Extent2D,
+        FilterMode, PixelRect, PrimitiveTopology, RasterState, RenderPassDesc, SamplerDesc,
+        StoreOp, TextureWrite, Transform, VertexBufferLayout,
+    };
+
+    fn pipeline(fragment: FragmentProgram) -> RenderPipelineDesc {
+        RenderPipelineDesc::new(
+            TextureFormat::Bgra8Unorm,
+            PrimitiveTopology::TriangleList,
+            VertexBufferLayout::new(
+                40,
+                vec![
+                    VertexAttribute::new(0, VertexFormat::Float32x4, 0),
+                    VertexAttribute::new(1, VertexFormat::Float32x4, 16),
+                    VertexAttribute::new(2, VertexFormat::Float32x2, 32),
+                ],
+            )
+            .expect("valid vertex layout"),
+            fragment,
+            BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
+            RasterState::new(ir::CullMode::None, ir::FrontFace::CounterClockwise),
+        )
+        .expect("valid pipeline")
+    }
+
+    #[test]
+    fn generated_texture_vertex_color_shader_contains_both_bindings() {
+        let source = shader_source(
+            &pipeline(FragmentProgram::TextureVertexColor(TextureSampleMode::Rgba)),
+            None,
+        )
+        .expect("shader source");
+        assert!(source.contains("@binding(1) var sampled_texture"));
+        assert!(source.contains("@binding(2) var texture_sampler"));
+        assert!(source.contains("input.attr2"));
+    }
+
+    #[test]
+    fn alpha_mask_shader_reads_the_r8_channel_for_glyph_atlases() {
+        let descriptor = pipeline(FragmentProgram::TextureVertexColor(
+            TextureSampleMode::AlphaMask,
+        ));
+        let r8_source = shader_source(&descriptor, Some(TextureFormat::R8Unorm))
+            .expect("R8 alpha-mask shader source");
+        assert!(r8_source.contains("sampled.r * input.color.a"));
+
+        let rgba_source = shader_source(&descriptor, None).expect("RGBA alpha-mask shader source");
+        assert!(rgba_source.contains("sampled.a * input.color.a"));
+    }
+
+    #[test]
+    fn logical_surface_formats_accept_srgb_color_targets() {
+        assert_eq!(
+            logical_format(raw::TextureFormat::Bgra8UnormSrgb),
+            Some(TextureFormat::Bgra8Unorm)
+        );
+        assert_eq!(
+            logical_format(raw::TextureFormat::Rgba8UnormSrgb),
+            Some(TextureFormat::Rgba8Unorm)
+        );
+        assert_eq!(logical_format(raw::TextureFormat::Depth32Float), None);
+    }
+
+    #[test]
+    fn only_an_exact_target_sized_area_uses_attachment_clear() {
+        let full = PixelRect::new(0, 0, 8, 6).expect("full area");
+        let partial = PixelRect::new(1, 1, 6, 4).expect("partial area");
+        assert!(render_area_is_full(full, 8, 6));
+        assert!(!render_area_is_full(partial, 8, 6));
+    }
+
+    #[test]
+    fn headless_scissor_limits_the_drawn_pixels() {
+        let instance = raw::Instance::new(&raw::InstanceDescriptor::default());
+        let adapter = pollster::block_on(instance.request_adapter(&raw::RequestAdapterOptions {
+            power_preference: raw::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .expect("headless WGPU adapter");
+        let (raw_device, raw_queue) =
+            pollster::block_on(adapter.request_device(&raw::DeviceDescriptor::default(), None))
+                .expect("headless WGPU device");
+        let device = Device::new(raw_device, raw_queue);
+        let context = device.create_context();
+        let image = context
+            .create_image(16, 16, TextureFormat::Bgra8Unorm)
+            .expect("headless target image");
+        let resources = Rc::new(ResourceTable::new());
+        let target = resources
+            .define_texture(
+                TextureDesc::new(
+                    TextureFormat::Bgra8Unorm,
+                    Extent2D::new(16, 16).expect("target extent"),
+                    TextureUsage::RENDER_ATTACHMENT
+                        | TextureUsage::COPY_SRC
+                        | TextureUsage::PRESENT,
+                )
+                .expect("target descriptor"),
+            )
+            .expect("target resource");
+        let vertices: [[f32; 8]; 6] = [
+            [-1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [-1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [-1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+        ];
+        let vertex_buffer = resources
+            .define_buffer(
+                BufferDesc::new(
+                    core::mem::size_of_val(&vertices) as u64,
+                    BufferUsage::VERTEX | BufferUsage::COPY_DST,
+                )
+                .expect("vertex descriptor"),
+            )
+            .expect("vertex resource");
+        let pipeline = resources
+            .define_render_pipeline(
+                RenderPipelineDesc::new(
+                    TextureFormat::Bgra8Unorm,
+                    PrimitiveTopology::TriangleList,
+                    VertexBufferLayout::new(
+                        32,
+                        vec![
+                            VertexAttribute::new(0, VertexFormat::Float32x4, 0),
+                            VertexAttribute::new(1, VertexFormat::Float32x4, 16),
+                        ],
+                    )
+                    .expect("vertex layout"),
+                    FragmentProgram::VertexColor,
+                    BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
+                    RasterState::new(ir::CullMode::None, ir::FrontFace::CounterClockwise),
+                )
+                .expect("pipeline descriptor"),
+            )
+            .expect("pipeline resource");
+        let white = Color::rgba(1.0, 1.0, 1.0, 1.0).expect("clear color");
+        let mut encoder = CommandEncoder::new(resources.as_ref());
+        encoder
+            .write_buffer(vertex_buffer, 0, bytemuck::cast_slice(&vertices))
+            .expect("vertex upload");
+        let pass = RenderPassDesc::new(
+            resources.as_ref(),
+            target,
+            PixelRect::new(0, 0, 16, 16).expect("render area"),
+            LoadOp::Clear(white),
+            StoreOp::Store,
+        )
+        .expect("render pass");
+        let mut pass = encoder.begin_render_pass(pass).expect("begin pass");
+        pass.set_pipeline(pipeline).expect("set pipeline");
+        pass.set_vertex_buffer(vertex_buffer, 0)
+            .expect("set vertex buffer");
+        pass.set_uniforms(DrawUniforms::new(Transform::identity(), white))
+            .expect("set uniforms");
+        pass.set_scissor(Some(PixelRect::new(0, 0, 16, 8).expect("top-half scissor")))
+            .expect("set scissor");
+        pass.draw(6, 0).expect("draw clipped rectangle");
+        pass.end().expect("end pass");
+        let commands = encoder.finish().expect("finish commands");
+        let mut cache = context.create_resources(Rc::clone(&resources));
+        cache
+            .map_image(target.id(), Arc::clone(&image))
+            .expect("map target image");
+        context
+            .create_queue()
+            .submit(&mut cache, &commands)
+            .expect("submit clipped frame");
+
+        let bytes_per_row = 256u32;
+        let readback = device.raw_device().create_buffer(&raw::BufferDescriptor {
+            label: Some("sgfx scissor readback"),
+            size: u64::from(bytes_per_row) * 16,
+            usage: raw::BufferUsages::COPY_DST | raw::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let mut raw_encoder =
+            device
+                .raw_device()
+                .create_command_encoder(&raw::CommandEncoderDescriptor {
+                    label: Some("sgfx scissor readback encoder"),
+                });
+        raw_encoder.copy_texture_to_buffer(
+            raw::TexelCopyTextureInfo {
+                texture: image.raw_texture(),
+                mip_level: 0,
+                origin: raw::Origin3d::ZERO,
+                aspect: raw::TextureAspect::All,
+            },
+            raw::TexelCopyBufferInfo {
+                buffer: &readback,
+                layout: raw::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(bytes_per_row),
+                    rows_per_image: Some(16),
+                },
+            },
+            raw::Extent3d {
+                width: 16,
+                height: 16,
+                depth_or_array_layers: 1,
+            },
+        );
+        device
+            .raw_queue()
+            .submit(core::iter::once(raw_encoder.finish()));
+        let slice = readback.slice(..);
+        let (sender, receiver) = std::sync::mpsc::channel();
+        slice.map_async(raw::MapMode::Read, move |result| {
+            sender.send(result).expect("send map result");
+        });
+        let _ = device.raw_device().poll(raw::Maintain::Wait);
+        receiver
+            .recv()
+            .expect("receive map result")
+            .expect("map readback");
+        let bytes = slice.get_mapped_range();
+        let pixel = |x: usize, y: usize| {
+            let start = y * bytes_per_row as usize + x * 4;
+            [
+                bytes[start],
+                bytes[start + 1],
+                bytes[start + 2],
+                bytes[start + 3],
+            ]
+        };
+        assert_eq!(pixel(8, 4), [0, 0, 255, 255]);
+        assert_eq!(pixel(8, 12), [255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn headless_triangle_submission_uses_the_portable_ir() {
+        let instance = raw::Instance::new(&raw::InstanceDescriptor::default());
+        let adapter = pollster::block_on(instance.request_adapter(&raw::RequestAdapterOptions {
+            power_preference: raw::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .or_else(|| {
+            pollster::block_on(instance.request_adapter(&raw::RequestAdapterOptions {
+                power_preference: raw::PowerPreference::LowPower,
+                compatible_surface: None,
+                force_fallback_adapter: true,
+            }))
+        });
+        let Some(adapter) = adapter else {
+            #[cfg(target_os = "macos")]
+            panic!("Metal adapter must be available for the SGFX WGPU backend test");
+            #[cfg(not(target_os = "macos"))]
+            {
+                eprintln!("skipping SGFX WGPU backend test: no adapter available");
+                return;
+            }
+        };
+        eprintln!("SGFX WGPU test adapter: {:?}", adapter.get_info());
+        let (raw_device, raw_queue) = match pollster::block_on(
+            adapter.request_device(&raw::DeviceDescriptor::default(), None),
+        ) {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+        let device = Device::new(raw_device, raw_queue);
+        let context = device.create_context();
+        let image = context
+            .create_image(4, 4, TextureFormat::Bgra8Unorm)
+            .expect("headless target image");
+        let replacement = context
+            .create_image(4, 4, TextureFormat::Bgra8Unorm)
+            .expect("replacement target image");
+        let resources = Rc::new(ResourceTable::new());
+        let target = resources
+            .define_texture(
+                TextureDesc::new(
+                    TextureFormat::Bgra8Unorm,
+                    Extent2D::new(4, 4).expect("target extent"),
+                    TextureUsage::RENDER_ATTACHMENT | TextureUsage::PRESENT,
+                )
+                .expect("target descriptor"),
+            )
+            .expect("target resource");
+        let vertices: [[f32; 8]; 3] = [
+            [-0.5, -0.5, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [0.5, -0.5, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            [0.0, 0.5, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0],
+        ];
+        let vertex_buffer = resources
+            .define_buffer(
+                BufferDesc::new(
+                    core::mem::size_of_val(&vertices) as u64,
+                    BufferUsage::VERTEX | BufferUsage::COPY_DST,
+                )
+                .expect("vertex descriptor"),
+            )
+            .expect("vertex resource");
+        let layout = VertexBufferLayout::new(
+            32,
+            vec![
+                VertexAttribute::new(0, VertexFormat::Float32x4, 0),
+                VertexAttribute::new(1, VertexFormat::Float32x4, 16),
+            ],
+        )
+        .expect("vertex layout");
+        let pipeline = resources
+            .define_render_pipeline(
+                RenderPipelineDesc::new(
+                    TextureFormat::Bgra8Unorm,
+                    PrimitiveTopology::TriangleList,
+                    layout,
+                    FragmentProgram::VertexColor,
+                    BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
+                    RasterState::new(ir::CullMode::None, ir::FrontFace::CounterClockwise),
+                )
+                .expect("pipeline descriptor"),
+            )
+            .expect("pipeline resource");
+        let glyph_texture = resources
+            .define_texture(
+                TextureDesc::new(
+                    TextureFormat::R8Unorm,
+                    Extent2D::new(2, 2).expect("glyph extent"),
+                    TextureUsage::SAMPLED | TextureUsage::COPY_DST,
+                )
+                .expect("glyph texture descriptor"),
+            )
+            .expect("glyph texture resource");
+        let glyph_sampler = resources
+            .define_sampler(SamplerDesc::new(
+                FilterMode::Nearest,
+                FilterMode::Nearest,
+                AddressMode::ClampToEdge,
+                AddressMode::ClampToEdge,
+            ))
+            .expect("glyph sampler resource");
+        let glyph_vertices: [[f32; 10]; 3] = [
+            [-0.5, -0.5, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+            [0.5, -0.5, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            [0.0, 0.5, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.0],
+        ];
+        let glyph_buffer = resources
+            .define_buffer(
+                BufferDesc::new(
+                    core::mem::size_of_val(&glyph_vertices) as u64,
+                    BufferUsage::VERTEX | BufferUsage::COPY_DST,
+                )
+                .expect("glyph vertex descriptor"),
+            )
+            .expect("glyph vertex resource");
+        let glyph_pipeline = resources
+            .define_render_pipeline(
+                RenderPipelineDesc::new(
+                    TextureFormat::Bgra8Unorm,
+                    PrimitiveTopology::TriangleList,
+                    VertexBufferLayout::new(
+                        40,
+                        vec![
+                            VertexAttribute::new(0, VertexFormat::Float32x4, 0),
+                            VertexAttribute::new(1, VertexFormat::Float32x4, 16),
+                            VertexAttribute::new(2, VertexFormat::Float32x2, 32),
+                        ],
+                    )
+                    .expect("glyph vertex layout"),
+                    FragmentProgram::TextureVertexColor(TextureSampleMode::AlphaMask),
+                    BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
+                    RasterState::new(ir::CullMode::None, ir::FrontFace::CounterClockwise),
+                )
+                .expect("glyph pipeline descriptor"),
+            )
+            .expect("glyph pipeline resource");
+        let area = PixelRect::new(0, 0, 4, 4).expect("render area");
+        let clear = Color::rgba(0.0, 0.0, 0.0, 1.0).expect("clear color");
+        let pass = RenderPassDesc::new(
+            resources.as_ref(),
+            target,
+            area,
+            LoadOp::Clear(clear),
+            StoreOp::Store,
+        )
+        .expect("render pass");
+        let glyph_pixels = [0_u8, 255, 255, 0];
+        let mut encoder = CommandEncoder::new(resources.as_ref());
+        encoder
+            .write_buffer(vertex_buffer, 0, bytemuck::cast_slice(&vertices))
+            .expect("vertex upload");
+        encoder
+            .write_texture(
+                glyph_texture,
+                TextureWrite::new(
+                    PixelRect::new(0, 0, 2, 2).expect("glyph upload area"),
+                    2,
+                    &glyph_pixels,
+                )
+                .expect("glyph upload"),
+            )
+            .expect("record glyph upload");
+        let mut render_pass = encoder.begin_render_pass(pass).expect("begin pass");
+        render_pass.set_pipeline(pipeline).expect("set pipeline");
+        render_pass
+            .set_vertex_buffer(vertex_buffer, 0)
+            .expect("set vertex buffer");
+        render_pass
+            .set_uniforms(DrawUniforms::new(Transform::identity(), clear))
+            .expect("set uniforms");
+        render_pass.draw(3, 0).expect("draw triangle");
+        render_pass.end().expect("end pass");
+        let glyph_pass = RenderPassDesc::new(
+            resources.as_ref(),
+            target,
+            area,
+            LoadOp::Load,
+            StoreOp::Store,
+        )
+        .expect("glyph render pass");
+        let mut glyph_render_pass = encoder
+            .begin_render_pass(glyph_pass)
+            .expect("begin glyph pass");
+        glyph_render_pass
+            .set_pipeline(glyph_pipeline)
+            .expect("set glyph pipeline");
+        glyph_render_pass
+            .set_vertex_buffer(glyph_buffer, 0)
+            .expect("set glyph vertex buffer");
+        glyph_render_pass
+            .set_texture(glyph_texture)
+            .expect("set glyph texture");
+        glyph_render_pass
+            .set_sampler(glyph_sampler)
+            .expect("set glyph sampler");
+        glyph_render_pass
+            .set_uniforms(DrawUniforms::new(Transform::identity(), clear))
+            .expect("set glyph uniforms");
+        glyph_render_pass.draw(3, 0).expect("draw glyph triangle");
+        glyph_render_pass.end().expect("end glyph pass");
+        let partial_clear = Color::rgba(0.1, 0.2, 0.3, 1.0).expect("partial clear color");
+        let partial_pass = RenderPassDesc::new(
+            resources.as_ref(),
+            target,
+            PixelRect::new(1, 1, 2, 2).expect("partial render area"),
+            LoadOp::Clear(partial_clear),
+            StoreOp::Store,
+        )
+        .expect("partial render pass");
+        let mut partial_render_pass = encoder
+            .begin_render_pass(partial_pass)
+            .expect("begin partial pass");
+        partial_render_pass
+            .set_pipeline(pipeline)
+            .expect("set partial pipeline");
+        partial_render_pass
+            .set_vertex_buffer(vertex_buffer, 0)
+            .expect("set partial vertex buffer");
+        partial_render_pass
+            .set_uniforms(DrawUniforms::new(Transform::identity(), clear))
+            .expect("set partial uniforms");
+        partial_render_pass
+            .draw(3, 0)
+            .expect("draw partial triangle");
+        partial_render_pass.end().expect("end partial pass");
+        let commands = encoder.finish().expect("finish commands");
+        let mut cache = context.create_resources(Rc::clone(&resources));
+        cache
+            .map_image(target.id(), image)
+            .expect("map target image");
+        cache
+            .map_image(target.id(), replacement)
+            .expect("replace target image");
+        device
+            .raw_device()
+            .push_error_scope(raw::ErrorFilter::Validation);
+        context
+            .create_queue()
+            .submit(&mut cache, &commands)
+            .expect("submit IR frame");
+        let _ = device.raw_device().poll(raw::Maintain::Wait);
+        let error = pollster::block_on(device.raw_device().pop_error_scope());
+        assert!(error.is_none(), "WGPU validation error: {error:?}");
+    }
+}


### PR DESCRIPTION
## Summary

- add a feature-gated WGPU execution backend for the portable SGFX IR
- materialize buffers, textures, samplers, render pipelines, depth targets, scissor state, copies, and partial clears through WGPU
- expose validated IR resource descriptors needed by backend lowerers
- cover real Metal submission, depth, texture, and scissor behavior with headless tests

## Why

Native ScarletUI rendering needs a GPU path that reuses SGFX IR instead of uploading a CPU-rendered framebuffer. This backend supplies the portable execution layer used by the companion ScarletUI integration while leaving the existing Scarlet/VirGL path unchanged.

This is the SGFX half of #541. Companion ScarletUI integration: petitstrawberry/scarlet-ui#18.

## Impact

The backend is opt-in through the `wgpu` feature and requires `std`. Existing default and `scarlet-std` builds are unchanged.

## Validation

- `cargo test --manifest-path user/lib/sgfx/Cargo.toml --no-default-features --features wgpu` — 12 passed
- `cargo clippy --manifest-path user/lib/sgfx/Cargo.toml --no-default-features --features wgpu --no-deps -- -D warnings`
- `cargo fmt --manifest-path user/lib/sgfx/Cargo.toml -- --check`
