### PR TITLE
fix(fs): isolate overlay inode identities from backing layers

### DIFF
--- a/kernel/src/fs/vfs_v2/core.rs
+++ b/kernel/src/fs/vfs_v2/core.rs
@@ -524,7 +524,11 @@ impl FileObject for VfsFileObject {
     }
 
     fn metadata(&self) -> Result<FileMetadata, StreamError> {
-        self.inner.metadata()
+        let mut metadata = self.inner.metadata()?;
+        // Filesystems such as overlay expose their own inode identity while
+        // delegating I/O to a file from another backing filesystem.
+        metadata.file_id = self.vfs_entry.node().id();
+        Ok(metadata)
     }
 
     fn truncate(&self, size: u64) -> Result<(), StreamError> {

--- a/kernel/src/fs/vfs_v2/drivers/overlayfs/mod.rs
+++ b/kernel/src/fs/vfs_v2/drivers/overlayfs/mod.rs
@@ -41,7 +41,13 @@
 use crate::sync::IrqRwSpinLock;
 use alloc::boxed::Box;
 use alloc::string::ToString;
-use alloc::{collections::BTreeSet, format, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    format,
+    string::String,
+    sync::Arc,
+    vec::Vec,
+};
 use core::any::Any;
 
 use crate::driver_initcall;
@@ -87,6 +93,15 @@ pub struct OverlayFS {
     name: String,
     /// Root node (composite of all layers)
     root_node: Arc<OverlayNode>,
+    /// Overlay inode identities are independent of backing filesystems and
+    /// remain stable when a lower path is copied to the upper layer.
+    inode_ids: Arc<IrqRwSpinLock<OverlayInodeIds>>,
+}
+
+#[derive(Default)]
+struct OverlayInodeIds {
+    by_path: BTreeMap<String, u64>,
+    next_id: u64,
 }
 
 /// A composite node that represents a file/directory across overlay layers
@@ -225,9 +240,39 @@ impl OverlayFS {
             lower_layers,
             name,
             root_node: root_node.clone(),
+            inode_ids: Arc::new(IrqRwSpinLock::new(OverlayInodeIds {
+                by_path: BTreeMap::new(),
+                next_id: 2,
+            })),
         });
         root_node.set_overlay_fs(overlay.clone());
         Ok(overlay)
+    }
+
+    fn inode_for_path(&self, path: &str) -> u64 {
+        if path == "/" {
+            return 1;
+        }
+        if let Some(id) = self.inode_ids.read().by_path.get(path) {
+            return *id;
+        }
+        let mut ids = self.inode_ids.write();
+        if let Some(id) = ids.by_path.get(path) {
+            return *id;
+        }
+        let id = ids.next_id;
+        ids.next_id = id.checked_add(1).expect("overlay inode IDs exhausted");
+        ids.by_path.insert(path.to_string(), id);
+        id
+    }
+
+    fn child_inode(&self, parent_path: &str, name: &str) -> u64 {
+        let path = if parent_path == "/" {
+            format!("/{}", name)
+        } else {
+            format!("{}/{}", parent_path, name)
+        };
+        self.inode_for_path(&path)
     }
 
     /// Create a new OverlayFS from VFS paths
@@ -386,14 +431,18 @@ impl OverlayFS {
         // Check upper layer first
         if let Some((ref upper_fs, ref upper_node)) = self.upper {
             if let Ok(node) = self.resolve_in_layer(upper_fs, upper_node, path) {
-                return node.metadata();
+                let mut metadata = node.metadata()?;
+                metadata.file_id = self.inode_for_path(path);
+                return Ok(metadata);
             }
         }
 
         // Check lower layers
         for (lower_fs, lower_node) in &self.lower_layers {
             if let Ok(node) = self.resolve_in_layer(lower_fs, lower_node, path) {
-                return node.metadata();
+                let mut metadata = node.metadata()?;
+                metadata.file_id = self.inode_for_path(path);
+                return Ok(metadata);
             }
         }
 
@@ -778,17 +827,7 @@ impl FileSystemOperations for OverlayFS {
                 "/"
             };
             let parent_name = parent_path.split('/').last().unwrap_or("/");
-            let parent_file_id = self
-                .get_metadata_for_path(parent_path)
-                .map(|m| m.file_id)
-                .unwrap_or_else(|_| {
-                    // Deterministic fallback from path hash
-                    let mut hash: u64 = 5381;
-                    for byte in parent_path.bytes() {
-                        hash = hash.wrapping_mul(33).wrapping_add(byte as u64);
-                    }
-                    hash
-                });
+            let parent_file_id = self.inode_for_path(parent_path);
             let node = OverlayNode::new(
                 parent_name.to_string(),
                 parent_path.to_string(),
@@ -980,12 +1019,8 @@ impl FileSystemOperations for OverlayFS {
 
         // Return overlay node
         let metadata = new_node.metadata()?;
-        let overlay_node = OverlayNode::new(
-            name.clone(),
-            child_path,
-            metadata.file_type,
-            metadata.file_id,
-        );
+        let file_id = self.inode_for_path(&child_path);
+        let overlay_node = OverlayNode::new(name.clone(), child_path, metadata.file_type, file_id);
         if let Some(ref fs) = *overlay_parent.overlay_fs.read() {
             overlay_node.set_overlay_fs(Arc::clone(fs));
         }
@@ -1026,6 +1061,7 @@ impl FileSystemOperations for OverlayFS {
                             break;
                         }
                     }
+                    self.inode_ids.write().by_path.remove(&child_path);
                     return Ok(());
                 }
             }
@@ -1038,6 +1074,7 @@ impl FileSystemOperations for OverlayFS {
                 .is_ok()
             {
                 self.create_whiteout(&child_path)?;
+                self.inode_ids.write().by_path.remove(&child_path);
                 return Ok(());
             }
         }
@@ -1164,6 +1201,11 @@ impl FileSystemOperations for OverlayFS {
                         }
                     }
                 }
+            }
+        }
+        for entry in &mut entries {
+            if entry.name != "." && entry.name != ".." {
+                entry.file_id = self.child_inode(&overlay_node.path, &entry.name);
             }
         }
         entries.sort_by(|a, b| a.file_id.cmp(&b.file_id)); // Sort entries by file_id
@@ -1315,6 +1357,9 @@ impl OverlayDirectoryObject {
             }
         }
 
+        for entry in &mut all_entries {
+            entry.file_id = self.overlay_fs.child_inode(&self.path, &entry.name);
+        }
         // Sort entries by file_id to maintain consistent order
         all_entries.sort_by(|a, b| a.file_id.cmp(&b.file_id));
         special_entries.extend(all_entries);

--- a/kernel/src/fs/vfs_v2/drivers/overlayfs/tests.rs
+++ b/kernel/src/fs/vfs_v2/drivers/overlayfs/tests.rs
@@ -78,6 +78,116 @@ fn test_vfs_exclusive_create_checks_lower_layer_before_creating_upper() {
 }
 
 #[test_case]
+fn test_overlayfs_mounts_do_not_alias_layer_ids_and_copy_up_preserves_ids() {
+    use crate::fs::VfsManager;
+
+    let lower = TmpFS::new(0);
+    let upper = TmpFS::new(0);
+    let lower_bin = lower
+        .create(
+            &lower.root_node(),
+            &"bin".to_string(),
+            FileType::Directory,
+            0o755,
+        )
+        .unwrap();
+    let lower_stemd = lower
+        .create(
+            &lower_bin,
+            &"stemd".to_string(),
+            FileType::RegularFile,
+            0o755,
+        )
+        .unwrap();
+    lower
+        .open(&lower_stemd, 0x2)
+        .unwrap()
+        .write(b"stemd")
+        .unwrap();
+    let overlay = OverlayFS::new(
+        Some(make_mount_and_entry(upper.clone())),
+        vec![make_mount_and_entry(lower.clone())],
+        "bootstrap-mounts".to_string(),
+    )
+    .unwrap();
+    let vfs = VfsManager::new_with_root(overlay.clone());
+
+    // Diskless bootstrap creates /dev in the upper layer before binding it.
+    // Both layers allocate their first child the same underlying inode ID.
+    vfs.create_dir("/dev").unwrap();
+    let upper_dev = upper
+        .lookup(&upper.root_node(), &"dev".to_string())
+        .unwrap();
+    assert_eq!(lower_bin.id(), upper_dev.id());
+    let root = overlay.root_node();
+    let bin = overlay.lookup(&root, &"bin".to_string()).unwrap();
+    let dev = overlay.lookup(&root, &"dev".to_string()).unwrap();
+    let stemd = overlay.lookup(&bin, &"stemd".to_string()).unwrap();
+    let bin_id = bin.id();
+    let stemd_id = stemd.id();
+    assert_ne!(bin_id, dev.id());
+    assert_ne!(stemd_id, bin_id);
+    assert_ne!(stemd_id, dev.id());
+    assert_ne!(root.id(), bin_id);
+
+    let devices = Arc::new(VfsManager::new_with_root(TmpFS::new(0)));
+    vfs.bind_mount_from(&devices, "/", "/dev").unwrap();
+    let executable = vfs.open("/bin/stemd", 0).unwrap();
+    let mut bytes = [0; 5];
+    assert_eq!(executable.as_file().unwrap().read(&mut bytes).unwrap(), 5);
+    assert_eq!(&bytes, b"stemd");
+
+    for copied_up in [false, true] {
+        if copied_up {
+            // This copies both /bin and its file to newly allocated upper IDs.
+            vfs.open("/bin/stemd", 0x2).unwrap();
+            let upper_bin = upper
+                .lookup(&upper.root_node(), &"bin".to_string())
+                .unwrap();
+            let upper_stemd = upper.lookup(&upper_bin, &"stemd".to_string()).unwrap();
+            assert_ne!(upper_bin.id(), lower_bin.id());
+            assert_ne!(upper_stemd.id(), lower_stemd.id());
+        }
+
+        let fresh_bin = overlay.lookup(&root, &"bin".to_string()).unwrap();
+        let fresh_stemd = overlay.lookup(&fresh_bin, &"stemd".to_string()).unwrap();
+        assert_eq!(fresh_bin.id(), bin_id);
+        assert_eq!(fresh_stemd.id(), stemd_id);
+        assert_eq!(bin.metadata().unwrap().file_id, bin_id);
+        assert_eq!(stemd.metadata().unwrap().file_id, stemd_id);
+        let root_entries = overlay.readdir(&root).unwrap();
+        for (name, expected_id) in [("bin", bin_id), ("dev", dev.id())] {
+            assert_eq!(
+                root_entries
+                    .iter()
+                    .find(|entry| entry.name == name)
+                    .unwrap()
+                    .file_id,
+                expected_id
+            );
+        }
+        let bin_entries = overlay.readdir(&fresh_bin).unwrap();
+        for (name, expected_id) in [(".", bin_id), ("..", root.id()), ("stemd", stemd_id)] {
+            assert_eq!(
+                bin_entries
+                    .iter()
+                    .find(|entry| entry.name == name)
+                    .unwrap()
+                    .file_id,
+                expected_id
+            );
+        }
+        let executable = vfs.open("/bin/stemd", 0).unwrap();
+        assert_eq!(
+            executable.as_file().unwrap().metadata().unwrap().file_id,
+            stemd_id
+        );
+        assert_eq!(executable.as_file().unwrap().read(&mut bytes).unwrap(), 5);
+        assert_eq!(&bytes, b"stemd");
+    }
+}
+
+#[test_case]
 fn test_overlayfs_basic() {
     /*
     Directory structure:


### PR DESCRIPTION
Diskless init can fail to open `/bin/stemd` after binding devfs onto `/dev`. A lower layer's `/bin` and an upper layer's `/dev` can both have inode 2, and OverlayFS exposed those backing IDs in one mount namespace. The mount lookup therefore treated both directories as the `/dev` mount point.

Allocate inode IDs within each overlay and preserve them across copy-up. Keep lookup, metadata, directory entries, and open-file metadata consistent. Add a regression that deliberately collides backing inode IDs, binds `/dev`, reads `/bin/stemd`, and checks identities before and after copy-up.

Validation:

- AArch64 test kernel builds successfully with `cargo test --lib --no-run --target targets/aarch64-unknown-none-elf.json` from `kernel/`.
- All 15 overlayfs tests pass under QEMU AArch64, including the new regression. A temporary test-runner filter was used for this targeted run; it is not part of the PR.
- The new regression fails against the unmodified `dev` implementation (`a4b9a9b0`), reporting the colliding inode IDs `2 == 2`.
- The full AArch64 suite stops earlier at `test_ext2_directory_size_and_metadata_follow_cached_writes` with “got 512 bytes, need at least 1024 bytes”. That failure was independently reproduced against the unmodified `dev` implementation.

This PR contains only the shared filesystem fix and its regression test; the ARMv5TE port is separate.
