### PR TITLE
Test SGFX culling semantics across backends

### DIFF
--- a/user/lib/scarlet-sgfx-virgl/src/virgl.rs
+++ b/user/lib/scarlet-sgfx-virgl/src/virgl.rs
@@ -3086,6 +3086,25 @@ mod tests {
     }
 
     #[test]
+    fn ir_ccw_back_culling_uses_the_upper_left_viewport_contract() {
+        let flags = ir_rasterizer_flags(IrCullMode::Back, IrFrontFace::CounterClockwise);
+        assert_eq!(
+            flags & (3 << VIRGL_RASTERIZER_CULL_FACE_SHIFT),
+            2 << VIRGL_RASTERIZER_CULL_FACE_SHIFT
+        );
+        assert_ne!(flags & VIRGL_RASTERIZER_FRONT_CCW, 0);
+
+        let mut commands = Vec::new();
+        push_viewport(
+            &mut commands,
+            Viewport::new(640, 480),
+            FramebufferOrientation::UPPER_LEFT,
+        );
+        let words = dwords(&commands);
+        assert_eq!(f32::from_bits(words[3]), -240.0);
+    }
+
+    #[test]
     fn ir_color_only_packets_keep_depth_unbound_and_disabled() {
         let mut commands = Vec::new();
         push_ir_bind_pass_state(

--- a/user/lib/sgfx-backend-wgpu/src/lib.rs
+++ b/user/lib/sgfx-backend-wgpu/src/lib.rs
@@ -1764,7 +1764,7 @@ mod tests {
     }
 
     #[test]
-    fn headless_scissor_limits_the_drawn_pixels() {
+    fn headless_ccw_front_face_survives_back_culling_and_scissor() {
         let instance = raw::Instance::new(&raw::InstanceDescriptor::default());
         let adapter = pollster::block_on(instance.request_adapter(&raw::RequestAdapterOptions {
             power_preference: raw::PowerPreference::HighPerformance,
@@ -1794,12 +1794,12 @@ mod tests {
             )
             .expect("target resource");
         let vertices: [[f32; 8]; 6] = [
-            [-1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
-            [1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
-            [1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
-            [-1.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
-            [1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
-            [-1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [-0.9, -0.8, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [-0.1, -0.8, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [-0.5, 0.8, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+            [0.1, -0.8, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            [0.5, 0.8, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            [0.9, -0.8, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
         ];
         let vertex_buffer = resources
             .define_buffer(
@@ -1825,7 +1825,7 @@ mod tests {
                     .expect("vertex layout"),
                     FragmentProgram::VertexColor,
                     BlendState::SOURCE_OVER_STRAIGHT_ALPHA,
-                    RasterState::new(ir::CullMode::None, ir::FrontFace::CounterClockwise),
+                    RasterState::new(ir::CullMode::Back, ir::FrontFace::CounterClockwise),
                 )
                 .expect("pipeline descriptor"),
             )
@@ -1920,8 +1920,9 @@ mod tests {
                 bytes[start + 3],
             ]
         };
-        assert_eq!(pixel(8, 4), [0, 0, 255, 255]);
-        assert_eq!(pixel(8, 12), [255, 255, 255, 255]);
+        assert_eq!(pixel(4, 4), [0, 0, 255, 255]);
+        assert_eq!(pixel(12, 4), [255, 255, 255, 255]);
+        assert_eq!(pixel(4, 12), [255, 255, 255, 255]);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Extend the WGPU headless readback test to render one CCW and one CW triangle under back-face culling.
- Assert that CCW survives, CW is culled, and scissor still clips the lower half.
- Add a VirGL IR packet regression test for back-face culling, `front_ccw`, and the upper-left viewport Y scale.

## Why

A Boxcraft far-mesh winding bug appeared only on the WGPU path, raising concern that SGFX backend front-face semantics differed. The tests pin the portable contract at both backend boundaries and demonstrate that WGPU/Metal classifies the intended CCW triangle correctly.

## Impact

No production rendering behavior changes. Future backend changes will fail tests if CCW/back-cull semantics or the upper-left viewport contract drift.

## Validation

- `cargo test --manifest-path user/lib/sgfx-backend-wgpu/Cargo.toml` (6 passed, including Metal readback)
- `cargo test --manifest-path user/lib/sgfx-backend-virgl/Cargo.toml` (2 passed)
- `cargo test --manifest-path user/lib/scarlet-sgfx-virgl/Cargo.toml --no-default-features --features std ir_ccw_back_culling_uses_the_upper_left_viewport_contract` (passed)
- `cargo fmt` checks for both touched packages