### PR TITLE
Use the merged ScarletUI SGFX integration

### DIFF
--- a/.cargo/Cargo.lock
+++ b/.cargo/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
+source = "git+https://github.com/petitstrawberry/scarlet-ui#41a81dce0db0e3620e226052ee7f7917bcf68c7a"
 dependencies = [
  "scarlet-ui-core",
  "scarlet-ui-platform-sws",
@@ -2286,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-core"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
+source = "git+https://github.com/petitstrawberry/scarlet-ui#41a81dce0db0e3620e226052ee7f7917bcf68c7a"
 dependencies = [
  "ab_glyph",
  "bitflags 2.13.1",
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-icons-tabler"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
+source = "git+https://github.com/petitstrawberry/scarlet-ui#41a81dce0db0e3620e226052ee7f7917bcf68c7a"
 dependencies = [
  "svgtypes",
 ]
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-macros"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
+source = "git+https://github.com/petitstrawberry/scarlet-ui#41a81dce0db0e3620e226052ee7f7917bcf68c7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-platform-sws"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
+source = "git+https://github.com/petitstrawberry/scarlet-ui#41a81dce0db0e3620e226052ee7f7917bcf68c7a"
 dependencies = [
  "scarlet-std",
  "scarlet-ui-core",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-platform-winit"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
+source = "git+https://github.com/petitstrawberry/scarlet-ui#41a81dce0db0e3620e226052ee7f7917bcf68c7a"
 dependencies = [
  "raw-window-handle",
  "scarlet-ui-core",
@@ -2346,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "scarlet-ui-renderer-sgfx"
 version = "0.1.0"
-source = "git+https://github.com/petitstrawberry/scarlet-ui?branch=feature%2Fsgfx-frontend-selection#c25eaa4baf5aa932f684ac0740b3f2dedb1a3e40"
+source = "git+https://github.com/petitstrawberry/scarlet-ui#41a81dce0db0e3620e226052ee7f7917bcf68c7a"
 dependencies = [
  "libm",
  "scarlet-ui-core",

--- a/user/bin/Cargo.toml
+++ b/user/bin/Cargo.toml
@@ -182,8 +182,8 @@ sgfx_compat = { package = "sgfx-compat-scarlet", path = "../lib/sgfx-compat" }
 sws-protocol = { path = "../lib/sws-protocol" }
 sws-client = { path = "../lib/sws-client" }
 scarlet-os = { path = "../lib/scarlet-os" }
-scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui", default-features = false, features = ["legacy-scarlet-std", "platform-sws"] }
-scarlet-ui-macros = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui-macros" }
+scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui", default-features = false, features = ["legacy-scarlet-std", "platform-sws"] }
+scarlet-ui-macros = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui-macros" }
 scarlet-desktop-config = { path = "../lib/scarlet-desktop-config" }
 sbus = { path = "../lib/sbus" }
 sbus-client = { path = "../lib/sbus-client" }

--- a/user/std-bin/Cargo.toml
+++ b/user/std-bin/Cargo.toml
@@ -18,7 +18,7 @@ libm = "0.2"
 lyon_path = "1.0"
 lyon_tessellation = "1.0"
 scarlet-sys = { path = "../lib/scarlet-sys" }
-scarlet-ui-macros = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui-macros" }
+scarlet-ui-macros = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui-macros" }
 rust_h264 = { git = "https://github.com/petitstrawberry/rust_h264.git", rev = "a559fe2545fd88def12146dcc06286475b53ead3", default-features = false, features = ["portable-simd"] }
 symphonia-core = { git = "https://github.com/petitstrawberry/Symphonia.git", rev = "71f92f0bc0fdd9d4f2a77129a543ee6c99611009", default-features = false, optional = true }
 symphonia-codec-aac = { git = "https://github.com/petitstrawberry/Symphonia.git", rev = "71f92f0bc0fdd9d4f2a77129a543ee6c99611009", default-features = false, optional = true }
@@ -38,12 +38,12 @@ sws-client = { path = "../lib/sws-client", default-features = false, features = 
 
 [target.'cfg(target_os = "scarlet")'.dependencies]
 scarlet-os = { path = "../lib/scarlet-os", default-features = false, features = ["std"] }
-scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui", default-features = false, features = ["std", "platform-sws"] }
+scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui", default-features = false, features = ["std", "platform-sws"] }
 sas-protocol = { path = "../lib/sas-protocol", default-features = false, features = ["std"] }
 sas-client = { path = "../lib/sas-client", default-features = false, features = ["std"] }
 
 [target.'cfg(not(target_os = "scarlet"))'.dependencies]
-scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui", default-features = false, features = ["std", "platform-winit"] }
+scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui", default-features = false, features = ["std", "platform-winit"] }
 
 [[bin]]
 name = "hello"

--- a/user/video_player/Cargo.toml
+++ b/user/video_player/Cargo.toml
@@ -21,7 +21,7 @@ vp9-stateless-hw = ["dep:scarlet-codecs", "scarlet-codecs/vp9"]
 [dependencies]
 scarlet-std = { path = "../lib/std", features = ["alloc_debug"] }
 scarlet-codecs = { path = "../lib/scarlet-codecs", default-features = false, optional = true }
-scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", branch = "feature/sgfx-frontend-selection", package = "scarlet-ui", default-features = false, features = ["legacy-scarlet-std", "platform-sws"] }
+scarlet-ui = { git = "https://github.com/petitstrawberry/scarlet-ui", package = "scarlet-ui", default-features = false, features = ["legacy-scarlet-std", "platform-sws"] }
 sas-client = { path = "../lib/sas-client", default-features = false, features = ["legacy-scarlet-std"] }
 sbus = { path = "../lib/sbus" }
 sbus-client = { path = "../lib/sbus-client", default-features = false, features = ["legacy-scarlet-std"] }


### PR DESCRIPTION
Follow-up to #550 after petitstrawberry/scarlet-ui#23 was merged.

- removes the temporary ScarletUI feature-branch pins
- resolves all ScarletUI crates from main at 41a81dce
- keeps target selection explicit at build call sites; no default target configuration is added

Validation:
- cargo check --manifest-path .cargo/Cargo.toml -p userprogram --target aarch64-unknown-scarlet
- cargo check --manifest-path .cargo/Cargo.toml -p userprogram --target riscv64gc-unknown-scarlet
- git diff --check