### PR TITLE
Add the cross-platform SGFX frontend

### DIFF
--- a/.cargo/Cargo.lock
+++ b/.cargo/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 2.0.20",
 ]
@@ -80,6 +80,15 @@ name = "android-properties"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -150,6 +159,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +180,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +205,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block2"
@@ -318,6 +360,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "colorchoice"
@@ -517,6 +569,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -743,6 +804,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45cf04b2726f02df5508c6de726acdc90cdf97ac771a9a0ffd8ba10a6e696bf9"
+dependencies = [
+ "bitflags 2.13.1",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bbed164dd10ed526c2e4fe3e721ca4a71c61730e5aafac6844b417b3227058"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.13.1",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "gpu-raw"
 version = "0.16.0"
 dependencies = [
@@ -788,6 +932,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "httparse"
@@ -1038,6 +1188,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,12 +1369,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+dependencies = [
+ "bitflags 2.13.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "naga"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "rustc-hash",
+ "spirv",
+ "strum",
+ "termcolor",
+ "thiserror 2.0.20",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1204,7 +1423,7 @@ dependencies = [
  "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -1215,6 +1434,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -1264,6 +1492,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -1559,12 +1796,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1632,6 +1901,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1914,12 @@ checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
@@ -1657,6 +1938,12 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "pulldown-cmark"
@@ -1706,6 +1993,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "ratatui"
@@ -1790,9 +2083,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "rust_h264"
 version = "0.4.0"
 source = "git+https://github.com/petitstrawberry/rust_h264.git?rev=a559fe2545fd88def12146dcc06286475b53ead3#a559fe2545fd88def12146dcc06286475b53ead3"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1971,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#ffd5dfb9224501fe34123b686bb432b422365b22"
+source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
 dependencies = [
  "scarlet-ui-core",
  "scarlet-ui-platform-sws",
@@ -1981,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-core"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#ffd5dfb9224501fe34123b686bb432b422365b22"
+source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
 dependencies = [
  "ab_glyph",
  "bitflags 2.13.1",
@@ -1997,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-icons-tabler"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#ffd5dfb9224501fe34123b686bb432b422365b22"
+source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
 dependencies = [
  "svgtypes",
 ]
@@ -2005,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-macros"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#ffd5dfb9224501fe34123b686bb432b422365b22"
+source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2015,11 +2320,12 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-platform-sws"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#ffd5dfb9224501fe34123b686bb432b422365b22"
+source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
 dependencies = [
  "scarlet-std",
  "scarlet-ui-core",
  "scarlet-ui-renderer-sgfx",
+ "sgfx",
  "sws-client",
  "sws-protocol",
 ]
@@ -2027,10 +2333,12 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-platform-winit"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#ffd5dfb9224501fe34123b686bb432b422365b22"
+source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
 dependencies = [
  "raw-window-handle",
  "scarlet-ui-core",
+ "scarlet-ui-renderer-sgfx",
+ "sgfx",
  "softbuffer",
  "winit",
 ]
@@ -2038,11 +2346,11 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-renderer-sgfx"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui#ffd5dfb9224501fe34123b686bb432b422365b22"
+source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
 dependencies = [
  "libm",
  "scarlet-ui-core",
- "sgfx",
+ "sgfx-core",
 ]
 
 [[package]]
@@ -2142,8 +2450,10 @@ dependencies = [
 name = "sgfx"
 version = "0.16.0"
 dependencies = [
+ "raw-window-handle",
  "scarlet-std",
  "sgfx-backend-scarlet-virgl",
+ "sgfx-backend-wgpu",
  "sgfx-core",
 ]
 
@@ -2156,6 +2466,17 @@ dependencies = [
  "scarlet-std",
  "sgfx-codegen-virgl",
  "sgfx-core",
+]
+
+[[package]]
+name = "sgfx-backend-wgpu"
+version = "0.16.0"
+dependencies = [
+ "bytemuck",
+ "pollster",
+ "raw-window-handle",
+ "sgfx-core",
+ "wgpu",
 ]
 
 [[package]]
@@ -2210,6 +2531,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -2296,6 +2626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2465,6 +2804,15 @@ dependencies = [
  "bitflags 2.13.1",
  "log",
  "num-traits",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2650,6 +2998,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -2935,6 +3289,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "document-features",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.20",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "24.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.13.1",
+ "block",
+ "bytemuck",
+ "cfg_aliases",
+ "core-graphics-types",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.20",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+dependencies = [
+ "bitflags 2.13.1",
+ "js-sys",
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,10 +3407,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3171,6 +3698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,7 +3820,3 @@ checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]
-
-[[patch.unused]]
-name = "sgfx-backend-wgpu"
-version = "0.16.0"

--- a/.cargo/Cargo.lock
+++ b/.cargo/Cargo.lock
@@ -1914,17 +1914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sgfx-backend-scarlet-virgl"
-version = "0.16.0"
-dependencies = [
- "gpu-raw",
- "scarlet-os",
- "scarlet-std",
- "sgfx-codegen-virgl",
- "sgfx-core",
-]
-
-[[package]]
 name = "scarlet-std"
 version = "0.16.0"
 dependencies = [
@@ -1962,7 +1951,7 @@ dependencies = [
  "scarlet-ui-macros",
  "serde",
  "serde_json",
- "sgfx",
+ "sgfx-compat-scarlet",
  "svgtypes",
  "sws-client",
  "sws-protocol",
@@ -2153,8 +2142,20 @@ dependencies = [
 name = "sgfx"
 version = "0.16.0"
 dependencies = [
- "framebuffer",
+ "scarlet-std",
  "sgfx-backend-scarlet-virgl",
+ "sgfx-core",
+]
+
+[[package]]
+name = "sgfx-backend-scarlet-virgl"
+version = "0.16.0"
+dependencies = [
+ "gpu-raw",
+ "scarlet-os",
+ "scarlet-std",
+ "sgfx-codegen-virgl",
+ "sgfx-core",
 ]
 
 [[package]]
@@ -2162,6 +2163,14 @@ name = "sgfx-codegen-virgl"
 version = "0.16.0"
 dependencies = [
  "sgfx-core",
+]
+
+[[package]]
+name = "sgfx-compat-scarlet"
+version = "0.16.0"
+dependencies = [
+ "framebuffer",
+ "sgfx-backend-scarlet-virgl",
 ]
 
 [[package]]
@@ -2673,6 +2682,7 @@ dependencies = [
  "serde",
  "serde-json-core",
  "sgfx",
+ "sgfx-compat-scarlet",
  "sws-client",
  "sws-protocol",
  "vm-fdt",

--- a/.cargo/Cargo.toml
+++ b/.cargo/Cargo.toml
@@ -18,7 +18,8 @@ scarlet-os = { path = "../user/lib/scarlet-os" }
 scarlet-rt = { path = "../user/lib/scarlet-rt" }
 scarlet-std = { path = "../user/lib/std" }
 scarlet-sys = { path = "../user/lib/scarlet-sys" }
-sgfx = { path = "../user/lib/sgfx-compat" }
+sgfx = { path = "../user/lib/sgfx-frontend" }
+sgfx-compat-scarlet = { path = "../user/lib/sgfx-compat" }
 sgfx-core = { path = "../user/lib/sgfx" }
 sgfx-codegen-virgl = { path = "../user/lib/sgfx-codegen-virgl" }
 sgfx-backend-scarlet-virgl = { path = "../user/lib/sgfx-backend-scarlet-virgl" }

--- a/user/bin/Cargo.toml
+++ b/user/bin/Cargo.toml
@@ -177,7 +177,8 @@ path = "src/sas/main.rs"
 scarlet-std = { path = "../lib/std", features = ["alloc_debug"] }
 scpm = { path = "../lib/scpm" }
 framebuffer = { path = "../lib/framebuffer" }
-sgfx = { path = "../lib/sgfx-compat" }
+sgfx = { path = "../lib/sgfx-frontend", default-features = false, features = ["backend-scarlet-virgl", "legacy-scarlet-std"] }
+sgfx_compat = { package = "sgfx-compat-scarlet", path = "../lib/sgfx-compat" }
 sws-protocol = { path = "../lib/sws-protocol" }
 sws-client = { path = "../lib/sws-client" }
 scarlet-os = { path = "../lib/scarlet-os" }

--- a/user/bin/Cargo.toml
+++ b/user/bin/Cargo.toml
@@ -182,8 +182,8 @@ sgfx_compat = { package = "sgfx-compat-scarlet", path = "../lib/sgfx-compat" }
 sws-protocol = { path = "../lib/sws-protocol" }
 sws-client = { path = "../lib/sws-client" }
 scarlet-os = { path = "../lib/scarlet-os" }
-scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui", default-features = false, features = ["legacy-scarlet-std", "platform-sws"] }
-scarlet-ui-macros = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui-macros" }
+scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui", default-features = false, features = ["legacy-scarlet-std", "platform-sws"] }
+scarlet-ui-macros = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui-macros" }
 scarlet-desktop-config = { path = "../lib/scarlet-desktop-config" }
 sbus = { path = "../lib/sbus" }
 sbus-client = { path = "../lib/sbus-client" }

--- a/user/bin/src/sgfx_probe.rs
+++ b/user/bin/src/sgfx_probe.rs
@@ -5,12 +5,21 @@
 
 extern crate scarlet_std as std;
 
-use sgfx::Device;
+use sgfx::Instance;
 use std::println;
 
 #[unsafe(no_mangle)]
 fn main() -> i32 {
-    let device = match Device::open("/dev/gpu0") {
+    let instance = match Instance::new() {
+        Ok(instance) => instance,
+        Err(error) => {
+            println!("failed to select an SGFX backend: {}", error);
+            return 1;
+        }
+    };
+    println!("SGFX backend: {}", instance.backend());
+
+    let device = match instance.open_device("/dev/gpu0") {
         Ok(device) => device,
         Err(error) => {
             println!("failed to open /dev/gpu0: {:?}", error);
@@ -30,13 +39,8 @@ fn main() -> i32 {
             return 1;
         }
     };
-    match context.create_queue() {
-        Ok(_) => println!("  graphics queue: available"),
-        Err(error) => {
-            println!("failed to create graphics queue: {:?}", error);
-            return 1;
-        }
-    }
+    let _ = context;
+    println!("  graphics context: available");
 
     0
 }

--- a/user/bin/src/sws/gpu_compositor.rs
+++ b/user/bin/src/sws/gpu_compositor.rs
@@ -5,7 +5,7 @@ use core::mem;
 use super::cursor::Cursor;
 use super::window::{Window, WindowId};
 use framebuffer::DisplaySurface;
-use sgfx::{
+use sgfx_compat::{
     Color, CompositionPass, Context, Device, Image, PixelRect, Queue, SgfxImagePresentExt,
     SourceAlpha, Texture,
 };

--- a/user/lib/Makefile.toml
+++ b/user/lib/Makefile.toml
@@ -179,7 +179,7 @@ script = [
     "cd ../framebuffer && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../gpu-raw && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../sgfx-backend-scarlet-virgl && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
-    "cd ../sgfx-frontend && cargo build --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
+    "cd ../sgfx-frontend && cargo build -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../sws-protocol && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../scarlet-desktop-config && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../scpm && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json"
@@ -197,7 +197,7 @@ script = [
     "cd ../framebuffer && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../gpu-raw && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../sgfx-backend-scarlet-virgl && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
-    "cd ../sgfx-frontend && cargo build --release --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
+    "cd ../sgfx-frontend && cargo build -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --release --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../sws-protocol && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../scarlet-desktop-config && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../scpm && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json"
@@ -215,7 +215,7 @@ script = [
     "cd ../framebuffer && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../gpu-raw && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../sgfx-backend-scarlet-virgl && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
-    "cd ../sgfx-frontend && cargo build --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/aarch64-unknown-scarlet-elf.json",
+    "cd ../sgfx-frontend && cargo build -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../sws-protocol && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../scarlet-desktop-config && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../scpm && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json"
@@ -233,7 +233,7 @@ script = [
     "cd ../framebuffer && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../gpu-raw && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../sgfx-backend-scarlet-virgl && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
-    "cd ../sgfx-frontend && cargo build --release --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/aarch64-unknown-scarlet-elf.json",
+    "cd ../sgfx-frontend && cargo build -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem --release --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../sws-protocol && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../scarlet-desktop-config && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../scpm && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json"

--- a/user/lib/Makefile.toml
+++ b/user/lib/Makefile.toml
@@ -7,11 +7,11 @@ skip_core_tasks = true
 
 [tasks.fmt]
 description = "Format all user library code"
-dependencies = ["fmt-scarlet-abi", "fmt-scarlet-sys", "fmt-scarlet-rt", "fmt-scarlet-os", "fmt-scarlet-codecs", "fmt-std", "fmt-framebuffer", "fmt-gpu-raw", "fmt-sgfx", "fmt-sws-protocol", "fmt-scarlet-desktop-config", "fmt-scpm"]
+dependencies = ["fmt-scarlet-abi", "fmt-scarlet-sys", "fmt-scarlet-rt", "fmt-scarlet-os", "fmt-scarlet-codecs", "fmt-std", "fmt-framebuffer", "fmt-gpu-raw", "fmt-sgfx", "fmt-sgfx-frontend", "fmt-sws-protocol", "fmt-scarlet-desktop-config", "fmt-scpm"]
 
 [tasks.fmt-check]
 description = "Check formatting for all user library code"
-dependencies = ["fmt-scarlet-abi-check", "fmt-scarlet-sys-check", "fmt-scarlet-rt-check", "fmt-scarlet-os-check", "fmt-scarlet-codecs-check", "fmt-std-check", "fmt-framebuffer-check", "fmt-gpu-raw-check", "fmt-sgfx-check", "fmt-sws-protocol-check", "fmt-scpm-check"]
+dependencies = ["fmt-scarlet-abi-check", "fmt-scarlet-sys-check", "fmt-scarlet-rt-check", "fmt-scarlet-os-check", "fmt-scarlet-codecs-check", "fmt-std-check", "fmt-framebuffer-check", "fmt-gpu-raw-check", "fmt-sgfx-check", "fmt-sgfx-frontend-check", "fmt-sws-protocol-check", "fmt-scpm-check"]
 
 [tasks.fmt-scarlet-abi-check]
 description = "Check formatting for Scarlet ABI code"
@@ -58,6 +58,12 @@ args = ["fmt", "--", "--check"]
 [tasks.fmt-sgfx-check]
 description = "Check formatting for user library sgfx code"
 cwd = "sgfx"
+command = "cargo"
+args = ["fmt", "--", "--check"]
+
+[tasks.fmt-sgfx-frontend-check]
+description = "Check formatting for the cross-platform SGFX frontend"
+cwd = "sgfx-frontend"
 command = "cargo"
 args = ["fmt", "--", "--check"]
 
@@ -121,6 +127,12 @@ cwd = "sgfx"
 command = "cargo"
 args = ["fmt"]
 
+[tasks.fmt-sgfx-frontend]
+description = "Format the cross-platform SGFX frontend"
+cwd = "sgfx-frontend"
+command = "cargo"
+args = ["fmt"]
+
 [tasks.fmt-gpu-raw]
 description = "Format user library gpu raw transport code"
 cwd = "gpu-raw"
@@ -167,6 +179,7 @@ script = [
     "cd ../framebuffer && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../gpu-raw && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../sgfx-backend-scarlet-virgl && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
+    "cd ../sgfx-frontend && cargo build --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../sws-protocol && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../scarlet-desktop-config && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../scpm && cargo build --target ../../targets/riscv64gc-unknown-scarlet-elf.json"
@@ -184,6 +197,7 @@ script = [
     "cd ../framebuffer && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../gpu-raw && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../sgfx-backend-scarlet-virgl && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
+    "cd ../sgfx-frontend && cargo build --release --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../sws-protocol && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../scarlet-desktop-config && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json",
     "cd ../scpm && cargo build --release --target ../../targets/riscv64gc-unknown-scarlet-elf.json"
@@ -201,6 +215,7 @@ script = [
     "cd ../framebuffer && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../gpu-raw && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../sgfx-backend-scarlet-virgl && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
+    "cd ../sgfx-frontend && cargo build --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../sws-protocol && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../scarlet-desktop-config && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../scpm && cargo build --target ../../targets/aarch64-unknown-scarlet-elf.json"
@@ -218,6 +233,7 @@ script = [
     "cd ../framebuffer && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../gpu-raw && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../sgfx-backend-scarlet-virgl && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
+    "cd ../sgfx-frontend && cargo build --release --no-default-features --features backend-scarlet-virgl,legacy-scarlet-std --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../sws-protocol && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../scarlet-desktop-config && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json",
     "cd ../scpm && cargo build --release --target ../../targets/aarch64-unknown-scarlet-elf.json"
@@ -235,6 +251,7 @@ script = [
     "cd ../framebuffer && cargo clean",
     "cd ../gpu-raw && cargo clean",
     "cd ../sgfx && cargo clean",
+    "cd ../sgfx-frontend && cargo clean",
     "cd ../sws-protocol && cargo clean",
     "cd ../sws-client && cargo clean",
     "cd ../sas-protocol && cargo clean",
@@ -253,6 +270,7 @@ script = [
     "cd std && cargo test",
     "cd ../framebuffer && cargo test",
     "cd ../sgfx && cargo test",
+    "cd ../sgfx-frontend && cargo test",
     "cd ../sws-protocol && cargo test",
     "cd ../scarlet-desktop-config && cargo test",
     "cd ../scpm && cargo test"
@@ -269,6 +287,7 @@ script = [
     "cd ../framebuffer && cargo doc --no-deps",
     "cd ../gpu-raw && cargo doc --no-deps",
     "cd ../sgfx && cargo doc --no-deps",
+    "cd ../sgfx-frontend && cargo doc --no-deps",
     "cd ../sws-protocol && cargo doc --no-deps",
     "cd ../scarlet-desktop-config && cargo doc --no-deps",
     "cd ../scpm && cargo doc --no-deps"
@@ -276,7 +295,7 @@ script = [
 
 [tasks.clippy]
 description = "Run clippy for all user libraries"
-dependencies = ["clippy-scarlet-abi", "clippy-scarlet-sys", "clippy-scarlet-rt", "clippy-scarlet-os", "clippy-std", "clippy-framebuffer", "clippy-gpu-raw", "clippy-sgfx", "clippy-sws-protocol", "clippy-scarlet-desktop-config", "clippy-scpm"]
+dependencies = ["clippy-scarlet-abi", "clippy-scarlet-sys", "clippy-scarlet-rt", "clippy-scarlet-os", "clippy-std", "clippy-framebuffer", "clippy-gpu-raw", "clippy-sgfx", "clippy-sgfx-frontend", "clippy-sws-protocol", "clippy-scarlet-desktop-config", "clippy-scpm"]
 
 [tasks.clippy-scarlet-abi]
 description = "Run clippy for Scarlet ABI code"
@@ -317,6 +336,12 @@ args = ["clippy", "--", "-D", "warnings"]
 [tasks.clippy-sgfx]
 description = "Run clippy for user library sgfx code"
 cwd = "sgfx"
+command = "cargo"
+args = ["clippy", "--", "-D", "warnings"]
+
+[tasks.clippy-sgfx-frontend]
+description = "Run clippy for the cross-platform SGFX frontend"
+cwd = "sgfx-frontend"
 command = "cargo"
 args = ["clippy", "--", "-D", "warnings"]
 

--- a/user/lib/sgfx-backend-scarlet-virgl/src/driver.rs
+++ b/user/lib/sgfx-backend-scarlet-virgl/src/driver.rs
@@ -2,7 +2,6 @@
 
 use alloc::{rc::Rc, vec::Vec};
 
-use gpu_raw::Gpu as RawGpu;
 #[cfg(feature = "std")]
 use scarlet_os::handle::{Handle, HandleError, HandleResult};
 #[cfg(not(feature = "std"))]
@@ -22,13 +21,6 @@ pub(crate) enum Device {
 
 impl Device {
     pub(crate) fn open(path: &str) -> HandleResult<Self> {
-        // A complete backend validates only its own execution contract. The
-        // SGFX environment facade owns composition between different backends.
-        let probe = RawGpu::open(path)?;
-        let info = probe.query_info()?;
-        if !crate::matches_backend_id(info.backend_id_bytes()) {
-            return Err(HandleError::Unsupported);
-        }
         let backend = Rc::new(virgl::Device::open(path)?);
         Ok(Self::Virgl(backend))
     }

--- a/user/lib/sgfx-backend-scarlet-virgl/src/driver.rs
+++ b/user/lib/sgfx-backend-scarlet-virgl/src/driver.rs
@@ -1,4 +1,4 @@
-//! Scarlet transport selection and dispatch for the application facade.
+//! Private Scarlet/VirGL resource and queue dispatch.
 
 use alloc::{rc::Rc, vec::Vec};
 
@@ -16,43 +16,21 @@ use scarlet_os::ipc::SharedMemory;
 #[cfg(not(feature = "std"))]
 use std::ipc::SharedMemory;
 
-const APPLE_AGX_BACKEND_ID: &[u8] = b"apple-agx";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BackendKind {
-    Virgl,
-    AppleAgx,
-    Unknown,
-}
-
-fn classify_backend_id(backend_id: &[u8]) -> BackendKind {
-    if crate::matches_backend_id(backend_id) {
-        BackendKind::Virgl
-    } else if backend_id == APPLE_AGX_BACKEND_ID {
-        BackendKind::AppleAgx
-    } else {
-        BackendKind::Unknown
-    }
-}
-
 pub(crate) enum Device {
     Virgl(Rc<virgl::Device>),
 }
 
 impl Device {
     pub(crate) fn open(path: &str) -> HandleResult<Self> {
-        // Queue command bytes are backend-defined. Probe the stable backend ID
-        // before selecting a lowerer so a non-VirGL device never receives
-        // VirGL command streams merely because it exposes generic queues.
+        // A complete backend validates only its own execution contract. The
+        // SGFX environment facade owns composition between different backends.
         let probe = RawGpu::open(path)?;
         let info = probe.query_info()?;
-        match classify_backend_id(info.backend_id_bytes()) {
-            BackendKind::Virgl => {
-                let backend = Rc::new(virgl::Device::open(path)?);
-                Ok(Self::Virgl(backend))
-            }
-            BackendKind::AppleAgx | BackendKind::Unknown => Err(HandleError::Unsupported),
+        if !crate::matches_backend_id(info.backend_id_bytes()) {
+            return Err(HandleError::Unsupported);
         }
+        let backend = Rc::new(virgl::Device::open(path)?);
+        Ok(Self::Virgl(backend))
     }
 
     pub(crate) fn capabilities(&self) -> Capabilities {
@@ -627,25 +605,14 @@ pub(crate) enum Pipeline {
 
 #[cfg(test)]
 mod tests {
-    use super::{BackendKind, classify_backend_id};
+    use crate::matches_backend_id;
 
     #[test]
-    fn selects_virgl_for_exact_virtio_backend_id() {
-        assert_eq!(classify_backend_id(b"virtio-gpu"), BackendKind::Virgl);
-        assert_eq!(
-            classify_backend_id(b"virtio-gpu-extra"),
-            BackendKind::Unknown
-        );
-    }
-
-    #[test]
-    fn reserves_apple_agx_without_falling_back_to_virgl() {
-        assert_eq!(classify_backend_id(b"apple-agx"), BackendKind::AppleAgx);
-    }
-
-    #[test]
-    fn rejects_unknown_and_empty_backend_ids() {
-        assert_eq!(classify_backend_id(b""), BackendKind::Unknown);
-        assert_eq!(classify_backend_id(b"software"), BackendKind::Unknown);
+    fn matches_only_the_exact_virtio_gpu_backend_id() {
+        assert!(matches_backend_id(b"virtio-gpu"));
+        assert!(!matches_backend_id(b"virtio-gpu-extra"));
+        assert!(!matches_backend_id(b"apple-agx"));
+        assert!(!matches_backend_id(b""));
+        assert!(!matches_backend_id(b"software"));
     }
 }

--- a/user/lib/sgfx-backend-scarlet-virgl/src/virgl.rs
+++ b/user/lib/sgfx-backend-scarlet-virgl/src/virgl.rs
@@ -308,7 +308,10 @@ impl Device {
     pub(crate) fn open(path: &str) -> HandleResult<Self> {
         let raw = RawGpu::open(path)?;
         let info = raw.query_info()?;
-        if info.result != GPU_RESULT_SUCCESS || info.device_state != GPU_DEVICE_STATE_READY {
+        if info.result != GPU_RESULT_SUCCESS
+            || info.device_state != GPU_DEVICE_STATE_READY
+            || !crate::matches_backend_id(info.backend_id_bytes())
+        {
             return Err(HandleError::Unsupported);
         }
 

--- a/user/lib/sgfx-backend-wgpu/Cargo.toml
+++ b/user/lib/sgfx-backend-wgpu/Cargo.toml
@@ -5,11 +5,10 @@ edition = "2024"
 
 [dependencies]
 bytemuck = { version = "1", features = ["derive"] }
+pollster = "0.4"
+raw-window-handle = "0.6"
 sgfx-core = { path = "../sgfx", default-features = false }
 wgpu = "24"
-
-[dev-dependencies]
-pollster = "0.4"
 
 [lib]
 name = "sgfx_backend_wgpu"

--- a/user/lib/sgfx-backend-wgpu/src/lib.rs
+++ b/user/lib/sgfx-backend-wgpu/src/lib.rs
@@ -13,6 +13,7 @@ use alloc::{borrow::Cow, format, rc::Rc, string::String, sync::Arc, vec::Vec};
 use core::fmt;
 
 use bytemuck::{Pod, Zeroable};
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use wgpu as raw;
 
 use sgfx_core::ir::{
@@ -41,6 +42,14 @@ pub enum Error {
     Unsupported(UnsupportedFeature),
     /// The command stream or persistent backend state is inconsistent.
     InvalidState,
+    /// Native window handles could not be bound to a WGPU surface.
+    SurfaceCreation,
+    /// No WGPU adapter can present to the requested surface.
+    AdapterUnavailable,
+    /// The selected WGPU adapter could not create a device and queue.
+    DeviceRequest,
+    /// A configured surface frame could not be acquired for presentation.
+    SurfaceAcquire,
 }
 
 impl From<ir::Error> for Error {
@@ -60,6 +69,10 @@ impl fmt::Display for Error {
                 write!(formatter, "unsupported SGFX feature: {feature:?}")
             }
             Self::InvalidState => formatter.write_str("invalid WGPU backend state"),
+            Self::SurfaceCreation => formatter.write_str("WGPU surface creation failed"),
+            Self::AdapterUnavailable => formatter.write_str("no compatible WGPU adapter"),
+            Self::DeviceRequest => formatter.write_str("WGPU device creation failed"),
+            Self::SurfaceAcquire => formatter.write_str("WGPU surface acquisition failed"),
         }
     }
 }
@@ -338,6 +351,213 @@ impl MappedTargetSession {
     /// The WGPU queue owned by this session's context.
     pub fn raw_queue(&self) -> &raw::Queue {
         self.context.raw_queue()
+    }
+}
+
+/// WGPU window surface, device, and presentation state owned by the backend.
+pub struct WindowContext {
+    surface: raw::Surface<'static>,
+    config: raw::SurfaceConfiguration,
+    context: Context,
+    sampler: raw::Sampler,
+    blit_pipeline: raw::RenderPipeline,
+    // Fields drop in declaration order. Retain the instance until the surface
+    // and every resource created from its adapter have been released.
+    _instance: raw::Instance,
+}
+
+impl WindowContext {
+    /// Create a complete WGPU execution context for native window handles.
+    ///
+    /// # Arguments
+    ///
+    /// * `raw_display_handle` - Display handle retained by the platform.
+    /// * `raw_window_handle` - Window handle retained by the platform.
+    /// * `width` - Initial physical surface width.
+    /// * `height` - Initial physical surface height.
+    ///
+    /// # Returns
+    ///
+    /// A surface-compatible WGPU context, or an initialization error.
+    ///
+    /// # Safety
+    ///
+    /// Both raw handles must remain valid until the returned context is
+    /// dropped. Callers must drop SGFX rendering state before the native
+    /// window and display objects.
+    pub unsafe fn new(
+        raw_display_handle: RawDisplayHandle,
+        raw_window_handle: RawWindowHandle,
+        width: u32,
+        height: u32,
+    ) -> Result<Self> {
+        let instance = raw::Instance::new(&raw::InstanceDescriptor::default());
+        // SAFETY: the caller guarantees that both native handles outlive the
+        // returned context and its surface.
+        let surface = unsafe {
+            instance.create_surface_unsafe(raw::SurfaceTargetUnsafe::RawHandle {
+                raw_display_handle,
+                raw_window_handle,
+            })
+        }
+        .map_err(|_| Error::SurfaceCreation)?;
+        let adapter = pollster::block_on(instance.request_adapter(&raw::RequestAdapterOptions {
+            power_preference: raw::PowerPreference::HighPerformance,
+            force_fallback_adapter: false,
+            compatible_surface: Some(&surface),
+        }))
+        .ok_or(Error::AdapterUnavailable)?;
+        let (device, queue) = pollster::block_on(async {
+            adapter
+                .request_device(&raw::DeviceDescriptor::default(), None)
+                .await
+        })
+        .map_err(|_| Error::DeviceRequest)?;
+        device.on_uncaptured_error(Box::new(|error| {
+            eprintln!("[SGFX/WGPU] uncaptured error: {error}");
+        }));
+        let capabilities = surface.get_capabilities(&adapter);
+        let format = select_surface_format(&capabilities.formats).ok_or(Error::SurfaceCreation)?;
+        let alpha_mode = capabilities
+            .alpha_modes
+            .first()
+            .copied()
+            .ok_or(Error::SurfaceCreation)?;
+        let config = raw::SurfaceConfiguration {
+            usage: raw::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width: width.max(1),
+            height: height.max(1),
+            present_mode: raw::PresentMode::AutoVsync,
+            desired_maximum_frame_latency: 2,
+            alpha_mode,
+            view_formats: Vec::new(),
+        };
+        let device = Device::new(device, queue);
+        let context = device.create_context();
+        surface.configure(context.raw_device(), &config);
+        let sampler = context
+            .raw_device()
+            .create_sampler(&raw::SamplerDescriptor {
+                label: Some("sgfx WGPU presentation sampler"),
+                address_mode_u: raw::AddressMode::ClampToEdge,
+                address_mode_v: raw::AddressMode::ClampToEdge,
+                address_mode_w: raw::AddressMode::ClampToEdge,
+                mag_filter: raw::FilterMode::Nearest,
+                min_filter: raw::FilterMode::Nearest,
+                mipmap_filter: raw::FilterMode::Nearest,
+                ..Default::default()
+            });
+        let blit_pipeline = create_blit_pipeline(context.raw_device(), config.format);
+        Ok(Self {
+            surface,
+            config,
+            context,
+            sampler,
+            blit_pipeline,
+            _instance: instance,
+        })
+    }
+
+    /// Create mapped physical targets through this surface-compatible device.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Logical SGFX resource table.
+    /// * `targets` - Presentation texture identities to materialize.
+    ///
+    /// # Returns
+    ///
+    /// A mapped session sharing the window context's WGPU device.
+    pub fn create_mapped_target_session(
+        &self,
+        resources: Rc<ResourceTable>,
+        targets: &[TextureId],
+    ) -> Result<MappedTargetSession> {
+        self.context
+            .create_mapped_target_session(resources, targets)
+    }
+
+    /// Reconfigure the native surface after a physical resize.
+    ///
+    /// # Arguments
+    ///
+    /// * `width` - New physical width.
+    /// * `height` - New physical height.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        self.config.width = width.max(1);
+        self.config.height = height.max(1);
+        self.surface
+            .configure(self.context.raw_device(), &self.config);
+    }
+
+    /// Present one mapped SGFX target to the native window surface.
+    ///
+    /// # Arguments
+    ///
+    /// * `session` - Session owning the target image.
+    /// * `target` - Logical target texture to present.
+    ///
+    /// # Returns
+    ///
+    /// Success after the surface frame is submitted and presented.
+    pub fn present(&mut self, session: &MappedTargetSession, target: TextureId) -> Result<()> {
+        let image = session.image(target)?;
+        let frame = self
+            .surface
+            .get_current_texture()
+            .map_err(|_| Error::SurfaceAcquire)?;
+        let view = frame
+            .texture
+            .create_view(&raw::TextureViewDescriptor::default());
+        let bind_group = self
+            .context
+            .raw_device()
+            .create_bind_group(&raw::BindGroupDescriptor {
+                label: Some("sgfx WGPU presentation bind group"),
+                layout: &self.blit_pipeline.get_bind_group_layout(0),
+                entries: &[
+                    raw::BindGroupEntry {
+                        binding: 0,
+                        resource: raw::BindingResource::TextureView(image.raw_view()),
+                    },
+                    raw::BindGroupEntry {
+                        binding: 1,
+                        resource: raw::BindingResource::Sampler(&self.sampler),
+                    },
+                ],
+            });
+        let mut encoder =
+            self.context
+                .raw_device()
+                .create_command_encoder(&raw::CommandEncoderDescriptor {
+                    label: Some("sgfx WGPU presentation encoder"),
+                });
+        {
+            let mut pass = encoder.begin_render_pass(&raw::RenderPassDescriptor {
+                label: Some("sgfx WGPU presentation pass"),
+                color_attachments: &[Some(raw::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: raw::Operations {
+                        load: raw::LoadOp::Clear(raw::Color::BLACK),
+                        store: raw::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&self.blit_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+        self.context
+            .raw_queue()
+            .submit(core::iter::once(encoder.finish()));
+        frame.present();
+        let _ = self.context.raw_device().poll(raw::Maintain::Poll);
+        Ok(())
     }
 }
 
@@ -1273,6 +1493,85 @@ fn raw_format(format: TextureFormat) -> Option<raw::TextureFormat> {
     }
 }
 
+fn select_surface_format(formats: &[raw::TextureFormat]) -> Option<raw::TextureFormat> {
+    formats
+        .iter()
+        .copied()
+        .find(|format| {
+            matches!(
+                format,
+                raw::TextureFormat::Bgra8Unorm | raw::TextureFormat::Rgba8Unorm
+            )
+        })
+        .or_else(|| formats.iter().copied().find(|format| !format.is_srgb()))
+        .or_else(|| formats.first().copied())
+}
+
+fn create_blit_pipeline(device: &raw::Device, format: raw::TextureFormat) -> raw::RenderPipeline {
+    let shader = device.create_shader_module(raw::ShaderModuleDescriptor {
+        label: Some("sgfx WGPU presentation shader"),
+        source: raw::ShaderSource::Wgsl(BLIT_SHADER.into()),
+    });
+    device.create_render_pipeline(&raw::RenderPipelineDescriptor {
+        label: Some("sgfx WGPU presentation pipeline"),
+        layout: None,
+        vertex: raw::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            compilation_options: Default::default(),
+            buffers: &[],
+        },
+        fragment: Some(raw::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            compilation_options: Default::default(),
+            targets: &[Some(raw::ColorTargetState {
+                format,
+                blend: Some(raw::BlendState::REPLACE),
+                write_mask: raw::ColorWrites::ALL,
+            })],
+        }),
+        primitive: raw::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: raw::MultisampleState::default(),
+        multiview: None,
+        cache: None,
+    })
+}
+
+const BLIT_SHADER: &str = r#"
+struct VertexOut {
+    @builtin(position) position: vec4f,
+    @location(0) uv: vec2f,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vid: u32) -> VertexOut {
+    var positions = array<vec2f, 3>(
+        vec2f(-1.0, -1.0),
+        vec2f( 3.0, -1.0),
+        vec2f(-1.0,  3.0),
+    );
+    var uvs = array<vec2f, 3>(
+        vec2f(0.0, 1.0),
+        vec2f(2.0, 1.0),
+        vec2f(0.0, -1.0),
+    );
+    var out: VertexOut;
+    out.position = vec4f(positions[vid], 0.0, 1.0);
+    out.uv = uvs[vid];
+    return out;
+}
+
+@group(0) @binding(0) var t_frame: texture_2d<f32>;
+@group(0) @binding(1) var s_frame: sampler;
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4f {
+    return textureSample(t_frame, s_frame, in.uv);
+}
+"#;
+
 #[cfg(test)]
 fn logical_format(format: raw::TextureFormat) -> Option<TextureFormat> {
     match format {
@@ -1828,6 +2127,25 @@ mod tests {
         FilterMode, PixelRect, PrimitiveTopology, RasterState, RenderPassDesc, SamplerDesc,
         StoreOp, TextureWrite, Transform, VertexBufferLayout,
     };
+
+    #[test]
+    fn surface_prefers_display_ready_unorm() {
+        assert_eq!(
+            select_surface_format(&[
+                raw::TextureFormat::Bgra8UnormSrgb,
+                raw::TextureFormat::Bgra8Unorm,
+            ]),
+            Some(raw::TextureFormat::Bgra8Unorm)
+        );
+    }
+
+    #[test]
+    fn surface_uses_srgb_when_it_is_the_only_choice() {
+        assert_eq!(
+            select_surface_format(&[raw::TextureFormat::Bgra8UnormSrgb]),
+            Some(raw::TextureFormat::Bgra8UnormSrgb)
+        );
+    }
 
     fn pipeline(fragment: FragmentProgram) -> RenderPipelineDesc {
         RenderPipelineDesc::new(

--- a/user/lib/sgfx-compat/Cargo.lock
+++ b/user/lib/sgfx-compat/Cargo.lock
@@ -105,14 +105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sgfx"
-version = "0.16.0"
-dependencies = [
- "framebuffer",
- "sgfx-backend-scarlet-virgl",
-]
-
-[[package]]
 name = "sgfx-backend-scarlet-virgl"
 version = "0.16.0"
 dependencies = [
@@ -128,6 +120,14 @@ name = "sgfx-codegen-virgl"
 version = "0.16.0"
 dependencies = [
  "sgfx-core",
+]
+
+[[package]]
+name = "sgfx-compat-scarlet"
+version = "0.16.0"
+dependencies = [
+ "framebuffer",
+ "sgfx-backend-scarlet-virgl",
 ]
 
 [[package]]

--- a/user/lib/sgfx-compat/Cargo.toml
+++ b/user/lib/sgfx-compat/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sgfx"
+name = "sgfx-compat-scarlet"
 version = "0.16.0"
 edition = "2024"
 
@@ -13,5 +13,5 @@ framebuffer = { path = "../framebuffer", default-features = false }
 sgfx-backend-scarlet-virgl = { path = "../sgfx-backend-scarlet-virgl", default-features = false }
 
 [lib]
-name = "sgfx"
+name = "sgfx_compat_scarlet"
 path = "src/lib.rs"

--- a/user/lib/sgfx-compat/src/lib.rs
+++ b/user/lib/sgfx-compat/src/lib.rs
@@ -1,57 +1,12 @@
-//! Scarlet composition facade for SGFX applications and platform integrations.
+//! Legacy compatibility facade for existing Scarlet SGFX applications.
 //!
-//! This environment-level crate owns concrete backend composition for Scarlet.
-//! Complete backend crates validate, lower, budget, and submit SGFX IR for one
-//! execution contract; consumers use this facade without naming that backend.
-//!
-//! The current Scarlet binding is VirGL. A future AGX backend belongs here as
-//! another facade-selected implementation, not inside the VirGL backend.
+//! New applications and platform composition roots should use the
+//! cross-platform `sgfx` frontend. This crate temporarily preserves the former
+//! Scarlet/VirGL immediate-mode surface while remaining explicitly legacy.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use sgfx_backend_scarlet_virgl::{
-    Capabilities, Color, CompositionPass, Context, CullMode, Executor, FrontFace, Handle,
-    HandleError, HandleResult, Image, IrResources, IrSubmitError, MAX_COMPOSITION_OPERATIONS,
-    MappedTargetSession, Pipeline, PipelineDesc, PipelineKind, PixelRect, Queue, RenderPass,
-    SourceAlpha, Texture, UnsupportedIrFeature, VertexClip4Color3, Viewport, ir,
-};
-
-/// Scarlet graphics device selected by the SGFX environment facade.
-pub struct Device {
-    backend: sgfx_backend_scarlet_virgl::Device,
-}
-
-impl Device {
-    /// Open a Scarlet graphics device through a compatible complete SGFX backend.
-    ///
-    /// The facade owns which complete backend implementation is compiled and
-    /// exposed. The selected backend remains responsible for validating that
-    /// the device matches its own execution contract.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Device path such as `/dev/gpu0`.
-    ///
-    /// # Returns
-    ///
-    /// An opened facade device or a handle error when the selected backend does
-    /// not accept the device.
-    pub fn open(path: &str) -> HandleResult<Self> {
-        Ok(Self {
-            backend: sgfx_backend_scarlet_virgl::Device::open(path)?,
-        })
-    }
-
-    /// Return the application-level capabilities of the selected backend.
-    pub fn capabilities(&self) -> Capabilities {
-        self.backend.capabilities()
-    }
-
-    /// Create a graphics context through the selected backend.
-    pub fn create_context(&self) -> HandleResult<Context> {
-        self.backend.create_context()
-    }
-}
+pub use sgfx_backend_scarlet_virgl::*;
 
 /// Compatibility presentation extension for direct Scarlet framebuffer apps.
 ///

--- a/user/lib/sgfx-compat/src/lib.rs
+++ b/user/lib/sgfx-compat/src/lib.rs
@@ -1,13 +1,57 @@
 //! Scarlet composition facade for SGFX applications and platform integrations.
 //!
-//! This environment-level crate selects and reexports the complete Scarlet
-//! execution backend, allowing consumers such as `platform-sws` to own SGFX
-//! sessions without naming a VirGL implementation dependency. Cross-platform
-//! renderers should depend only on `sgfx-core` and its backend contract.
+//! This environment-level crate owns concrete backend composition for Scarlet.
+//! Complete backend crates validate, lower, budget, and submit SGFX IR for one
+//! execution contract; consumers use this facade without naming that backend.
+//!
+//! The current Scarlet binding is VirGL. A future AGX backend belongs here as
+//! another facade-selected implementation, not inside the VirGL backend.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use sgfx_backend_scarlet_virgl::*;
+pub use sgfx_backend_scarlet_virgl::{
+    Capabilities, Color, CompositionPass, Context, CullMode, Executor, FrontFace, Handle,
+    HandleError, HandleResult, Image, IrResources, IrSubmitError, MAX_COMPOSITION_OPERATIONS,
+    MappedTargetSession, Pipeline, PipelineDesc, PipelineKind, PixelRect, Queue, RenderPass,
+    SourceAlpha, Texture, UnsupportedIrFeature, VertexClip4Color3, Viewport, ir,
+};
+
+/// Scarlet graphics device selected by the SGFX environment facade.
+pub struct Device {
+    backend: sgfx_backend_scarlet_virgl::Device,
+}
+
+impl Device {
+    /// Open a Scarlet graphics device through a compatible complete SGFX backend.
+    ///
+    /// The facade owns which complete backend implementation is compiled and
+    /// exposed. The selected backend remains responsible for validating that
+    /// the device matches its own execution contract.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Device path such as `/dev/gpu0`.
+    ///
+    /// # Returns
+    ///
+    /// An opened facade device or a handle error when the selected backend does
+    /// not accept the device.
+    pub fn open(path: &str) -> HandleResult<Self> {
+        Ok(Self {
+            backend: sgfx_backend_scarlet_virgl::Device::open(path)?,
+        })
+    }
+
+    /// Return the application-level capabilities of the selected backend.
+    pub fn capabilities(&self) -> Capabilities {
+        self.backend.capabilities()
+    }
+
+    /// Create a graphics context through the selected backend.
+    pub fn create_context(&self) -> HandleResult<Context> {
+        self.backend.create_context()
+    }
+}
 
 /// Compatibility presentation extension for direct Scarlet framebuffer apps.
 ///

--- a/user/lib/sgfx-frontend/Cargo.lock
+++ b/user/lib/sgfx-frontend/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,11 +305,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-raw"
+version = "0.16.0"
+dependencies = [
+ "scarlet-os",
+ "scarlet-std",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -633,6 +649,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "scarlet-abi"
+version = "0.16.0"
+
+[[package]]
+name = "scarlet-os"
+version = "0.16.0"
+dependencies = [
+ "scarlet-abi",
+ "scarlet-rt",
+ "scarlet-sys",
+]
+
+[[package]]
+name = "scarlet-rt"
+version = "0.16.0"
+dependencies = [
+ "lock_api",
+ "scarlet-sys",
+ "spin",
+ "talc",
+]
+
+[[package]]
+name = "scarlet-std"
+version = "0.16.0"
+dependencies = [
+ "hashbrown 0.15.5",
+ "scarlet-abi",
+ "scarlet-os",
+ "scarlet-rt",
+ "scarlet-sys",
+ "spin",
+]
+
+[[package]]
+name = "scarlet-sys"
+version = "0.16.0"
+dependencies = [
+ "scarlet-abi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +717,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sgfx"
+version = "0.16.0"
+dependencies = [
+ "raw-window-handle",
+ "scarlet-std",
+ "sgfx-backend-scarlet-virgl",
+ "sgfx-backend-wgpu",
+ "sgfx-core",
+]
+
+[[package]]
+name = "sgfx-backend-scarlet-virgl"
+version = "0.16.0"
+dependencies = [
+ "gpu-raw",
+ "scarlet-os",
+ "scarlet-std",
+ "sgfx-codegen-virgl",
+ "sgfx-core",
+]
+
+[[package]]
 name = "sgfx-backend-wgpu"
 version = "0.16.0"
 dependencies = [
@@ -667,6 +747,13 @@ dependencies = [
  "raw-window-handle",
  "sgfx-core",
  "wgpu",
+]
+
+[[package]]
+name = "sgfx-codegen-virgl"
+version = "0.16.0"
+dependencies = [
+ "sgfx-core",
 ]
 
 [[package]]
@@ -693,6 +780,15 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spirv"
@@ -751,6 +847,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "talc"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/user/lib/sgfx-frontend/Cargo.toml
+++ b/user/lib/sgfx-frontend/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "sgfx"
+version = "0.16.0"
+edition = "2024"
+
+[features]
+default = ["std", "backend-wgpu", "backend-scarlet-virgl"]
+std = ["sgfx-backend-scarlet-virgl?/std"]
+legacy-scarlet-std = [
+    "dep:scarlet-std",
+    "sgfx-backend-scarlet-virgl?/scarlet-std",
+]
+# Compatibility alias for consumers that previously selected Scarlet's
+# no_std support directly on the `sgfx` package.
+scarlet-std = ["legacy-scarlet-std"]
+backend-wgpu = ["dep:raw-window-handle", "dep:sgfx-backend-wgpu"]
+backend-scarlet-virgl = ["dep:sgfx-backend-scarlet-virgl"]
+
+[dependencies]
+sgfx-core = { path = "../sgfx", default-features = false }
+
+[target.'cfg(not(target_os = "scarlet"))'.dependencies]
+raw-window-handle = { version = "0.6", optional = true }
+sgfx-backend-wgpu = { path = "../sgfx-backend-wgpu", optional = true }
+
+[target.'cfg(target_os = "scarlet")'.dependencies]
+scarlet-std = { path = "../std", optional = true }
+sgfx-backend-scarlet-virgl = { path = "../sgfx-backend-scarlet-virgl", default-features = false, optional = true }
+
+[lib]
+name = "sgfx"
+path = "src/lib.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("scarlet"))'] }

--- a/user/lib/sgfx-frontend/src/host.rs
+++ b/user/lib/sgfx-frontend/src/host.rs
@@ -1,0 +1,145 @@
+//! Window-surface integration for host SGFX backends.
+
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
+use sgfx_core::backend::CommandExecutor;
+
+use crate::{BackendKind, Error, Instance, Result, ir};
+
+/// Selected host window context and presentation surface.
+pub struct WindowContext {
+    backend: sgfx_backend_wgpu::WindowContext,
+}
+
+impl WindowContext {
+    /// Create mapped physical targets for one logical resource table.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Logical SGFX resource table.
+    /// * `targets` - Presentation texture identities to materialize.
+    ///
+    /// # Returns
+    ///
+    /// A backend-owned mapped target session.
+    pub fn create_mapped_target_session(
+        &self,
+        resources: alloc::rc::Rc<ir::ResourceTable>,
+        targets: &[ir::TextureId],
+    ) -> Result<MappedTargetSession> {
+        self.backend
+            .create_mapped_target_session(resources, targets)
+            .map(|backend| MappedTargetSession { backend })
+            .map_err(Error::Wgpu)
+    }
+
+    /// Reconfigure the presentation surface after a physical resize.
+    ///
+    /// # Arguments
+    ///
+    /// * `width` - New non-zero physical width.
+    /// * `height` - New non-zero physical height.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        self.backend.resize(width, height);
+    }
+
+    /// Present one mapped target through the selected host backend.
+    ///
+    /// # Arguments
+    ///
+    /// * `session` - Session that owns the mapped image.
+    /// * `target` - Logical texture identity to present.
+    ///
+    /// # Returns
+    ///
+    /// Success after queuing and presenting the surface frame.
+    pub fn present(&mut self, session: &MappedTargetSession, target: ir::TextureId) -> Result<()> {
+        self.backend
+            .present(&session.backend, target)
+            .map_err(Error::Wgpu)
+    }
+
+    /// Return whether the selected backend supports depth attachments.
+    ///
+    /// # Returns
+    ///
+    /// `true` when depth-enabled SGFX canvas passes are available.
+    pub const fn supports_depth(&self) -> bool {
+        true
+    }
+}
+
+impl Instance {
+    /// Create a host presentation context from borrowed native window handles.
+    ///
+    /// # Arguments
+    ///
+    /// * `raw_display_handle` - Display handle retained by the platform window.
+    /// * `raw_window_handle` - Window handle retained by the platform window.
+    /// * `width` - Initial physical surface width.
+    /// * `height` - Initial physical surface height.
+    ///
+    /// # Returns
+    ///
+    /// A selected SGFX host window context.
+    ///
+    /// # Safety
+    ///
+    /// Both raw handles must remain valid until the returned context is
+    /// dropped. The platform must therefore drop its SGFX renderer before the
+    /// native window and display objects.
+    pub unsafe fn create_window_context(
+        &self,
+        raw_display_handle: RawDisplayHandle,
+        raw_window_handle: RawWindowHandle,
+        width: u32,
+        height: u32,
+    ) -> Result<WindowContext> {
+        match self.backend() {
+            BackendKind::Wgpu => {
+                // SAFETY: the caller upholds the raw-handle lifetime contract.
+                unsafe {
+                    sgfx_backend_wgpu::WindowContext::new(
+                        raw_display_handle,
+                        raw_window_handle,
+                        width,
+                        height,
+                    )
+                }
+                .map(|backend| WindowContext { backend })
+                .map_err(Error::Wgpu)
+            }
+            backend => Err(Error::BackendUnavailable(backend)),
+        }
+    }
+}
+
+/// Backend-owned host mapped-target session.
+pub struct MappedTargetSession {
+    backend: sgfx_backend_wgpu::MappedTargetSession,
+}
+
+impl MappedTargetSession {
+    /// Bind the selected backend queue and resources for command execution.
+    ///
+    /// # Returns
+    ///
+    /// A frontend executor delegating complete command buffers to WGPU.
+    pub fn executor(&mut self) -> Executor<'_> {
+        Executor {
+            backend: self.backend.executor(),
+        }
+    }
+}
+
+/// Host command executor selected by the SGFX frontend.
+pub struct Executor<'a> {
+    backend: sgfx_backend_wgpu::Executor<'a>,
+}
+
+impl CommandExecutor for Executor<'_> {
+    type Error = Error;
+
+    fn execute<'r, 'data>(&mut self, commands: &ir::CommandBuffer<'r, 'data>) -> Result<()> {
+        self.backend.execute(commands).map_err(Error::Wgpu)
+    }
+}

--- a/user/lib/sgfx-frontend/src/lib.rs
+++ b/user/lib/sgfx-frontend/src/lib.rs
@@ -1,0 +1,314 @@
+//! Cross-platform SGFX frontend and execution-backend selector.
+//!
+//! Portable renderers record resources and command buffers through
+//! [`sgfx_core`]. Applications and platform composition roots use this crate
+//! to select one complete execution backend. A selected backend continues to
+//! own physical resources, command lowering, transport limits, and submission.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+#[cfg(all(
+    not(feature = "std"),
+    target_os = "scarlet",
+    feature = "legacy-scarlet-std"
+))]
+extern crate scarlet_std as std;
+
+use core::fmt;
+
+pub use sgfx_core::{backend, ir};
+
+#[cfg(all(not(target_os = "scarlet"), feature = "backend-wgpu"))]
+mod host;
+#[cfg(all(target_os = "scarlet", feature = "backend-scarlet-virgl"))]
+mod scarlet;
+
+#[cfg(all(not(target_os = "scarlet"), feature = "backend-wgpu"))]
+pub use host::{Executor, MappedTargetSession, WindowContext};
+#[cfg(all(target_os = "scarlet", feature = "backend-scarlet-virgl"))]
+pub use scarlet::{Capabilities, Context, Device, Executor, Handle, ImageRef, MappedTargetSession};
+
+/// Environment variable used to override automatic SGFX backend selection.
+pub const BACKEND_ENV: &str = "SGFX_BACKEND";
+
+/// A complete execution backend that may be selected by the SGFX frontend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BackendKind {
+    /// SGFX execution through WGPU.
+    Wgpu,
+    /// Direct SGFX execution through Metal.
+    Metal,
+    /// SGFX VirGL execution through the Scarlet GPU ABI.
+    ScarletVirgl,
+    /// SGFX AGX execution through the Scarlet GPU ABI.
+    ScarletAgx,
+}
+
+impl BackendKind {
+    /// Return the stable configuration name for this backend.
+    ///
+    /// # Returns
+    ///
+    /// A value accepted by [`BACKEND_ENV`].
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Wgpu => "wgpu",
+            Self::Metal => "metal",
+            Self::ScarletVirgl => "scarlet-virgl",
+            Self::ScarletAgx => "scarlet-agx",
+        }
+    }
+}
+
+impl fmt::Display for BackendKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Backend selection requested by an application or the process environment.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BackendPreference {
+    /// Select the best compiled backend for the active target and device.
+    #[default]
+    Auto,
+    /// Require WGPU execution.
+    Wgpu,
+    /// Require direct Metal execution.
+    Metal,
+    /// Require Scarlet/VirGL execution.
+    ScarletVirgl,
+    /// Require Scarlet/AGX execution.
+    ScarletAgx,
+}
+
+impl BackendPreference {
+    /// Parse one backend preference name.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - `auto` or one stable [`BackendKind`] name.
+    ///
+    /// # Returns
+    ///
+    /// The parsed preference, or [`Error::InvalidBackendPreference`].
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "auto" => Ok(Self::Auto),
+            "wgpu" => Ok(Self::Wgpu),
+            "metal" => Ok(Self::Metal),
+            "scarlet-virgl" | "virgl" => Ok(Self::ScarletVirgl),
+            "scarlet-agx" | "agx" => Ok(Self::ScarletAgx),
+            _ => Err(Error::InvalidBackendPreference),
+        }
+    }
+
+    /// Read the process backend preference.
+    ///
+    /// # Returns
+    ///
+    /// The parsed [`BACKEND_ENV`] value, or [`BackendPreference::Auto`] when
+    /// the variable is absent.
+    pub fn from_environment() -> Result<Self> {
+        match backend_environment_value() {
+            Some(value) => Self::parse(value.as_str()),
+            None => Ok(Self::Auto),
+        }
+    }
+}
+
+/// Failure returned by the cross-platform SGFX frontend.
+#[derive(Debug)]
+pub enum Error {
+    /// The requested backend name is invalid.
+    InvalidBackendPreference,
+    /// The requested backend was not compiled for this target.
+    BackendUnavailable(BackendKind),
+    /// WGPU initialization, materialization, execution, or presentation failed.
+    #[cfg(all(not(target_os = "scarlet"), feature = "backend-wgpu"))]
+    Wgpu(sgfx_backend_wgpu::Error),
+    /// A Scarlet/VirGL device or context operation failed.
+    #[cfg(all(target_os = "scarlet", feature = "backend-scarlet-virgl"))]
+    ScarletVirglHandle(sgfx_backend_scarlet_virgl::HandleError),
+    /// A Scarlet/VirGL IR materialization or execution operation failed.
+    #[cfg(all(target_os = "scarlet", feature = "backend-scarlet-virgl"))]
+    ScarletVirglIr(sgfx_backend_scarlet_virgl::IrSubmitError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidBackendPreference => {
+                formatter.write_str("invalid SGFX backend preference")
+            }
+            Self::BackendUnavailable(backend) => {
+                write!(formatter, "SGFX backend {backend} is unavailable")
+            }
+            #[cfg(all(not(target_os = "scarlet"), feature = "backend-wgpu"))]
+            Self::Wgpu(error) => write!(formatter, "SGFX WGPU backend failed: {error}"),
+            #[cfg(all(target_os = "scarlet", feature = "backend-scarlet-virgl"))]
+            Self::ScarletVirglHandle(error) => {
+                write!(formatter, "SGFX Scarlet/VirGL device failed: {error:?}")
+            }
+            #[cfg(all(target_os = "scarlet", feature = "backend-scarlet-virgl"))]
+            Self::ScarletVirglIr(error) => {
+                write!(formatter, "SGFX Scarlet/VirGL execution failed: {error:?}")
+            }
+        }
+    }
+}
+
+/// Result returned by the SGFX frontend.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Selected SGFX execution environment.
+pub struct Instance {
+    backend: BackendKind,
+}
+
+impl Instance {
+    /// Select an SGFX backend using [`BACKEND_ENV`] and target defaults.
+    ///
+    /// # Returns
+    ///
+    /// A selected instance, or a configuration error.
+    pub fn new() -> Result<Self> {
+        Self::with_preference(BackendPreference::from_environment()?)
+    }
+
+    /// Select an SGFX backend from an explicit preference.
+    ///
+    /// # Arguments
+    ///
+    /// * `preference` - Automatic or required backend selection.
+    ///
+    /// # Returns
+    ///
+    /// A selected instance, or [`Error::BackendUnavailable`].
+    pub fn with_preference(preference: BackendPreference) -> Result<Self> {
+        Ok(Self {
+            backend: resolve_backend(preference)?,
+        })
+    }
+
+    /// Return the selected complete backend.
+    ///
+    /// # Returns
+    ///
+    /// The stable selected backend identity.
+    pub const fn backend(&self) -> BackendKind {
+        self.backend
+    }
+}
+
+fn resolve_backend(preference: BackendPreference) -> Result<BackendKind> {
+    match preference {
+        BackendPreference::Auto => default_backend(),
+        BackendPreference::Wgpu => require_backend(BackendKind::Wgpu),
+        BackendPreference::Metal => require_backend(BackendKind::Metal),
+        BackendPreference::ScarletVirgl => require_backend(BackendKind::ScarletVirgl),
+        BackendPreference::ScarletAgx => require_backend(BackendKind::ScarletAgx),
+    }
+}
+
+fn default_backend() -> Result<BackendKind> {
+    #[cfg(all(target_os = "scarlet", feature = "backend-scarlet-virgl"))]
+    {
+        return Ok(BackendKind::ScarletVirgl);
+    }
+    #[cfg(all(not(target_os = "scarlet"), feature = "backend-wgpu"))]
+    {
+        return Ok(BackendKind::Wgpu);
+    }
+    #[allow(unreachable_code)]
+    Err(Error::BackendUnavailable(default_backend_kind()))
+}
+
+const fn default_backend_kind() -> BackendKind {
+    if cfg!(target_os = "scarlet") {
+        BackendKind::ScarletVirgl
+    } else {
+        BackendKind::Wgpu
+    }
+}
+
+fn require_backend(backend: BackendKind) -> Result<BackendKind> {
+    let available = match backend {
+        BackendKind::Wgpu => cfg!(all(not(target_os = "scarlet"), feature = "backend-wgpu")),
+        BackendKind::Metal => false,
+        BackendKind::ScarletVirgl => cfg!(all(
+            target_os = "scarlet",
+            feature = "backend-scarlet-virgl"
+        )),
+        BackendKind::ScarletAgx => false,
+    };
+    if available {
+        Ok(backend)
+    } else {
+        Err(Error::BackendUnavailable(backend))
+    }
+}
+
+#[cfg(feature = "std")]
+fn backend_environment_value() -> Option<std::string::String> {
+    std::env::var(BACKEND_ENV).ok()
+}
+
+#[cfg(all(
+    not(feature = "std"),
+    target_os = "scarlet",
+    feature = "legacy-scarlet-std"
+))]
+fn backend_environment_value() -> Option<std::string::String> {
+    std::env::var(BACKEND_ENV)
+}
+
+#[cfg(not(any(
+    feature = "std",
+    all(target_os = "scarlet", feature = "legacy-scarlet-std")
+)))]
+fn backend_environment_value() -> Option<alloc::string::String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackendKind, BackendPreference, Error, Instance};
+
+    #[test]
+    fn parses_stable_backend_names() {
+        assert_eq!(
+            BackendPreference::parse("wgpu").unwrap(),
+            BackendPreference::Wgpu
+        );
+        assert_eq!(
+            BackendPreference::parse("virgl").unwrap(),
+            BackendPreference::ScarletVirgl
+        );
+        assert!(matches!(
+            BackendPreference::parse("unknown"),
+            Err(Error::InvalidBackendPreference)
+        ));
+    }
+
+    #[test]
+    fn host_auto_selects_wgpu() {
+        #[cfg(not(target_os = "scarlet"))]
+        assert_eq!(
+            Instance::with_preference(BackendPreference::Auto)
+                .unwrap()
+                .backend(),
+            BackendKind::Wgpu
+        );
+    }
+
+    #[test]
+    fn unavailable_backend_is_not_silently_substituted() {
+        assert!(matches!(
+            Instance::with_preference(BackendPreference::Metal),
+            Err(Error::BackendUnavailable(BackendKind::Metal))
+        ));
+    }
+}

--- a/user/lib/sgfx-frontend/src/scarlet.rs
+++ b/user/lib/sgfx-frontend/src/scarlet.rs
@@ -1,0 +1,243 @@
+//! Scarlet device and mapped-target integration for the SGFX frontend.
+
+use alloc::rc::Rc;
+use sgfx_core::backend::CommandExecutor;
+
+use crate::{BackendKind, Error, Instance, Result, ir};
+
+pub use sgfx_backend_scarlet_virgl::Handle;
+
+/// Backend-neutral Scarlet rendering capabilities.
+#[derive(Clone, Copy, Debug)]
+pub struct Capabilities {
+    rendering: bool,
+    presentation: bool,
+    image_upload: bool,
+    depth: bool,
+}
+
+impl Capabilities {
+    /// Return whether SGFX command execution is available.
+    ///
+    /// # Returns
+    ///
+    /// `true` when rendering is supported.
+    pub const fn supports_rendering(&self) -> bool {
+        self.rendering
+    }
+
+    /// Return whether mapped images may be presented.
+    ///
+    /// # Returns
+    ///
+    /// `true` when presentation is supported.
+    pub const fn supports_presentation(&self) -> bool {
+        self.presentation
+    }
+
+    /// Return whether sampled image upload is available.
+    ///
+    /// # Returns
+    ///
+    /// `true` when image upload is supported.
+    pub const fn supports_image_upload(&self) -> bool {
+        self.image_upload
+    }
+
+    /// Return whether depth attachments are available.
+    ///
+    /// # Returns
+    ///
+    /// `true` when depth-enabled passes are supported.
+    pub const fn supports_depth(&self) -> bool {
+        self.depth
+    }
+}
+
+/// Scarlet graphics device selected by the SGFX frontend.
+pub struct Device {
+    backend: sgfx_backend_scarlet_virgl::Device,
+}
+
+impl Device {
+    /// Open a Scarlet device using process backend selection policy.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Scarlet GPU device path.
+    ///
+    /// # Returns
+    ///
+    /// A selected device or frontend/backend error.
+    pub fn open(path: &str) -> Result<Self> {
+        Instance::new()?.open_device(path)
+    }
+
+    /// Return the complete backend selected for this device.
+    ///
+    /// # Returns
+    ///
+    /// The stable Scarlet backend identity.
+    pub const fn backend(&self) -> BackendKind {
+        BackendKind::ScarletVirgl
+    }
+
+    /// Return portable capabilities for the selected Scarlet backend.
+    ///
+    /// # Returns
+    ///
+    /// Backend-neutral rendering capabilities.
+    pub fn capabilities(&self) -> Capabilities {
+        let capabilities = self.backend.capabilities();
+        Capabilities {
+            rendering: capabilities.supports_rendering(),
+            presentation: capabilities.supports_presentation(),
+            image_upload: capabilities.supports_image_upload(),
+            depth: capabilities.supports_depth(),
+        }
+    }
+
+    /// Create a context through the selected backend.
+    ///
+    /// # Returns
+    ///
+    /// A frontend context or device error.
+    pub fn create_context(&self) -> Result<Context> {
+        self.backend
+            .create_context()
+            .map(|backend| Context { backend })
+            .map_err(Error::ScarletVirglHandle)
+    }
+}
+
+impl Instance {
+    /// Open a Scarlet graphics device through the selected backend.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Scarlet GPU device path.
+    ///
+    /// # Returns
+    ///
+    /// A frontend device or backend error.
+    pub fn open_device(&self, path: &str) -> Result<Device> {
+        match self.backend() {
+            BackendKind::ScarletVirgl => sgfx_backend_scarlet_virgl::Device::open(path)
+                .map(|backend| Device { backend })
+                .map_err(Error::ScarletVirglHandle),
+            backend => Err(Error::BackendUnavailable(backend)),
+        }
+    }
+}
+
+/// Scarlet context selected by the SGFX frontend.
+pub struct Context {
+    backend: sgfx_backend_scarlet_virgl::Context,
+}
+
+impl Context {
+    /// Create and map physical images for logical presentation targets.
+    ///
+    /// # Arguments
+    ///
+    /// * `resources` - Logical SGFX resource table.
+    /// * `targets` - Presentation texture identities to materialize.
+    ///
+    /// # Returns
+    ///
+    /// A backend-owned mapped session or execution error.
+    pub fn create_mapped_target_session(
+        &self,
+        resources: Rc<ir::ResourceTable>,
+        targets: &[ir::TextureId],
+    ) -> Result<MappedTargetSession> {
+        self.backend
+            .create_mapped_target_session(resources, targets)
+            .map(|backend| MappedTargetSession { backend })
+            .map_err(Error::ScarletVirglIr)
+    }
+}
+
+/// Scarlet mapped-target session selected by the SGFX frontend.
+pub struct MappedTargetSession {
+    backend: sgfx_backend_scarlet_virgl::MappedTargetSession,
+}
+
+impl MappedTargetSession {
+    /// Borrow a mapped presentation image without exposing its backend type.
+    ///
+    /// # Arguments
+    ///
+    /// * `target` - Logical presentation texture identity.
+    ///
+    /// # Returns
+    ///
+    /// A borrowed image view or mapping error.
+    pub fn image(&self, target: ir::TextureId) -> Result<ImageRef<'_>> {
+        self.backend
+            .image(target)
+            .map(|backend| ImageRef { backend })
+            .map_err(Error::ScarletVirglIr)
+    }
+
+    /// Bind the selected backend queue and resources for command execution.
+    ///
+    /// # Returns
+    ///
+    /// A frontend executor delegating complete command buffers to VirGL.
+    pub fn executor(&mut self) -> Executor<'_> {
+        Executor {
+            backend: self.backend.executor(),
+        }
+    }
+}
+
+/// Borrowed Scarlet presentation image exposed by the SGFX frontend.
+#[derive(Clone, Copy)]
+pub struct ImageRef<'a> {
+    backend: &'a sgfx_backend_scarlet_virgl::Image,
+}
+
+impl ImageRef<'_> {
+    /// Return the image width in pixels.
+    ///
+    /// # Returns
+    ///
+    /// Physical image width.
+    pub fn width(&self) -> u32 {
+        self.backend.width()
+    }
+
+    /// Return the image height in pixels.
+    ///
+    /// # Returns
+    ///
+    /// Physical image height.
+    pub fn height(&self) -> u32 {
+        self.backend.height()
+    }
+
+    /// Borrow the Scarlet shared-image capability.
+    ///
+    /// # Returns
+    ///
+    /// Handle retained by the selected backend session.
+    pub fn shared_handle(&self) -> &Handle {
+        self.backend.shared_handle()
+    }
+}
+
+/// Scarlet command executor selected by the SGFX frontend.
+pub struct Executor<'a> {
+    backend: sgfx_backend_scarlet_virgl::Executor<'a>,
+}
+
+impl CommandExecutor for Executor<'_> {
+    type Error = Error;
+
+    fn execute<'r, 'data>(&mut self, commands: &ir::CommandBuffer<'r, 'data>) -> Result<()> {
+        self.backend
+            .execute(commands)
+            .map_err(Error::ScarletVirglIr)
+    }
+}

--- a/user/std-bin/Cargo.toml
+++ b/user/std-bin/Cargo.toml
@@ -18,7 +18,7 @@ libm = "0.2"
 lyon_path = "1.0"
 lyon_tessellation = "1.0"
 scarlet-sys = { path = "../lib/scarlet-sys" }
-scarlet-ui-macros = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui-macros" }
+scarlet-ui-macros = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui-macros" }
 rust_h264 = { git = "https://github.com/petitstrawberry/rust_h264.git", rev = "a559fe2545fd88def12146dcc06286475b53ead3", default-features = false, features = ["portable-simd"] }
 symphonia-core = { git = "https://github.com/petitstrawberry/Symphonia.git", rev = "71f92f0bc0fdd9d4f2a77129a543ee6c99611009", default-features = false, optional = true }
 symphonia-codec-aac = { git = "https://github.com/petitstrawberry/Symphonia.git", rev = "71f92f0bc0fdd9d4f2a77129a543ee6c99611009", default-features = false, optional = true }
@@ -38,12 +38,12 @@ sws-client = { path = "../lib/sws-client", default-features = false, features = 
 
 [target.'cfg(target_os = "scarlet")'.dependencies]
 scarlet-os = { path = "../lib/scarlet-os", default-features = false, features = ["std"] }
-scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui", default-features = false, features = ["std", "platform-sws"] }
+scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui", default-features = false, features = ["std", "platform-sws"] }
 sas-protocol = { path = "../lib/sas-protocol", default-features = false, features = ["std"] }
 sas-client = { path = "../lib/sas-client", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_os = "scarlet"))'.dependencies]
-scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui", default-features = false, features = ["std", "platform-winit"] }
+scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui", default-features = false, features = ["std", "platform-winit"] }
 
 [[bin]]
 name = "hello"

--- a/user/std-bin/Cargo.toml
+++ b/user/std-bin/Cargo.toml
@@ -12,7 +12,7 @@ mp4-aac = ["dep:symphonia-core", "dep:symphonia-codec-aac"]
 clap = { version = "4.5.32", features = ["derive"] }
 csv = "1.3"
 framebuffer = { path = "../lib/framebuffer", default-features = false, features = ["std"] }
-sgfx = { path = "../lib/sgfx-compat", default-features = false, features = ["std"] }
+sgfx = { package = "sgfx-compat-scarlet", path = "../lib/sgfx-compat", default-features = false, features = ["std"] }
 httparse = "1.9"
 libm = "0.2"
 lyon_path = "1.0"

--- a/user/video_player/Cargo.toml
+++ b/user/video_player/Cargo.toml
@@ -21,7 +21,7 @@ vp9-stateless-hw = ["dep:scarlet-codecs", "scarlet-codecs/vp9"]
 [dependencies]
 scarlet-std = { path = "../lib/std", features = ["alloc_debug"] }
 scarlet-codecs = { path = "../lib/scarlet-codecs", default-features = false, optional = true }
-scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui", default-features = false, features = ["legacy-scarlet-std", "platform-sws"] }
+scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui", default-features = false, features = ["legacy-scarlet-std", "platform-sws"] }
 sas-client = { path = "../lib/sas-client", default-features = false, features = ["legacy-scarlet-std"] }
 sbus = { path = "../lib/sbus" }
 sbus-client = { path = "../lib/sbus-client", default-features = false, features = ["legacy-scarlet-std"] }


### PR DESCRIPTION
## What changed

- add the real cross-platform sgfx frontend package above sgfx-core
- select complete backends by target, Cargo feature, explicit BackendPreference, or SGFX_BACKEND
- move native window surface creation and presentation into sgfx-backend-wgpu
- keep Scarlet VirGL lowering, resource ownership, transport limits, and submission inside sgfx-backend-scarlet-virgl
- rename the old immediate-mode facade to sgfx-compat-scarlet
- update in-tree consumers and build tasks

## Architecture

The dependency direction is now:

application/platform -> sgfx -> complete backend -> sgfx-core

Portable renderers depend directly on sgfx-core. Platform composition roots depend on sgfx and never name a concrete backend. Selection uses enum dispatch at the frontend boundary; there is no trait-object dispatch in the render path.

Current automatic choices are WGPU on host targets and Scarlet VirGL on Scarlet. Metal and Scarlet AGX have reserved preference identities and return BackendUnavailable until their complete backends exist.

## Validation

- sgfx frontend: 3 tests passed; clippy with warnings denied passed
- sgfx-backend-wgpu: 8 tests passed
- sgfx-backend-scarlet-virgl host std: 7 tests passed
- AArch64 and RISC-V Scarlet std target checks passed
- Widget Factory release build ran with renderer=sgfx backend=wgpu

Follow-up to #547 and #548. Supersedes #549, which GitHub closed while its head branch was renamed to the required feature prefix.